### PR TITLE
Fetch307

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,11 +4,15 @@
 !/.idea/scopes/
 !/.idea/copyright/
 *.iml
+.settings
+.project
+.classpath
 
 # Compiled source #
 ###################
 .gradle/
 build/
+bin/
 out/
 /client-app/build/
 /client-app/node_modules/

--- a/client-app/src/admin/AppModel.js
+++ b/client-app/src/admin/AppModel.js
@@ -33,7 +33,8 @@ export class AppModel extends BaseAppModel {
                     {name: 'performance', path: '/performance'},
                     {name: 'cube', path: '/cube'},
                     {name: 'webSockets', path: '/webSockets'},
-                    {name: 'panelResizing', path: '/panelResizing'}
+                    {name: 'panelResizing', path: '/panelResizing'},
+                    {name: 'fetchAPI', path: '/fetchAPI'}
                 ]
             },
             {

--- a/client-app/src/admin/tests/TestsTab.js
+++ b/client-app/src/admin/tests/TestsTab.js
@@ -13,6 +13,7 @@ import {CubeDataPanel} from './cube/CubeDataPanel';
 import {WebSocketTestPanel} from './websocket/WebSocketTestPanel';
 import {LocalDateTestPanel} from './localDate/LocalDateTestPanel';
 import {PanelResizingTestPanel} from './panels/PanelResizingTestPanel';
+import { FetchApiTestPanel } from './fetch/FetchApiTestPanel';
 
 
 export const TestsTab = hoistCmp(
@@ -24,7 +25,8 @@ export const TestsTab = hoistCmp(
                 {id: 'performance', title: 'Grid Performance', content: GridTestPanel},
                 {id: 'cube', title: 'Cube Data', content: CubeDataPanel},
                 {id: 'webSockets', title: 'WebSockets', content: WebSocketTestPanel},
-                {id: 'panelResizing', title: 'Panel Resizing', content: PanelResizingTestPanel}
+                {id: 'panelResizing', title: 'Panel Resizing', content: PanelResizingTestPanel},
+                {id: 'fetchAPI', title: 'Fetch API', content: FetchApiTestPanel}
             ],
             switcherPosition: 'left'
         }

--- a/client-app/src/admin/tests/TestsTab.js
+++ b/client-app/src/admin/tests/TestsTab.js
@@ -13,8 +13,7 @@ import {CubeDataPanel} from './cube/CubeDataPanel';
 import {WebSocketTestPanel} from './websocket/WebSocketTestPanel';
 import {LocalDateTestPanel} from './localDate/LocalDateTestPanel';
 import {PanelResizingTestPanel} from './panels/PanelResizingTestPanel';
-import { FetchApiTestPanel } from './fetch/FetchApiTestPanel';
-
+import {FetchApiTestPanel} from './fetch/FetchApiTestPanel';
 
 export const TestsTab = hoistCmp(
     () => tabContainer({

--- a/client-app/src/admin/tests/fetch/FetchApiTestModel.js
+++ b/client-app/src/admin/tests/fetch/FetchApiTestModel.js
@@ -1,5 +1,5 @@
-import { HoistModel, XH} from '@xh/hoist/core';
-import { bindable } from '@xh/hoist/mobx';
+import {HoistModel, XH} from '@xh/hoist/core';
+import {bindable} from '@xh/hoist/mobx';
 
 
 @HoistModel
@@ -33,7 +33,7 @@ export class FetchApiTestModel {
 
     async requestCodeAsync(code) {
         switch (this.testMethod) {
-            case 'fetch': return this.doFetchASync(code);
+            case 'fetch': return this.doFetchAsync(code);
             default: return  XH.fetchService[this.testMethod]({
                 fetchOpts: {
                     credentials: this.useCreds ? 'include' : 'omit'
@@ -53,7 +53,7 @@ export class FetchApiTestModel {
         }
     }
 
-    async doFetchASync(code) {
+    async doFetchAsync(code) {
         XH.fetch({
             fetchOpts: {
                 credentials: this.useCreds ? 'include' : 'omit'

--- a/client-app/src/admin/tests/fetch/FetchApiTestModel.js
+++ b/client-app/src/admin/tests/fetch/FetchApiTestModel.js
@@ -1,0 +1,413 @@
+import { HoistModel, XH} from '@xh/hoist/core';
+import { bindable } from '@xh/hoist/mobx';
+
+
+@HoistModel
+export class FetchApiTestModel {
+
+    @bindable testServer;
+    @bindable testMethod;
+    @bindable response = null;
+    referenceSite = 'https://httpstatuses.com/';
+    testServers = [
+        {
+            value: '//localhost:8080/fetchTest?status=',
+            label: 'Grails - Localhost'
+        },
+        {
+            value: 'https://httpstat.us/',
+            label: 'httpstat.us'
+        }
+    ];
+    testMethods = [
+        {
+            value: 'fetch',
+            label: 'fetch (GET)'
+        }, 'getJson', 'postJson', 'putJson', 'deleteJson'
+    ]
+
+    constructor() {
+        this.setTestServer(this.testServers[0].value);
+        this.setTestMethod(this.testMethods[0].value);
+    }
+
+    async requestCodeAsync(code) {
+        switch (this.testMethod) {
+            case 'fetch': return this.doFetchASync(code);
+            default: return  XH.fetchService[this.testMethod]({
+                fetchOpts: {
+                    credentials: this.useCreds ? 'include' : 'omit'
+                },
+                url: `${this.testServer}${code}`,
+                headers: {
+                    'Expect': code == 100 ? '100-continue' : undefined
+                }
+            }).then(
+                (resp) => {
+                    console.log(resp);
+                    
+                    this.setResponse(JSON.stringify(resp, undefined, 2));
+                }, 
+                (err) => this.handleError(err)
+            );
+        }
+    }
+
+    async doFetchASync(code) {
+        XH.fetch({
+            fetchOpts: {
+                credentials: this.useCreds ? 'include' : 'omit'
+            },
+            url: `${this.testServer}${code}`,
+            method: 'GET',
+            headers: {
+                'Accept': 'application/json',
+                'Expect': code == 100 ? '100-continue' : undefined
+            }
+        }).then(
+            async (resp) => {
+                const output = this.getResponseProps(resp);
+                output.headers = this.getResponseHeaders(resp);
+                output.body = await this.getResponseBodyAsync(resp);
+                this.setResponse(JSON.stringify(output, undefined, 2));
+            }, 
+            (err) => this.handleError(err)
+        );
+    }
+
+    handleError(err) {
+        let str;
+        if (err.name.includes('HTTP Error')) {
+            try {
+                str = JSON.stringify(err, undefined, 2);
+            } catch (err) {
+                str = err;
+            }
+        } else {
+            str = JSON.stringify({
+                name: err.name,
+                message: err.message
+            }, undefined, 2);
+        }
+
+        this.setResponse(str);   
+    }
+
+    get useCreds() {
+        return !this.testServer.includes('httpstat');
+    }
+
+    getResponseProps(resp) {
+        const ret = {};
+        for (let p in resp) {
+            const type = typeof resp[p];
+            
+            if (type == 'string' || type == 'number' || type == 'boolean') {
+                ret[p] = resp[p];
+            }
+        }
+        return ret;
+    }
+
+    getResponseHeaders(resp) {
+        const ret = {};
+        resp.headers.forEach((val, key) => {
+            ret[key] = val;
+        });
+        return ret;
+    }
+
+    async getResponseBodyAsync(resp) {
+        const ct = resp.headers.get('Content-Type');
+        let method;
+        switch (true) {
+            case ct?.includes('json') :
+                method = 'json';
+                break;
+            default:
+                method = 'text';
+                break;
+        }
+
+        try {
+            return await resp[method]();
+        } catch (error) {
+            return null;
+        } 
+    }
+
+    codes = [
+        {
+            code: 100,
+            description: 'Continue'
+        },
+        {
+            code: 101,
+            description: 'Switching Protocols'
+        },
+        {
+            code: 102,
+            description: 'Processing'
+        },
+        {
+            code: 103,
+            description: 'Early Hints'
+        },
+        {
+            code: 200,
+            description: 'OK'
+        },
+        {
+            code: 201,
+            description: 'Created'
+        },
+        {
+            code: 202,
+            description: 'Accepted'
+        },
+        {
+            code: 203,
+            description: 'Non-Authoritative Information'
+        },
+        {
+            code: 204,
+            description: 'No Content'
+        },
+        {
+            code: 205,
+            description: 'Reset Content'
+        },
+        {
+            code: 206,
+            description: 'Partial Content'
+        },
+        {
+            code: 207,
+            description: 'Multi-Status'
+        },
+        {
+            code: 208,
+            description: 'Already Reported'
+        },
+        {
+            code: 226,
+            description: 'I\'M Used'
+        },
+        {
+            code: 300,
+            description: 'Multiple Choices'
+        },
+        {
+            code: 301,
+            description: 'Moved Permanently'
+        },
+        {
+            code: 302,
+            description: 'Found'
+        },
+        {
+            code: 303,
+            description: 'See Other'
+        },
+        {
+            code: 304,
+            description: 'Not Modified'
+        },
+        {
+            code: 305,
+            description: 'Use Proxy'
+        },
+        {
+            code: 306,
+            description: 'Unused'
+        },
+        {
+            code: 307,
+            description: 'Temporary Redirect'
+        },
+        {
+            code: 308,
+            description: 'Permanent Redirect'
+        },
+        {
+            code: 400,
+            description: 'Bad Request'
+        },
+        {
+            code: 401,
+            description: 'Unauthorized'
+        },
+        {
+            code: 402,
+            description: 'Payment Required'
+        },
+        {
+            code: 403,
+            description: 'Forbidden'
+        },
+        {
+            code: 404,
+            description: 'Not Found'
+        },
+        {
+            code: 405,
+            description: 'Method Not Allowed'
+        },
+        {
+            code: 406,
+            description: 'Not Acceptable'
+        },
+        {
+            code: 407,
+            description: 'Proxy Authentication Required'
+        },
+        {
+            code: 408,
+            description: 'Request Timeout'
+        },
+        {
+            code: 409,
+            description: 'Conflict'
+        },
+        {
+            code: 410,
+            description: 'Gone'
+        },
+        {
+            code: 411,
+            description: 'Length Required'
+        },
+        {
+            code: 412,
+            description: 'Precondition Failed'
+        },
+        {
+            code: 413,
+            description: 'Request Entity Too Large'
+        },
+        {
+            code: 414,
+            description: 'Request-URI Too Long'
+        },
+        {
+            code: 415,
+            description: 'Unsupported Media Type'
+        },
+        {
+            code: 416,
+            description: 'Requested Range Not Satisfiable'
+        },
+        {
+            code: 417,
+            description: 'Expectation Failed'
+        },
+        {
+            code: 418,
+            description: 'I\'m a teapot'
+        },
+        {
+            code: 421,
+            description: 'Misdirected Request'
+        },
+        {
+            code: 422,
+            description: 'Unprocessable Entity'
+        },
+        {
+            code: 423,
+            description: 'Locked'
+        },
+        {
+            code: 424,
+            description: 'Failed Dependency'
+        },
+        {
+            code: 425,
+            description: 'Too Early'
+        },
+        {
+            code: 426,
+            description: 'Upgrade Required'
+        },
+        {
+            code: 428,
+            description: 'Precondition Required'
+        },
+        {
+            code: 429,
+            description: 'Too Many Requests'
+        },
+        {
+            code: 431,
+            description: 'Request Header Fields Too Large'
+        },
+        {
+            code: 451,
+            description: 'Unavailable For Legal Reasons'
+        },
+        {
+            code: 499,
+            description: 'Client Closed Request'
+        },
+        {
+            code: 500,
+            description: 'Internal Server Error'
+        },
+        {
+            code: 501,
+            description: 'Not Implemented'
+        },
+        {
+            code: 502,
+            description: 'Bad Gateway'
+        },
+        {
+            code: 503,
+            description: 'Service Unavailable'
+        },
+        {
+            code: 504,
+            description: 'Gateway Timeout'
+        },
+        {
+            code: 505,
+            description: 'HTTP Version Not Supported'
+        },
+        {
+            code: 506,
+            description: 'Variant Also Negotiates'
+        },
+        {
+            code: 507,
+            description: 'Insufficient Storage'
+        },
+        {
+            code: 508,
+            description: 'Loop Detected'
+        },
+        {
+            code: 510,
+            description: 'Not Extended'
+        },
+        {
+            code: 511,
+            description: 'Network Authentication Required'
+        },
+        {
+            code: 520,
+            description: 'Web server is returning an unknown error'
+        },
+        {
+            code: 522,
+            description: 'Connection timed out'
+        },
+        {
+            code: 524,
+            description: 'A timeout occurred'
+        },
+        {
+            code: 599,
+            description: 'Network Connect Timeout Error'
+        }
+    ]
+}

--- a/client-app/src/admin/tests/fetch/FetchApiTestModel.js
+++ b/client-app/src/admin/tests/fetch/FetchApiTestModel.js
@@ -109,14 +109,7 @@ export class FetchApiTestModel {
 
     @action 
     setResponse(obj) {
-        let str;
-        try {
-            str = JSON.stringify(obj, undefined, 2);
-        } catch (err) {
-            str = err;
-        }
-
-        this.response = str;
+        this.response = JSON.stringify(obj, undefined, 2);
     }
 
     requestOptions(code) {

--- a/client-app/src/admin/tests/fetch/FetchApiTestPanel.js
+++ b/client-app/src/admin/tests/fetch/FetchApiTestPanel.js
@@ -4,6 +4,7 @@ import {box, hbox, p, vbox, hframe, vframe} from '@xh/hoist/cmp/layout';
 import {button} from '@xh/hoist/desktop/cmp/button';
 import {panel} from '@xh/hoist/desktop/cmp/panel';
 import {select, jsonInput} from '@xh/hoist/desktop/cmp/input';
+import {mask} from '@xh/hoist/desktop/cmp/mask';
 
 import {FetchApiTestModel} from './FetchApiTestModel';
 
@@ -81,6 +82,10 @@ export const FetchApiTestPanel = hoistCmp({
                                 }),
                                 padding: 10
                             })
+                        }),
+                        mask({
+                            model: model.loadModel,
+                            spinner: true
                         })
                     ]
                 })

--- a/client-app/src/admin/tests/fetch/FetchApiTestPanel.js
+++ b/client-app/src/admin/tests/fetch/FetchApiTestPanel.js
@@ -1,19 +1,19 @@
-import { hoistCmp, creates } from '@xh/hoist/core';
-import { Icon } from '@xh/hoist/icon';
-import { box, hbox, p, vbox, hframe, vframe } from '@xh/hoist/cmp/layout';
-import { button } from '@xh/hoist/desktop/cmp/button';
-import { panel } from '@xh/hoist/desktop/cmp/panel';
-import { select, jsonInput} from '@xh/hoist/desktop/cmp/input';
+import {hoistCmp, creates} from '@xh/hoist/core';
+import {Icon} from '@xh/hoist/icon';
+import {box, hbox, p, vbox, hframe, vframe} from '@xh/hoist/cmp/layout';
+import {button} from '@xh/hoist/desktop/cmp/button';
+import {panel} from '@xh/hoist/desktop/cmp/panel';
+import {select, jsonInput} from '@xh/hoist/desktop/cmp/input';
 
-import { FetchApiTestModel } from './FetchApiTestModel';
+import {FetchApiTestModel} from './FetchApiTestModel';
 
 import './FetchApiTestStyles.scss';
 
 
 export const FetchApiTestPanel = hoistCmp({
-    model: creates(() => new FetchApiTestModel()),
+    model: creates(FetchApiTestModel),
 
-    render({ model }) {
+    render({model}) {
         return panel({
             title: 'Fetch API Tester',
             icon: Icon.rocket(),

--- a/client-app/src/admin/tests/fetch/FetchApiTestPanel.js
+++ b/client-app/src/admin/tests/fetch/FetchApiTestPanel.js
@@ -43,14 +43,14 @@ export const FetchApiTestPanel = hoistCmp({
                         model: {
                             tabs: [
                                 {
-                                    id: 'individual', 
-                                    title: 'Individual Codes', 
-                                    content: individualBtns
-                                },
-                                {
                                     id: 'groups',
                                     title: 'Code Groups',
                                     content: codeGroupBtns
+                                },
+                                {
+                                    id: 'individual', 
+                                    title: 'Individual Codes', 
+                                    content: individualBtns
                                 }
                             ]
                         }

--- a/client-app/src/admin/tests/fetch/FetchApiTestPanel.js
+++ b/client-app/src/admin/tests/fetch/FetchApiTestPanel.js
@@ -1,6 +1,6 @@
 import {hoistCmp, creates} from '@xh/hoist/core';
 import {Icon} from '@xh/hoist/icon';
-import {box, hbox, p, vbox, hframe, vframe} from '@xh/hoist/cmp/layout';
+import {box, hbox, vbox, hframe, vframe} from '@xh/hoist/cmp/layout';
 import {button} from '@xh/hoist/desktop/cmp/button';
 import {panel} from '@xh/hoist/desktop/cmp/panel';
 import {select, jsonInput} from '@xh/hoist/desktop/cmp/input';
@@ -15,79 +15,65 @@ export const FetchApiTestPanel = hoistCmp({
     model: creates(FetchApiTestModel),
 
     render({model}) {
-        return panel({
-            title: 'Fetch API Tester',
-            icon: Icon.rocket(),
+        return hbox({
+            flex: 1,
             items: [
-                vbox({
-                    padding: '10px 10px 10px 10px',
-                    items: [
-                        p('Test if FetchService correctly handles a response with a particular status code.'),
-                        p('Click on a status code button in the left panel to make a request that will respond with that status code.'),
-                        p('The response ouput from that request will display in the right hand panel.')
-                    ]
-                }),
-                hbox({
-                    flex: 1,
-                    items: [
-                        panel({
-                            title: 'Send Request with Status Code',
-                            className: 'xh-border-right',
-                            width: 350,
-                            margin: '0 1px 0 0',
-                            flexShrink: 0,
-                            tbar: [
-                                box('Svr:'),
-                                select({
-                                    bind: 'testServer',
-                                    options: model.testServers,
-                                    width: 160
-                                }),
-                                box('Mth:'),
-                                select({
-                                    bind: 'testMethod',
-                                    options: model.testMethods,
-                                    width: 110
-                                })
-                            ],
-                            item: vbox({
-                                style: {overflowY: 'scroll'},
-                                items: model.codes.map(it => hframe({
-                                    className: 'http-status-code-frame',
-                                    overflow: 'unset',
-                                    items: [
-                                        button({
-                                            flexGrow: 1,
-                                            className: 'http-status-code-button',
-                                            text: `${it.code}: ${it.description}`,
-                                            onClick: () => model.requestCodeAsync(it.code),
-                                            minimal: false
-                                        }),
-                                        button({
-                                            icon: Icon.info(),
-                                            onClick: () => window.open(`${model.referenceSite}${it.code}`),
-                                            minimal: false
-                                        })]
-                                }))
-                            })
+                panel({
+                    title: 'Send Request with Status Code',
+                    className: 'xh-border-right',
+                    width: 350,
+                    margin: '0 1px 0 0',
+                    flexShrink: 0,
+                    tbar: [
+                        box('Svr:'),
+                        select({
+                            bind: 'testServer',
+                            options: model.testServers,
+                            width: 160
                         }),
-                        panel({
-                            title: 'Response',
-                            className: 'xh-border-left',
-                            item: vframe({
-                                item: jsonInput({
-                                    flex: 1,
-                                    width: '100%',
-                                    value: model.response
-                                }),
-                                padding: 10
-                            })
-                        }),
-                        mask({
-                            model: model.loadModel,
-                            spinner: true
+                        box('Mth:'),
+                        select({
+                            bind: 'testMethod',
+                            options: model.testMethods,
+                            width: 110
                         })
-                    ]
+                    ],
+                    item: vbox({
+                        style: {overflowY: 'scroll'},
+                        items: model.codes.map(it => hframe({
+                            className: 'http-status-code-frame',
+                            overflow: 'unset',
+                            items: [
+                                button({
+                                    flexGrow: 1,
+                                    className: 'http-status-code-button',
+                                    text: `${it.code}: ${it.description}`,
+                                    onClick: () => model.requestCodeAsync(it.code),
+                                    minimal: false
+                                }),
+                                button({
+                                    icon: Icon.info(),
+                                    onClick: () => window.open(`${model.referenceSite}${it.code}`),
+                                    minimal: false
+                                })]
+                        }))
+                    })
+                }),
+                panel({
+                    title: 'Response',
+                    className: 'xh-border-left',
+                    item: vframe({
+                        item: jsonInput({
+                            flex: 1,
+                            width: '100%',
+                            value: model.response
+                        }),
+                        padding: 10
+                    })
+                }),
+                mask({
+                    model: model.loadModel,
+                    spinner: true
                 })
             ]
         });

--- a/client-app/src/admin/tests/fetch/FetchApiTestPanel.js
+++ b/client-app/src/admin/tests/fetch/FetchApiTestPanel.js
@@ -1,10 +1,11 @@
-import {hoistCmp, creates} from '@xh/hoist/core';
+import {hoistCmp, creates, uses} from '@xh/hoist/core';
 import {Icon} from '@xh/hoist/icon';
 import {box, hbox, vbox, hframe, vframe} from '@xh/hoist/cmp/layout';
 import {button} from '@xh/hoist/desktop/cmp/button';
 import {panel} from '@xh/hoist/desktop/cmp/panel';
 import {select, jsonInput} from '@xh/hoist/desktop/cmp/input';
 import {mask} from '@xh/hoist/desktop/cmp/mask';
+import {tabContainer} from '@xh/hoist/cmp/tab';
 
 import {FetchApiTestModel} from './FetchApiTestModel';
 
@@ -38,25 +39,21 @@ export const FetchApiTestPanel = hoistCmp({
                             width: 110
                         })
                     ],
-                    item: vbox({
-                        style: {overflowY: 'scroll'},
-                        items: model.codes.map(it => hframe({
-                            className: 'http-status-code-frame',
-                            overflow: 'unset',
-                            items: [
-                                button({
-                                    flexGrow: 1,
-                                    className: 'http-status-code-button',
-                                    text: `${it.code}: ${it.description}`,
-                                    onClick: () => model.requestCodeAsync(it.code),
-                                    minimal: false
-                                }),
-                                button({
-                                    icon: Icon.info(),
-                                    onClick: () => window.open(`${model.referenceSite}${it.code}`),
-                                    minimal: false
-                                })]
-                        }))
+                    item: tabContainer({
+                        model: {
+                            tabs: [
+                                {
+                                    id: 'individual', 
+                                    title: 'Individual Codes', 
+                                    content: individualBtns
+                                },
+                                {
+                                    id: 'groups',
+                                    title: 'Code Groups',
+                                    content: codeGroupBtns
+                                }
+                            ]
+                        }
                     })
                 }),
                 panel({
@@ -79,3 +76,50 @@ export const FetchApiTestPanel = hoistCmp({
         });
     }
 });
+
+const individualBtns = hoistCmp.factory(
+    {
+        model: uses(FetchApiTestModel),
+        render({model}) {
+            return vbox({
+                style: {overflowY: 'scroll'},
+                items: model.codes.map(it => hframe({
+                    className: 'http-status-code-frame',
+                    overflow: 'unset',
+                    items: [
+                        button({
+                            flexGrow: 1,
+                            className: 'http-status-code-button',
+                            text: `${it.code}: ${it.description}`,
+                            onClick: () => model.testCodeAsync(it.code),
+                            minimal: false
+                        }),
+                        button({
+                            icon: Icon.info(),
+                            onClick: () => window.open(`${model.referenceSite}${it.code}`),
+                            minimal: false
+                        })]
+                }))
+            });
+        }
+    }
+);
+
+const codeGroupBtns = hoistCmp.factory(
+    {
+        model: uses(FetchApiTestModel),
+        render({model}) {
+            return vframe({
+                style: {overflowY: 'scroll'},
+                items: model.codes
+                    .filter(it => !(it.code % 100))
+                    .map(it => button({
+                        className: 'http-status-code-group-button',
+                        text: `${it.code.toString().replace(/00$/, 'XX')}: Test all ${it.code}s`,
+                        onClick: () => model.testCodeGroupAsync(it.code),
+                        minimal: false
+                    }))
+            });
+        }
+    }
+);

--- a/client-app/src/admin/tests/fetch/FetchApiTestPanel.js
+++ b/client-app/src/admin/tests/fetch/FetchApiTestPanel.js
@@ -1,0 +1,90 @@
+import { hoistCmp, creates } from '@xh/hoist/core';
+import { Icon } from '@xh/hoist/icon';
+import { box, hbox, p, vbox, hframe, vframe } from '@xh/hoist/cmp/layout';
+import { button } from '@xh/hoist/desktop/cmp/button';
+import { panel } from '@xh/hoist/desktop/cmp/panel';
+import { select, jsonInput} from '@xh/hoist/desktop/cmp/input';
+
+import { FetchApiTestModel } from './FetchApiTestModel';
+
+import './FetchApiTestStyles.scss';
+
+
+export const FetchApiTestPanel = hoistCmp({
+    model: creates(() => new FetchApiTestModel()),
+
+    render({ model }) {
+        return panel({
+            title: 'Fetch API Tester',
+            icon: Icon.rocket(),
+            items: [
+                vbox({
+                    padding: '10px 10px 10px 10px',
+                    items: [
+                        p('Test if FetchService correctly handles a response with a particular status code.'),
+                        p('Click on a status code button in the left panel to make a request that will respond with that status code.'),
+                        p('The response ouput from that request will display in the right hand panel.')
+                    ]
+                }),
+                hbox({
+                    flex: 1,
+                    items: [
+                        panel({
+                            title: 'Send Request with Status Code',
+                            className: 'xh-border-right',
+                            width: 350,
+                            margin: '0 1px 0 0',
+                            flexShrink: 0,
+                            tbar: [
+                                box('Svr:'),
+                                select({
+                                    bind: 'testServer',
+                                    options: model.testServers,
+                                    width: 160
+                                }),
+                                box('Mth:'),
+                                select({
+                                    bind: 'testMethod',
+                                    options: model.testMethods,
+                                    width: 110
+                                })
+                            ],
+                            item: vbox({
+                                style: {overflowY: 'scroll'},
+                                items: model.codes.map(it => hframe({
+                                    className: 'http-status-code-frame',
+                                    overflow: 'unset',
+                                    items: [
+                                        button({
+                                            flexGrow: 1,
+                                            className: 'http-status-code-button',
+                                            text: `${it.code}: ${it.description}`,
+                                            onClick: () => model.requestCodeAsync(it.code),
+                                            minimal: false
+                                        }),
+                                        button({
+                                            icon: Icon.info(),
+                                            onClick: () => window.open(`${model.referenceSite}${it.code}`),
+                                            minimal: false
+                                        })]
+                                }))
+                            })
+                        }),
+                        panel({
+                            title: 'Response',
+                            className: 'xh-border-left',
+                            item: vframe({
+                                item: jsonInput({
+                                    flex: 1,
+                                    width: '100%',
+                                    value: model.response
+                                }),
+                                padding: 10
+                            })
+                        })
+                    ]
+                })
+            ]
+        });
+    }
+});

--- a/client-app/src/admin/tests/fetch/FetchApiTestStyles.scss
+++ b/client-app/src/admin/tests/fetch/FetchApiTestStyles.scss
@@ -1,3 +1,4 @@
+.http-status-code-group-button,
 .http-status-code-frame {
     margin: 5px 10px;
     &:first-child {
@@ -7,6 +8,7 @@
         margin-bottom: 10px;
     }
 }
+.http-status-code-group-button,
 .http-status-code-button {
     justify-content: left;
     margin-right: 1px;

--- a/client-app/src/admin/tests/fetch/FetchApiTestStyles.scss
+++ b/client-app/src/admin/tests/fetch/FetchApiTestStyles.scss
@@ -1,0 +1,18 @@
+.http-status-code-frame {
+    margin: 5px 10px;
+    &:first-child {
+        margin-top: 10px;
+    }
+    &:last-child {
+        margin-bottom: 10px;
+    }
+}
+.http-status-code-button {
+    justify-content: left;
+    margin-right: 1px;
+    span {
+        text-overflow: ellipsis;
+        overflow: hidden;
+        white-space: nowrap;
+    }
+}

--- a/client-app/src/admin/tests/panels/PanelResizingTestModel.js
+++ b/client-app/src/admin/tests/panels/PanelResizingTestModel.js
@@ -1,7 +1,7 @@
 import {HoistModel} from '@xh/hoist/core';
 import {action, observable} from '@xh/hoist/mobx';
 import {PanelModel} from '@xh/hoist/desktop/cmp/panel';
-import {p, h3} from '@xh/hoist/cmp/layout';
+import {ol, li, p, h3} from '@xh/hoist/cmp/layout';
 
 
 @HoistModel
@@ -102,15 +102,18 @@ export class PanelResizingTestModel {
         return this.resizablePanelNames.every(it => this[it] && this[it].collapsed);
     }
 
-    loremIpsum = [
+    explanation = [
         h3({
             className: 'xh-text-color-accent',
-            item: 'Some old-fashioned text content'
+            item: 'Use this Page to Test the Panel Drag Bars'
         }),
-        p('Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nullam porta velit varius augue fermentum, vulputate tempus magna tempus.)'),
-        p('Fusce consectetur malesuada vehicula. Aliquam commodo magna at porta sollicitudin. Sed laoreet vehicula leo vel aliquam. Aliquam auctor fringilla ex, nec iaculis felis tincidunt ac. Pellentesque blandit ipsum odio, vel lacinia arcu blandit non.'),
-        p('Vestibulum non libero sem. Mauris a ipsum elit. Donec vestibulum sodales dapibus. Mauris posuere facilisis mollis. Etiam nec mauris nunc. Praesent mauris libero, blandit gravida ullamcorper vel, condimentum et velit. Suspendisse fermentum odio ac dui aliquet semper. Duis arcu felis, accumsan in leo sit amet, vehicula imperdiet tellus. Nulla ut condimentum quam. Donec eget mauris vitae libero blandit facilisis efficitur id justo.'),
-        p('Nam et tincidunt risus, at faucibus enim. Aliquam tortor est, finibus ac metus id, eleifend auctor quam. Aenean purus odio, tempus interdum velit et, faucibus placerat nisi. Etiam eget nunc vehicula, eleifend justo quis, varius leo. Orci varius natoque penatibus et magnis dis parturient montes, nascetur ridiculus mus. Mauris bibendum mollis tempor.'),
-        p('Fusce ac sollicitudin nunc, at tempus sem. Fusce dapibus lorem malesuada vestibulum luctus. Etiam semper est in ligula sagittis facilisis. Phasellus accumsan placerat ex, eu fringilla mauris semper nec.')
+        p('The vertical and horizontal drag bars on the surrounding panels should be draggable (hold mouse down on bar and drag) and dragging a bar should resize its panel.'),
+        p('There are two modes:'),
+        ol({
+            items: [
+                li('Resize after drag (the default mode)'),
+                li('Resize while dragging.')
+            ]}),
+        p('In default "Resize after Drag" mode, the drag bar should only be draggable as far as the next sibling\'s far side.  Also, if the next sibling is itself resizable, it will not shrink, but get pushed over.')
     ]
 }

--- a/client-app/src/admin/tests/panels/PanelResizingTestPanel.js
+++ b/client-app/src/admin/tests/panels/PanelResizingTestPanel.js
@@ -87,7 +87,7 @@ export const PanelResizingTestPanel = hoistCmp({
                         }),
                         panel({
                             item: box({
-                                items: model.loremIpsum,
+                                items: model.explanation,
                                 padding: '0 6 6 6',
                                 display: 'block',
                                 overflowY: 'auto'

--- a/grails-app/controllers/io/xh/toolbox/admin/FetchTestController.groovy
+++ b/grails-app/controllers/io/xh/toolbox/admin/FetchTestController.groovy
@@ -1,0 +1,64 @@
+package io.xh.toolbox.admin
+
+import grails.converters.JSON
+import io.xh.toolbox.BaseController
+import io.xh.hoist.security.Access
+
+
+
+@Access(['HOIST_ADMIN'])
+class FetchTestController extends BaseController {
+
+    def index() {
+        def status = params['status'],
+            statusInt = status.toInteger()
+
+        switch(status[0]) {
+            case '1':
+            respond(status: statusInt)
+                switch(statusInt) {
+                    case 100:
+                        respond(null, status: statusInt)
+                    break
+                }
+                break;
+            case '2':
+                respond(status: statusInt)
+                def responseData = [
+                    'outcome': 'good',
+                    'requestedStatus':  status
+                ]
+                render responseData as JSON
+            break
+            case '3':
+                response.setStatus(statusInt)
+                response.setHeader('Location', "/fetchTest/redirected?status=${status}")
+                def responseData = [
+                    'outcome': 'redirecting...',
+                    'requestedStatus':  status
+                ]
+                render responseData as JSON
+            break
+            case '4':
+            case '5':
+                response.setStatus(statusInt)
+                def responseData = [
+                    'outcome': 'error - as expected',
+                    'requestedStatus':  status
+                ]
+                render responseData as JSON
+            break
+        }
+    }
+
+    def redirected() {
+        def status = params['status']
+        def responseData = [
+            'outcome': 'redirect complete',
+            'requestedStatus':  status
+        ]
+        render responseData as JSON
+    }
+
+
+}

--- a/grails-app/controllers/io/xh/toolbox/admin/FetchTestController.groovy
+++ b/grails-app/controllers/io/xh/toolbox/admin/FetchTestController.groovy
@@ -11,41 +11,32 @@ class FetchTestController extends BaseController {
 
     def index() {
         def status = params['status'],
-            statusInt = status.toInteger()
+            statusInt = status.toInteger(),
+            responseData = ['requestedStatus':  status]
 
         switch(status[0]) {
             case '1':
-            respond(status: statusInt)
-                switch(statusInt) {
-                    case 100:
-                        respond(null, status: statusInt)
-                    break
-                }
-                break;
+                // not quite right for the 1XX
+                // but maybe not worth figuring out right now
+                response.setStatus(statusInt)
+                responseData.put('outcome', 'good')
+                render responseData as JSON
+            break
             case '2':
-                respond(status: statusInt)
-                def responseData = [
-                    'outcome': 'good',
-                    'requestedStatus':  status
-                ]
+                response.setStatus(statusInt)
+                responseData.put('outcome', 'good')
                 render responseData as JSON
             break
             case '3':
                 response.setStatus(statusInt)
                 response.setHeader('Location', "/fetchTest/redirected?status=${status}")
-                def responseData = [
-                    'outcome': 'redirecting...',
-                    'requestedStatus':  status
-                ]
+                responseData.put('outcome', 'redirecting...')
                 render responseData as JSON
             break
             case '4':
             case '5':
                 response.setStatus(statusInt)
-                def responseData = [
-                    'outcome': 'error - as expected',
-                    'requestedStatus':  status
-                ]
+                responseData.put('outcome', 'error - as expected')
                 render responseData as JSON
             break
         }

--- a/grails-app/controllers/io/xh/toolbox/admin/FetchTestController.groovy
+++ b/grails-app/controllers/io/xh/toolbox/admin/FetchTestController.groovy
@@ -5,41 +5,35 @@ import io.xh.toolbox.BaseController
 import io.xh.hoist.security.Access
 
 
-
 @Access(['HOIST_ADMIN'])
 class FetchTestController extends BaseController {
 
     def index() {
-        def status = params['status'],
+        def status = params.status,
             statusInt = status.toInteger(),
-            responseData = ['requestedStatus':  status]
+            responseData = [requestedStatus:  status]
+
+        response.status = statusInt
 
         switch(status[0]) {
             case '1':
                 // not quite right for the 1XX
                 // but maybe not worth figuring out right now
-                response.setStatus(statusInt)
                 responseData.put('outcome', 'good')
-                render responseData as JSON
             break
             case '2':
-                response.setStatus(statusInt)
                 responseData.put('outcome', 'good')
-                render responseData as JSON
             break
             case '3':
-                response.setStatus(statusInt)
                 response.setHeader('Location', "/fetchTest/redirected?status=${status}")
                 responseData.put('outcome', 'redirecting...')
-                render responseData as JSON
             break
             case '4':
             case '5':
-                response.setStatus(statusInt)
                 responseData.put('outcome', 'error - as expected')
-                render responseData as JSON
             break
         }
+        renderJSON(responseData)
     }
 
     def redirected() {
@@ -48,7 +42,7 @@ class FetchTestController extends BaseController {
             'outcome': 'redirect complete',
             'requestedStatus':  status
         ]
-        render responseData as JSON
+        renderJSON(responseData)
     }
 
 


### PR DESCRIPTION
This adds a test page for Hoist-React fetchservice to test how it handles all status codes.  We know it handles the common ones 200, 204, 401, 404, 500, but there are many more.

In particular, this test page lets us see how fetchservice handles 307 redirect status codes.
Issue #1347 in hoist-react https://github.com/xh/hoist-react/issues/1347 suggested that fetchservice did not handle redirect responses correctly.

But I think that it does, if the endpoint redirected to responds with the same content-type that the original request was expecting:  
 json -> redirect -> json   : all good
 json -> redirect -> html :  parse json throws error