### PR TITLE
Portfolio defaults

### DIFF
--- a/client-app/src/examples/portfolio/GridPanelModel.js
+++ b/client-app/src/examples/portfolio/GridPanelModel.js
@@ -11,7 +11,7 @@ export class GridPanelModel {
     @managed panelSizingModel = new PanelModel({
         defaultSize: 500,
         side: 'left',
-        prefName: 'portfolioMapPanelConfig'
+        prefName: 'portfolioGridPanelConfig'
     });
 
     @bindable loadTimestamp;

--- a/client-app/src/examples/portfolio/GridPanelModel.js
+++ b/client-app/src/examples/portfolio/GridPanelModel.js
@@ -2,11 +2,17 @@ import {HoistModel, XH, managed, LoadSupport} from '@xh/hoist/core';
 import {bindable} from '@xh/hoist/mobx';
 import {GridModel} from '@xh/hoist/cmp/grid';
 import {fmtNumberTooltip, millionsRenderer, numberRenderer} from '@xh/hoist/format';
-
+import {PanelModel} from '@xh/hoist/desktop/cmp/panel';
 
 @HoistModel
 @LoadSupport
 export class GridPanelModel {
+
+    @managed panelSizingModel = new PanelModel({
+        defaultSize: 500,
+        side: 'left',
+        prefName: 'portfolioMapPanelConfig'
+    });
 
     @bindable loadTimestamp;
 

--- a/client-app/src/examples/portfolio/MapPanelModel.js
+++ b/client-app/src/examples/portfolio/MapPanelModel.js
@@ -3,18 +3,11 @@ import {managed} from '@xh/hoist/core';
 import {hspacer} from '@xh/hoist/cmp/layout';
 import {fmtMillions} from '@xh/hoist/format';
 import {SplitTreeMapModel} from '@xh/hoist/desktop/cmp/treemap';
-import {PanelModel} from '@xh/hoist/desktop/cmp/panel';
 
 @HoistModel
 export class MapPanelModel {
 
     @managed splitTreeMapModel;
-
-    @managed panelSizingModel = new PanelModel({
-        defaultSize: 1000,
-        side: 'right',
-        prefName: 'portfolioMapPanelConfig'
-    });
 
     constructor({parentModel}) {
         this.splitTreeMapModel = new SplitTreeMapModel({

--- a/client-app/src/examples/portfolio/ui/ef/GridPanel.js
+++ b/client-app/src/examples/portfolio/ui/ef/GridPanel.js
@@ -12,11 +12,14 @@ import {GridPanelModel} from '../../GridPanelModel';
 export const gridPanel = hoistCmp.factory({
     model: uses(GridPanelModel),
 
-    render() {
+    render({model}) {
+        const {panelSizingModel} = model;
+
         return panel({
             title: 'Positions',
             icon: Icon.portfolio(),
             item: grid({agOptions: {groupDefaultExpanded: 1}}),
+            model: panelSizingModel,
             bbar: [
                 dimensionChooser(),
                 gridCountLabel({unit: 'position'}),

--- a/client-app/src/examples/portfolio/ui/ef/GridPanel.js
+++ b/client-app/src/examples/portfolio/ui/ef/GridPanel.js
@@ -16,7 +16,7 @@ export const gridPanel = hoistCmp.factory({
         return panel({
             title: 'Positions',
             icon: Icon.portfolio(),
-            item: grid(),
+            item: grid({agOptions: {groupDefaultExpanded: 1}}),
             bbar: [
                 dimensionChooser(),
                 gridCountLabel({unit: 'position'}),

--- a/client-app/src/examples/portfolio/ui/ef/MapPanel.js
+++ b/client-app/src/examples/portfolio/ui/ef/MapPanel.js
@@ -8,12 +8,11 @@ export const mapPanel = hoistCmp.factory({
     model: uses(MapPanelModel),
 
     render({model}) {
-        const {panelSizingModel, loadModel} = model;
+        const {loadModel} = model;
 
         return panel({
-            title: panelSizingModel.collapsed ? 'Treemap' : null,
+            title: 'Treemap',
             mask: loadModel,
-            model: panelSizingModel,
             item: splitTreeMap()
         });
     }

--- a/client-app/src/examples/portfolio/ui/jsx/GridPanel.js
+++ b/client-app/src/examples/portfolio/ui/jsx/GridPanel.js
@@ -17,8 +17,9 @@ export const GridPanel = hoistCmp({
         const {panelSizingModel} = model;
 
         return <Panel
-            title={panelSizingModel.collapsed ? 'Positions' : null}
+            title='Positions'
             icon={Icon.portfolio()}
+            model={panelSizingModel}
             bbar={[
                 <DimensionChooser/>,
                 <GridCountLabel unit='position'/>,
@@ -27,7 +28,7 @@ export const GridPanel = hoistCmp({
                 <RefreshButton intent='success'/>
             ]}
         >
-            <Grid/>
+            <Grid agOptions={{groupDefaultExpanded: 1}}/>
         </Panel>;
     }
 });

--- a/client-app/src/examples/portfolio/ui/jsx/GridPanel.js
+++ b/client-app/src/examples/portfolio/ui/jsx/GridPanel.js
@@ -14,8 +14,10 @@ export const GridPanel = hoistCmp({
     model: uses(GridPanelModel),
 
     render({model}) {
+        const {panelSizingModel} = model;
+
         return <Panel
-            title='Positions'
+            title={panelSizingModel.collapsed ? 'Treemap' : null}
             icon={Icon.portfolio()}
             bbar={[
                 <DimensionChooser/>,

--- a/client-app/src/examples/portfolio/ui/jsx/GridPanel.js
+++ b/client-app/src/examples/portfolio/ui/jsx/GridPanel.js
@@ -17,7 +17,7 @@ export const GridPanel = hoistCmp({
         const {panelSizingModel} = model;
 
         return <Panel
-            title={panelSizingModel.collapsed ? 'Treemap' : null}
+            title={panelSizingModel.collapsed ? 'Positions' : null}
             icon={Icon.portfolio()}
             bbar={[
                 <DimensionChooser/>,

--- a/client-app/src/examples/portfolio/ui/jsx/MapPanel.js
+++ b/client-app/src/examples/portfolio/ui/jsx/MapPanel.js
@@ -9,12 +9,11 @@ export const MapPanel = hoistCmp({
     model: uses(MapPanelModel),
 
     render({model}) {
-        const {panelSizingModel, loadModel} = model;
+        const {loadModel} = model;
 
         return <Panel
-            title={panelSizingModel.collapsed ? 'Treemap' : null}
+            title='Treemap'
             mask={loadModel}
-            model={panelSizingModel}
         >
             <SplitTreeMap/>
         </Panel>;

--- a/grails-app/init/io/xh/toolbox/BootStrap.groovy
+++ b/grails-app/init/io/xh/toolbox/BootStrap.groovy
@@ -164,7 +164,7 @@ class BootStrap {
                 groupName: 'Toolbox - Example Apps',
                 note: 'Object containing user\'s dimension picker value & history'
             ],
-            portfolioMapPanelConfig: [
+            portfolioGridPanelConfig: [
                 type: 'json',
                 defaultValue: [:],
                 local: true,

--- a/grails-app/init/io/xh/toolbox/BootStrap.groovy
+++ b/grails-app/init/io/xh/toolbox/BootStrap.groovy
@@ -154,7 +154,10 @@ class BootStrap {
             ],
             portfolioDims: [
                 type: 'json',
-                defaultValue: [:],
+                defaultValue: [
+                        value: ["sector", "symbol"],
+                        history: [["sector", "symbol"], ["fund", "trader", "model"], ["region", "sector"]]
+                ],
                 local: true,
                 groupName: 'Toolbox - Example Apps',
                 note: 'Object containing user\'s dimension picker value & history'

--- a/grails-app/init/io/xh/toolbox/BootStrap.groovy
+++ b/grails-app/init/io/xh/toolbox/BootStrap.groovy
@@ -155,8 +155,10 @@ class BootStrap {
             portfolioDims: [
                 type: 'json',
                 defaultValue: [
-                        value: ["sector", "symbol"],
-                        history: [["sector", "symbol"], ["fund", "trader", "model"], ["region", "sector"]]
+                        value: ['sector', 'symbol'],
+                        history: [['sector', 'symbol'],
+                                  ['fund', 'trader', 'model'],
+                                  ['region', 'sector']]
                 ],
                 local: true,
                 groupName: 'Toolbox - Example Apps',


### PR DESCRIPTION
The tree in the Portfolio example app will now be expanded by default and will display a more interesting grouping.

Will fix issue https://github.com/xh/toolbox/issues/247