### PR TITLE
New monitors

### DIFF
--- a/grails-app/init/io/xh/toolbox/BootStrap.groovy
+++ b/grails-app/init/io/xh/toolbox/BootStrap.groovy
@@ -238,6 +238,15 @@ class BootStrap {
                 metricUnit: '',
                 active: true
         )
+        createMonitorIfNeeded(
+                code: 'memoryUsage',
+                name: "Memory Usage of Server",
+                metricType: 'Ceil',
+                metricUnit: '%',
+                warnThreshold: 40,
+                failThreshold: 75,
+                active: true
+        )
     }
 
     private void createMonitorIfNeeded(Map data) {

--- a/grails-app/init/io/xh/toolbox/BootStrap.groovy
+++ b/grails-app/init/io/xh/toolbox/BootStrap.groovy
@@ -189,22 +189,22 @@ class BootStrap {
 
     private void ensureMonitorsCreated() {
         createMonitorIfNeeded(
-                code: 'instrumentCount',
-                name: 'Number of Instruments',
-                metricType: 'Floor',
-                metricUnit: 'instruments',
-                warnThreshold: 50,
-                failThreshold: 10,
-                active: true
+            code: 'instrumentCount',
+            name: 'Number of Instruments',
+            metricType: 'Floor',
+            metricUnit: 'instruments',
+            warnThreshold: 50,
+            failThreshold: 10,
+            active: true
         )
         createMonitorIfNeeded(
-                code: 'positionCount',
-                name: 'Number of Positions',
-                metricType: 'Floor',
-                metricUnit: 'positions',
-                warnThreshold: 50,
-                failThreshold: 10,
-                active: true
+            code: 'positionCount',
+            name: 'Number of Positions',
+            metricType: 'Floor',
+            metricUnit: 'positions',
+            warnThreshold: 50,
+            failThreshold: 10,
+            active: true
         )
         createMonitorIfNeeded(
             code: 'newsStoryCount',
@@ -231,38 +231,38 @@ class BootStrap {
             active: true
         )
         createMonitorIfNeeded(
-                code: 'storageSpaceUsed',
-                name: 'Storage Space Used by File Manager Example App',
-                metricType: 'Ceil',
-                metricUnit: 'MB',
-                warnThreshold: 16,
-                failThreshold: 32,
-                active: true
+            code: 'storageSpaceUsed',
+            name: 'Storage Space Used by File Manager Example App',
+            metricType: 'Ceil',
+            metricUnit: 'MB',
+            warnThreshold: 16,
+            failThreshold: 32,
+            active: true
         )
         createMonitorIfNeeded(
-                code: 'recallsFetchStatus',
-                name: 'Connection status to FDA API',
-                metricType: 'None',
-                metricUnit: '',
-                active: true
+            code: 'recallsFetchStatus',
+            name: 'Connection status to FDA API',
+            metricType: 'None',
+            metricUnit: '',
+            active: true
         )
         createMonitorIfNeeded(
-                code: 'memoryUsage',
-                name: 'Memory Usage of Server',
-                metricType: 'Ceil',
-                metricUnit: '%',
-                warnThreshold: 50,
-                failThreshold: 85,
-                active: true
+            code: 'memoryUsage',
+            name: 'Memory Usage of Server',
+            metricType: 'Ceil',
+            metricUnit: '%',
+            warnThreshold: 50,
+            failThreshold: 85,
+            active: true
         )
         createMonitorIfNeeded(
-                code: 'ninetyninthPercentileLatency',
-                name: '99th Percentile Page Load Time',
-                metricType: 'Ceil',
-                metricUnit: 'milliseconds',
-                warnThreshold: 10000,
-                failThreshold: 30000,
-                active: true
+            code: 'ninetyninthPercentileLatency',
+            name: '99th Percentile Page Load Time',
+            metricType: 'Ceil',
+            metricUnit: 'milliseconds',
+            warnThreshold: 10000,
+            failThreshold: 30000,
+            active: true
         )
     }
 

--- a/grails-app/init/io/xh/toolbox/BootStrap.groovy
+++ b/grails-app/init/io/xh/toolbox/BootStrap.groovy
@@ -207,6 +207,15 @@ class BootStrap {
             active: true
         )
         createMonitorIfNeeded(
+            code: 'pricesAgeMs',
+            name: 'Portfolio: Age of Prices',
+            metricType: 'Ceil',
+            metricUnit: 'ms',
+            warnThreshold: 30000,
+            failThreshold: 60000,
+            active: true
+        )
+        createMonitorIfNeeded(
             code: 'newsStoryCount',
             name: 'News: Loaded Stories',
             metricType: 'Floor',

--- a/grails-app/init/io/xh/toolbox/BootStrap.groovy
+++ b/grails-app/init/io/xh/toolbox/BootStrap.groovy
@@ -255,6 +255,15 @@ class BootStrap {
                 failThreshold: 85,
                 active: true
         )
+        createMonitorIfNeeded(
+                code: 'ninetyninthPercentileLatency',
+                name: '99th Percentile Page Load Latency',
+                metricType: 'Ceil',
+                metricUnit: 'milliseconds',
+                warnThreshold: 10000,
+                failThreshold: 30000,
+                active: true
+        )
     }
 
     private void createMonitorIfNeeded(Map data) {

--- a/grails-app/init/io/xh/toolbox/BootStrap.groovy
+++ b/grails-app/init/io/xh/toolbox/BootStrap.groovy
@@ -1,6 +1,7 @@
 package io.xh.toolbox
 
 import io.xh.hoist.config.AppConfig
+import io.xh.hoist.config.ConfigService
 import io.xh.hoist.util.Utils
 import io.xh.toolbox.user.User
 import io.xh.hoist.BaseService
@@ -192,7 +193,7 @@ class BootStrap {
             code: 'newsStoryCount',
             name: 'Loaded Stories',
             metricType: 'Floor',
-            failThreshold: 0,
+            failThreshold: 1,
             metricUnit: 'stories',
             active: true
         )
@@ -211,6 +212,31 @@ class BootStrap {
             metricType: 'None',
             metricUnit: 'sources',
             active: true
+        )
+        createMonitorIfNeeded(
+                code: 'storageSpaceUsed',
+                name: 'Storage Space Used by Uploaded Files',
+                metricType: 'Ceil',
+                metricUnit: 'MiB',
+                warnThreshold: 16,
+                failThreshold: 32,
+                active: true
+        )
+        createMonitorIfNeeded(
+                code: 'maliciousFilesFound',
+                name: 'Malicious Files Uploaded',
+                metricType: 'Ceil',
+                metricUnit: 'potentially malicious files',
+                warnThreshold: 0,
+                failThreshold: 1,
+                active: true
+        )
+        createMonitorIfNeeded(
+                code: 'recallsFetchStatus',
+                name: "Connection status to ${configService.getString('recallsHost', 'api.fda.gov')}",
+                metricType: 'None',
+                metricUnit: '',
+                active: true
         )
     }
 

--- a/grails-app/init/io/xh/toolbox/BootStrap.groovy
+++ b/grails-app/init/io/xh/toolbox/BootStrap.groovy
@@ -257,7 +257,7 @@ class BootStrap {
         )
         createMonitorIfNeeded(
                 code: 'ninetyninthPercentileLatency',
-                name: '99th Percentile Page Load Latency',
+                name: '99th Percentile Page Load Time',
                 metricType: 'Ceil',
                 metricUnit: 'milliseconds',
                 warnThreshold: 10000,

--- a/grails-app/init/io/xh/toolbox/BootStrap.groovy
+++ b/grails-app/init/io/xh/toolbox/BootStrap.groovy
@@ -189,6 +189,24 @@ class BootStrap {
 
     private void ensureMonitorsCreated() {
         createMonitorIfNeeded(
+                code: 'instrumentCount',
+                name: 'Number of Instruments',
+                metricType: 'Floor',
+                metricUnit: 'instruments',
+                warnThreshold: 50,
+                failThreshold: 10,
+                active: true
+        )
+        createMonitorIfNeeded(
+                code: 'positionCount',
+                name: 'Number of Positions',
+                metricType: 'Floor',
+                metricUnit: 'positions',
+                warnThreshold: 50,
+                failThreshold: 10,
+                active: true
+        )
+        createMonitorIfNeeded(
             code: 'newsStoryCount',
             name: 'Loaded Stories',
             metricType: 'Floor',

--- a/grails-app/init/io/xh/toolbox/BootStrap.groovy
+++ b/grails-app/init/io/xh/toolbox/BootStrap.groovy
@@ -190,7 +190,7 @@ class BootStrap {
     private void ensureMonitorsCreated() {
         createMonitorIfNeeded(
             code: 'instrumentCount',
-            name: 'Number of Instruments',
+            name: 'Portfolio: Number of Instruments',
             metricType: 'Floor',
             metricUnit: 'instruments',
             warnThreshold: 50,
@@ -199,7 +199,7 @@ class BootStrap {
         )
         createMonitorIfNeeded(
             code: 'positionCount',
-            name: 'Number of Positions',
+            name: 'Portfolio: Number of Positions',
             metricType: 'Floor',
             metricUnit: 'positions',
             warnThreshold: 50,
@@ -208,7 +208,7 @@ class BootStrap {
         )
         createMonitorIfNeeded(
             code: 'newsStoryCount',
-            name: 'Loaded Stories',
+            name: 'News: Loaded Stories',
             metricType: 'Floor',
             failThreshold: 1,
             metricUnit: 'stories',
@@ -216,7 +216,7 @@ class BootStrap {
         )
         createMonitorIfNeeded(
             code: 'lastUpdateAgeMins',
-            name: 'Most Recent Story',
+            name: 'News: Most Recent Story',
             metricType: 'Ceil',
             metricUnit: 'minutes since last story',
             warnThreshold: 60,
@@ -225,14 +225,14 @@ class BootStrap {
         )
         createMonitorIfNeeded(
             code: 'loadedSourcesCount',
-            name: 'All Sources Loaded',
+            name: 'News: Sources Loaded',
             metricType: 'None',
             metricUnit: 'sources',
             active: true
         )
         createMonitorIfNeeded(
             code: 'storageSpaceUsed',
-            name: 'Storage Space Used by File Manager Example App',
+            name: 'FileManager: Storage Space',
             metricType: 'Ceil',
             metricUnit: 'MB',
             warnThreshold: 16,
@@ -241,7 +241,7 @@ class BootStrap {
         )
         createMonitorIfNeeded(
             code: 'recallsFetchStatus',
-            name: 'Connection status to FDA API',
+            name: 'Recalls: Connection to FDA API',
             metricType: 'None',
             metricUnit: '',
             active: true
@@ -256,10 +256,10 @@ class BootStrap {
             active: true
         )
         createMonitorIfNeeded(
-            code: 'pageLoadTime',
-            name: 'Worst Page Load Time in Last Hour',
+            code: 'longestPageLoadMs',
+            name: 'Longest Page Load in Last Hour',
             metricType: 'Ceil',
-            metricUnit: 'milliseconds',
+            metricUnit: 'ms',
             warnThreshold: 10000,
             failThreshold: 30000,
             active: true

--- a/grails-app/init/io/xh/toolbox/BootStrap.groovy
+++ b/grails-app/init/io/xh/toolbox/BootStrap.groovy
@@ -223,15 +223,6 @@ class BootStrap {
                 active: true
         )
         createMonitorIfNeeded(
-                code: 'maliciousFilesFound',
-                name: 'Malicious Files Uploaded',
-                metricType: 'Ceil',
-                metricUnit: 'potentially malicious files',
-                warnThreshold: 0,
-                failThreshold: 1,
-                active: true
-        )
-        createMonitorIfNeeded(
                 code: 'recallsFetchStatus',
                 name: "Connection status to ${configService.getString('recallsHost', 'api.fda.gov')}",
                 metricType: 'None',

--- a/grails-app/init/io/xh/toolbox/BootStrap.groovy
+++ b/grails-app/init/io/xh/toolbox/BootStrap.groovy
@@ -224,7 +224,7 @@ class BootStrap {
         )
         createMonitorIfNeeded(
                 code: 'recallsFetchStatus',
-                name: "Connection status to ${configService.getString('recallsHost', 'api.fda.gov')}",
+                name: "Connection status to FDA API}",
                 metricType: 'None',
                 metricUnit: '',
                 active: true

--- a/grails-app/init/io/xh/toolbox/BootStrap.groovy
+++ b/grails-app/init/io/xh/toolbox/BootStrap.groovy
@@ -224,14 +224,14 @@ class BootStrap {
         )
         createMonitorIfNeeded(
                 code: 'recallsFetchStatus',
-                name: "Connection status to FDA API}",
+                name: 'Connection status to FDA API',
                 metricType: 'None',
                 metricUnit: '',
                 active: true
         )
         createMonitorIfNeeded(
                 code: 'memoryUsage',
-                name: "Memory Usage of Server",
+                name: 'Memory Usage of Server',
                 metricType: 'Ceil',
                 metricUnit: '%',
                 warnThreshold: 50,

--- a/grails-app/init/io/xh/toolbox/BootStrap.groovy
+++ b/grails-app/init/io/xh/toolbox/BootStrap.groovy
@@ -215,9 +215,9 @@ class BootStrap {
         )
         createMonitorIfNeeded(
                 code: 'storageSpaceUsed',
-                name: 'Storage Space Used by Uploaded Files',
+                name: 'Storage Space Used by File Manager Example App',
                 metricType: 'Ceil',
-                metricUnit: 'MiB',
+                metricUnit: 'MB',
                 warnThreshold: 16,
                 failThreshold: 32,
                 active: true

--- a/grails-app/init/io/xh/toolbox/BootStrap.groovy
+++ b/grails-app/init/io/xh/toolbox/BootStrap.groovy
@@ -189,6 +189,15 @@ class BootStrap {
 
     private void ensureMonitorsCreated() {
         createMonitorIfNeeded(
+            code: 'pricesAgeMs',
+            name: 'Portfolio: Last Price Update',
+            metricType: 'Ceil',
+            metricUnit: 'ms',
+            warnThreshold: 30000,
+            failThreshold: 60000,
+            active: true
+        )
+        createMonitorIfNeeded(
             code: 'instrumentCount',
             name: 'Portfolio: Number of Instruments',
             metricType: 'Floor',
@@ -204,15 +213,6 @@ class BootStrap {
             metricUnit: 'positions',
             warnThreshold: 50,
             failThreshold: 10,
-            active: true
-        )
-        createMonitorIfNeeded(
-            code: 'pricesAgeMs',
-            name: 'Portfolio: Age of Prices',
-            metricType: 'Ceil',
-            metricUnit: 'ms',
-            warnThreshold: 30000,
-            failThreshold: 60000,
             active: true
         )
         createMonitorIfNeeded(

--- a/grails-app/init/io/xh/toolbox/BootStrap.groovy
+++ b/grails-app/init/io/xh/toolbox/BootStrap.groovy
@@ -1,7 +1,6 @@
 package io.xh.toolbox
 
 import io.xh.hoist.config.AppConfig
-import io.xh.hoist.config.ConfigService
 import io.xh.hoist.util.Utils
 import io.xh.toolbox.user.User
 import io.xh.hoist.BaseService

--- a/grails-app/init/io/xh/toolbox/BootStrap.groovy
+++ b/grails-app/init/io/xh/toolbox/BootStrap.groovy
@@ -256,8 +256,8 @@ class BootStrap {
             active: true
         )
         createMonitorIfNeeded(
-            code: 'ninetyninthPercentileLatency',
-            name: '99th Percentile Page Load Time',
+            code: 'pageLoadTime',
+            name: 'Worst Page Load Time in Last Hour',
             metricType: 'Ceil',
             metricUnit: 'milliseconds',
             warnThreshold: 10000,

--- a/grails-app/init/io/xh/toolbox/BootStrap.groovy
+++ b/grails-app/init/io/xh/toolbox/BootStrap.groovy
@@ -243,8 +243,8 @@ class BootStrap {
                 name: "Memory Usage of Server",
                 metricType: 'Ceil',
                 metricUnit: '%',
-                warnThreshold: 40,
-                failThreshold: 75,
+                warnThreshold: 50,
+                failThreshold: 85,
                 active: true
         )
     }

--- a/grails-app/services/io/xh/toolbox/MonitorDefinitionService.groovy
+++ b/grails-app/services/io/xh/toolbox/MonitorDefinitionService.groovy
@@ -64,7 +64,7 @@ class MonitorDefinitionService extends BaseService {
                 .collect {it.length()}
                 .sum() ?: 0
         //and convert to megabytes rounded to two decimal places
-        def MiB = (bytes / (1024 * 1024)).setScale(2, BigDecimal.ROUND_HALF_UP)
+        def MB = (bytes / (1024 * 1024)).setScale(2, BigDecimal.ROUND_HALF_UP)
         result.metric = MiB
     }
 

--- a/grails-app/services/io/xh/toolbox/MonitorDefinitionService.groovy
+++ b/grails-app/services/io/xh/toolbox/MonitorDefinitionService.groovy
@@ -53,12 +53,11 @@ class MonitorDefinitionService extends BaseService {
      * Check the storage space used by uploaded files in the FileManager app, in megabytes
      */
     def storageSpaceUsed(MonitorResult result) {
-        //sum up the sizes of all uploaded files..
+        // sum up the sizes of all uploaded files..
         def bytes = fileManagerService.list()
-                .collect {it.length()}
-                .sum() ?: 0
-        //and convert to megabytes rounded to two decimal places
-        def MB = (bytes / (1024 * 1024)).setScale(2, BigDecimal.ROUND_HALF_UP)
+                .sum {it.length()} ?: 0
+        // and convert to megabytes rounded to two decimal places
+        def MB = ((double)(bytes / (1024 * 1024))).round(2)
         result.metric = MB
     }
 
@@ -68,7 +67,7 @@ class MonitorDefinitionService extends BaseService {
     def recallsFetchStatus(MonitorResult result) {
         recallsService.fetchRecalls('')
         def code = recallsService.getLastResponseCode()
-        if (recallsService.lastResponseCode == null) {
+        if (code == null) {
             result.message = 'Could not connect to server.'
             result.status = FAIL
         } else if (code >= 300 && code < 400) {
@@ -82,8 +81,8 @@ class MonitorDefinitionService extends BaseService {
      * Check the current memory usage of the server machine (in %)
      */
     def memoryUsage(MonitorResult result) {
-        result.metric = (Runtime.getRuntime().freeMemory() / Runtime.getRuntime().totalMemory() * 100)
-                .setScale(2, BigDecimal.ROUND_HALF_UP)
+        result.metric = ((double)(Runtime.runtime.freeMemory() / Runtime.runtime.totalMemory() * 100))
+                .round(2)
     }
 
     /**

--- a/grails-app/services/io/xh/toolbox/MonitorDefinitionService.groovy
+++ b/grails-app/services/io/xh/toolbox/MonitorDefinitionService.groovy
@@ -2,9 +2,6 @@ package io.xh.toolbox
 
 import io.xh.hoist.BaseService
 import io.xh.hoist.monitor.MonitorResult
-import io.xh.toolbox.app.FileManagerService
-
-import java.math.MathContext
 
 import static io.xh.hoist.monitor.MonitorStatus.OK
 import static io.xh.hoist.monitor.MonitorStatus.FAIL
@@ -101,5 +98,10 @@ class MonitorDefinitionService extends BaseService {
         } else if (code >= 400) {
             result.status = FAIL
         }
+    }
+
+    def memoryUsage(MonitorResult result) {
+        result.metric = ((double)Runtime.getRuntime().freeMemory() / Runtime.getRuntime().totalMemory() * 100)
+                .setScale(2, BigDecimal.ROUND_HALF_UP)
     }
 }

--- a/grails-app/services/io/xh/toolbox/MonitorDefinitionService.groovy
+++ b/grails-app/services/io/xh/toolbox/MonitorDefinitionService.groovy
@@ -18,8 +18,6 @@ class MonitorDefinitionService extends BaseService {
 
     /**
      * Check the count of news stories loaded by NewsService
-     * @param result
-     * @return
      */
     def newsStoryCount(MonitorResult result) {
         result.metric = newsService.itemCount
@@ -28,8 +26,6 @@ class MonitorDefinitionService extends BaseService {
     /**
      * Check when the last update to the news was fetched.
      * If no news stories have been fetched at all, we consider that a failure.
-     * @param result
-     * @return
      */
     def lastUpdateAgeMins(MonitorResult result) {
         if (newsService.lastTimestamp) {
@@ -45,8 +41,6 @@ class MonitorDefinitionService extends BaseService {
 
     /**
      * Check whether or not the NewsService has loaded stories from all its sources.
-     * @param result
-     * @return
      */
     def loadedSourcesCount(MonitorResult result) {
         result.metric = newsService.loadedSourcesCount
@@ -54,9 +48,7 @@ class MonitorDefinitionService extends BaseService {
     }
 
     /**
-     * Check the storage space used by uploaded files in the FileManager app, in megabytes
-     * @param result
-     * @return
+     * Check the storage space used by uploaded files in the FileManager app, in megabytes\
      */
     def storageSpaceUsed(MonitorResult result) {
         //sum up the sizes of all uploaded files..
@@ -70,8 +62,6 @@ class MonitorDefinitionService extends BaseService {
 
     /**
      * Check whether or not we connected to the FDA server successfully for drug recall information.
-     * @param result
-     * @return
      */
     def recallsFetchStatus(MonitorResult result) {
         recallsService.fetchRecalls('')
@@ -86,6 +76,9 @@ class MonitorDefinitionService extends BaseService {
         }
     }
 
+    /**
+     * Check the current memory usage of the server machine (in %)
+     */
     def memoryUsage(MonitorResult result) {
         result.metric = (Runtime.getRuntime().freeMemory() / Runtime.getRuntime().totalMemory() * 100)
                 .setScale(2, BigDecimal.ROUND_HALF_UP)

--- a/grails-app/services/io/xh/toolbox/MonitorDefinitionService.groovy
+++ b/grails-app/services/io/xh/toolbox/MonitorDefinitionService.groovy
@@ -100,6 +100,16 @@ class MonitorDefinitionService extends BaseService {
     }
 
     /**
+     * Check when the most recent prices in the Portfolio example were generated
+     */
+    def pricesAgeMs(MonitorResult result) {
+        def now = new Date()
+        use (TimeCategory) {
+            result.metric = (now - portfolioService.data.timeCreated).toMilliseconds()
+        }
+    }
+
+    /**
      * Check the longest page load time in the last hour
      */
     def longestPageLoadMs(MonitorResult result) {

--- a/grails-app/services/io/xh/toolbox/MonitorDefinitionService.groovy
+++ b/grails-app/services/io/xh/toolbox/MonitorDefinitionService.groovy
@@ -69,18 +69,6 @@ class MonitorDefinitionService extends BaseService {
     }
 
     /**
-     * Check whether or not any files that look like executables have been uploaded.
-     * @param result
-     * @return
-     */
-    def maliciousFilesFound(MonitorResult result) {
-        //count how many uploaded files contain .sh or .exe (i.e. look like an executable)
-        result.metric = fileManagerService.list()
-                .findAll {it.name.matches(".*\\.(sh|exe).*")}
-                .size()
-    }
-
-    /**
      * Check whether or not we connected to the FDA server successfully for drug recall information.
      * @param result
      * @return

--- a/grails-app/services/io/xh/toolbox/MonitorDefinitionService.groovy
+++ b/grails-app/services/io/xh/toolbox/MonitorDefinitionService.groovy
@@ -48,7 +48,7 @@ class MonitorDefinitionService extends BaseService {
     }
 
     /**
-     * Check the storage space used by uploaded files in the FileManager app, in megabytes\
+     * Check the storage space used by uploaded files in the FileManager app, in megabytes
      */
     def storageSpaceUsed(MonitorResult result) {
         //sum up the sizes of all uploaded files..

--- a/grails-app/services/io/xh/toolbox/MonitorDefinitionService.groovy
+++ b/grails-app/services/io/xh/toolbox/MonitorDefinitionService.groovy
@@ -2,28 +2,73 @@ package io.xh.toolbox
 
 import io.xh.hoist.BaseService
 import io.xh.hoist.monitor.MonitorResult
+import io.xh.toolbox.app.FileManagerService
+
+import java.math.MathContext
 
 import static io.xh.hoist.monitor.MonitorStatus.OK
 import static io.xh.hoist.monitor.MonitorStatus.FAIL
+import static io.xh.hoist.monitor.MonitorStatus.UNKNOWN
+import static io.xh.hoist.monitor.MonitorStatus.WARN
 import static io.xh.hoist.util.DateTimeUtils.MINUTES
 import static java.lang.System.currentTimeMillis
 
 class MonitorDefinitionService extends BaseService {
 
     def newsService
+    def fileManagerService
+    def recallsService
 
     def newsStoryCount(MonitorResult result) {
         result.metric = newsService.itemCount
     }
 
     def lastUpdateAgeMins(MonitorResult result) {
-        def diffMs = currentTimeMillis() - newsService.lastTimestamp.time,
-            diffHours = Math.floor(diffMs / MINUTES)
-        result.metric = diffHours
+        if (newsService.lastTimestamp) {
+            def diffMs = currentTimeMillis() - newsService.lastTimestamp.time,
+                diffHours = Math.floor(diffMs / MINUTES)
+            result.metric = diffHours
+        } else {
+            result.metric = -1;
+            result.status = FAIL
+            result.message = 'Have not yet loaded any stories'
+        }
     }
 
     def loadedSourcesCount(MonitorResult result) {
         result.metric = newsService.loadedSourcesCount
         result.status = newsService.allSourcesLoaded ? OK : FAIL
+    }
+
+    def storageSpaceUsed(MonitorResult result) {
+        //sum up the sizes of all uploaded files..
+        def bytes = fileManagerService.list()
+                .collect {it.length()}
+                .sum() ?: 0
+        //and convert to megabytes rounded to two decimal places
+        def MiB = (bytes / (1024 * 1024)).setScale(2, BigDecimal.ROUND_HALF_UP)
+        result.metric = MiB
+    }
+
+    def maliciousFilesFound(MonitorResult result) {
+        //count how many uploaded files contain .sh or .exe (i.e. look like an executable)
+        result.metric = fileManagerService.list()
+                .findAll {it.name.matches(".*\\.(sh|exe).*")}
+                .size()
+    }
+
+    def recallsFetchStatus(MonitorResult result) {
+        def code = recallsService.getLastResponseCode()
+        if (!recallsService.getDoneFetch()) {
+            result.message = 'Have not yet tried to fetch recalls.'
+            result.status = OK
+        } else if (!recallsService.getConnectedSuccessfully()) {
+            result.message = 'Could not connect to server.'
+            result.status = FAIL
+        } else if (code >= 300 && code < 400) {
+            result.status = WARN
+        } else if (code >= 400) {
+            result.status = FAIL
+        }
     }
 }

--- a/grails-app/services/io/xh/toolbox/MonitorDefinitionService.groovy
+++ b/grails-app/services/io/xh/toolbox/MonitorDefinitionService.groovy
@@ -85,10 +85,16 @@ class MonitorDefinitionService extends BaseService {
                 .setScale(2, BigDecimal.ROUND_HALF_UP)
     }
 
+    /**
+     * Check the current number of positions in the Portfolio example
+     */
     def positionCount(MonitorResult result) {
         result.metric = portfolioService.data.rawPositions.size()
     }
 
+    /**
+     * Check the current number of instruments in the Portfolio example
+     */
     def instrumentCount(MonitorResult result) {
         result.metric = portfolioService.data.instruments.size()
     }

--- a/grails-app/services/io/xh/toolbox/MonitorDefinitionService.groovy
+++ b/grails-app/services/io/xh/toolbox/MonitorDefinitionService.groovy
@@ -57,7 +57,7 @@ class MonitorDefinitionService extends BaseService {
                 .sum() ?: 0
         //and convert to megabytes rounded to two decimal places
         def MB = (bytes / (1024 * 1024)).setScale(2, BigDecimal.ROUND_HALF_UP)
-        result.metric = MiB
+        result.metric = MB
     }
 
     /**

--- a/grails-app/services/io/xh/toolbox/MonitorDefinitionService.groovy
+++ b/grails-app/services/io/xh/toolbox/MonitorDefinitionService.groovy
@@ -2,6 +2,7 @@ package io.xh.toolbox
 
 import io.xh.hoist.BaseService
 import io.xh.hoist.monitor.MonitorResult
+import io.xh.hoist.track.TrackLog
 
 import static io.xh.hoist.monitor.MonitorStatus.OK
 import static io.xh.hoist.monitor.MonitorStatus.FAIL
@@ -97,5 +98,16 @@ class MonitorDefinitionService extends BaseService {
      */
     def instrumentCount(MonitorResult result) {
         result.metric = portfolioService.data.instruments.size()
+    }
+
+    /**
+     * Check the 99% latency of client page loads
+     */
+    def ninetyninthPercentileLatency(MonitorResult result) {
+        def latencies = TrackLog.findAll(max: 5000, sort: 'dateCreated', order: 'desc')
+                        .collect{it.elapsed}.sort()
+        def count = latencies.size()
+        def ninetyninth = (int)(count * 0.99)
+        result.metric = (count > 0) ? latencies.get(ninetyninth) : 0
     }
 }

--- a/grails-app/services/io/xh/toolbox/MonitorDefinitionService.groovy
+++ b/grails-app/services/io/xh/toolbox/MonitorDefinitionService.groovy
@@ -101,7 +101,7 @@ class MonitorDefinitionService extends BaseService {
     }
 
     def memoryUsage(MonitorResult result) {
-        result.metric = ((double)Runtime.getRuntime().freeMemory() / Runtime.getRuntime().totalMemory() * 100)
+        result.metric = (Runtime.getRuntime().freeMemory() / Runtime.getRuntime().totalMemory() * 100)
                 .setScale(2, BigDecimal.ROUND_HALF_UP)
     }
 }

--- a/grails-app/services/io/xh/toolbox/MonitorDefinitionService.groovy
+++ b/grails-app/services/io/xh/toolbox/MonitorDefinitionService.groovy
@@ -19,10 +19,21 @@ class MonitorDefinitionService extends BaseService {
     def fileManagerService
     def recallsService
 
+    /**
+     * Check the count of news stories loaded by NewsService
+     * @param result
+     * @return
+     */
     def newsStoryCount(MonitorResult result) {
         result.metric = newsService.itemCount
     }
 
+    /**
+     * Check when the last update to the news was fetched.
+     * If no news stories have been fetched at all, we consider that a failure.
+     * @param result
+     * @return
+     */
     def lastUpdateAgeMins(MonitorResult result) {
         if (newsService.lastTimestamp) {
             def diffMs = currentTimeMillis() - newsService.lastTimestamp.time,
@@ -35,11 +46,21 @@ class MonitorDefinitionService extends BaseService {
         }
     }
 
+    /**
+     * Check whether or not the NewsService has loaded stories from all its sources.
+     * @param result
+     * @return
+     */
     def loadedSourcesCount(MonitorResult result) {
         result.metric = newsService.loadedSourcesCount
         result.status = newsService.allSourcesLoaded ? OK : FAIL
     }
 
+    /**
+     * Check the storage space used by uploaded files in the FileManager app, in megabytes
+     * @param result
+     * @return
+     */
     def storageSpaceUsed(MonitorResult result) {
         //sum up the sizes of all uploaded files..
         def bytes = fileManagerService.list()
@@ -50,6 +71,11 @@ class MonitorDefinitionService extends BaseService {
         result.metric = MiB
     }
 
+    /**
+     * Check whether or not any files that look like executables have been uploaded.
+     * @param result
+     * @return
+     */
     def maliciousFilesFound(MonitorResult result) {
         //count how many uploaded files contain .sh or .exe (i.e. look like an executable)
         result.metric = fileManagerService.list()
@@ -57,6 +83,11 @@ class MonitorDefinitionService extends BaseService {
                 .size()
     }
 
+    /**
+     * Check whether or not we connected to the FDA server successfully for drug recall information.
+     * @param result
+     * @return
+     */
     def recallsFetchStatus(MonitorResult result) {
         def code = recallsService.getLastResponseCode()
         if (!recallsService.getDoneFetch()) {

--- a/grails-app/services/io/xh/toolbox/MonitorDefinitionService.groovy
+++ b/grails-app/services/io/xh/toolbox/MonitorDefinitionService.groovy
@@ -74,11 +74,9 @@ class MonitorDefinitionService extends BaseService {
      * @return
      */
     def recallsFetchStatus(MonitorResult result) {
+        recallsService.fetchRecalls('')
         def code = recallsService.getLastResponseCode()
-        if (!recallsService.getDoneFetch()) {
-            result.message = 'Have not yet tried to fetch recalls.'
-            result.status = OK
-        } else if (!recallsService.getConnectedSuccessfully()) {
+        if (recallsService.lastResponseCode == null) {
             result.message = 'Could not connect to server.'
             result.status = FAIL
         } else if (code >= 300 && code < 400) {

--- a/grails-app/services/io/xh/toolbox/MonitorDefinitionService.groovy
+++ b/grails-app/services/io/xh/toolbox/MonitorDefinitionService.groovy
@@ -7,7 +7,6 @@ import io.xh.hoist.track.TrackLog
 
 import static io.xh.hoist.monitor.MonitorStatus.OK
 import static io.xh.hoist.monitor.MonitorStatus.FAIL
-import static io.xh.hoist.monitor.MonitorStatus.UNKNOWN
 import static io.xh.hoist.monitor.MonitorStatus.WARN
 import static io.xh.hoist.util.DateTimeUtils.MINUTES
 import static java.lang.Runtime.runtime
@@ -103,10 +102,7 @@ class MonitorDefinitionService extends BaseService {
      * Check when the most recent prices in the Portfolio example were generated
      */
     def pricesAgeMs(MonitorResult result) {
-        def now = new Date()
-        use (TimeCategory) {
-            result.metric = (now - portfolioService.data.timeCreated).toMilliseconds()
-        }
+        result.metric = currentTimeMillis() - portfolioService.data.timeCreated
     }
 
     /**

--- a/grails-app/services/io/xh/toolbox/MonitorDefinitionService.groovy
+++ b/grails-app/services/io/xh/toolbox/MonitorDefinitionService.groovy
@@ -102,7 +102,7 @@ class MonitorDefinitionService extends BaseService {
      * Check when the most recent prices in the Portfolio example were generated
      */
     def pricesAgeMs(MonitorResult result) {
-        result.metric = currentTimeMillis() - portfolioService.data.timeCreated
+        result.metric = currentTimeMillis() - portfolioService.data.timeCreated.time
     }
 
     /**

--- a/grails-app/services/io/xh/toolbox/MonitorDefinitionService.groovy
+++ b/grails-app/services/io/xh/toolbox/MonitorDefinitionService.groovy
@@ -15,6 +15,7 @@ class MonitorDefinitionService extends BaseService {
     def newsService
     def fileManagerService
     def recallsService
+    def portfolioService
 
     /**
      * Check the count of news stories loaded by NewsService
@@ -82,5 +83,13 @@ class MonitorDefinitionService extends BaseService {
     def memoryUsage(MonitorResult result) {
         result.metric = (Runtime.getRuntime().freeMemory() / Runtime.getRuntime().totalMemory() * 100)
                 .setScale(2, BigDecimal.ROUND_HALF_UP)
+    }
+
+    def positionCount(MonitorResult result) {
+        result.metric = portfolioService.data.rawPositions.size()
+    }
+
+    def instrumentCount(MonitorResult result) {
+        result.metric = portfolioService.data.instruments.size()
     }
 }

--- a/grails-app/services/io/xh/toolbox/app/NewsService.groovy
+++ b/grails-app/services/io/xh/toolbox/app/NewsService.groovy
@@ -33,7 +33,7 @@ class NewsService extends BaseService {
     // For sample monitors
     //------------------------
     int getItemCount() {
-        return _newsItems.size()
+        return _newsItems ? newsItems.size() : 0
     }
 
     int getLoadedSourcesCount() {

--- a/grails-app/services/io/xh/toolbox/app/NewsService.groovy
+++ b/grails-app/services/io/xh/toolbox/app/NewsService.groovy
@@ -33,7 +33,7 @@ class NewsService extends BaseService {
     // For sample monitors
     //------------------------
     int getItemCount() {
-        return _newsItems ? newsItems.size() : 0
+        return newsItems.size()
     }
 
     int getLoadedSourcesCount() {

--- a/grails-app/services/io/xh/toolbox/app/RecallsService.groovy
+++ b/grails-app/services/io/xh/toolbox/app/RecallsService.groovy
@@ -6,13 +6,7 @@ import io.xh.hoist.json.JSON
 class RecallsService extends BaseService {
 
     def configService
-
-    //last time we tried to fetch data, did we successfully connect to the server?
-    def connectedSuccessfully;
-    //last HTTP code from the server
     def lastResponseCode;
-    //have we tried to fetch data so far in the lifetime of the server?
-    def doneFetch = false;
 
     List fetchRecalls(String searchQuery) {
         connectedSuccessfully = true;
@@ -36,7 +30,7 @@ class RecallsService extends BaseService {
             }
         } catch (IOException e) {
             //we got an exception, so our connection was not successful.
-            connectedSuccessfully = false;
+            lastResponseCode = null
             return []
         } finally {
             inputStream?.close()

--- a/grails-app/services/io/xh/toolbox/app/RecallsService.groovy
+++ b/grails-app/services/io/xh/toolbox/app/RecallsService.groovy
@@ -6,8 +6,13 @@ import io.xh.hoist.json.JSON
 class RecallsService extends BaseService {
 
     def configService
+    def lastResponseCode;
+    def doneFetch = false;
+    def connectedSuccessfully;
 
     List fetchRecalls(String searchQuery) {
+        connectedSuccessfully = true;
+        doneFetch = true;
         def host = configService.getString('recallsHost'),
             url = !searchQuery ?
                 // `_exists_:openfda` ensures all search hits includes a nested openfda object that contains essential data for frontend
@@ -17,17 +22,18 @@ class RecallsService extends BaseService {
         def connection = url.openConnection(),
             inputStream = null
         try {
+            lastResponseCode = connection.responseCode
             if (connection.responseCode == 404) {
                 return []
             } else {
                 inputStream = connection.getInputStream()
                 return JSON.parse(inputStream, 'UTF-8').results
             }
+        } catch (IOException e) {
+            connectedSuccessfully = false;
+            return []
         } finally {
             inputStream?.close()
         }
-
     }
-
-
 }

--- a/grails-app/services/io/xh/toolbox/app/RecallsService.groovy
+++ b/grails-app/services/io/xh/toolbox/app/RecallsService.groovy
@@ -9,8 +9,6 @@ class RecallsService extends BaseService {
     def lastResponseCode;
 
     List fetchRecalls(String searchQuery) {
-        connectedSuccessfully = true;
-        doneFetch = true;
 
         def host = configService.getString('recallsHost'),
             url = !searchQuery ?

--- a/grails-app/services/io/xh/toolbox/app/RecallsService.groovy
+++ b/grails-app/services/io/xh/toolbox/app/RecallsService.groovy
@@ -6,13 +6,18 @@ import io.xh.hoist.json.JSON
 class RecallsService extends BaseService {
 
     def configService
-    def lastResponseCode;
-    def doneFetch = false;
+
+    //last time we tried to fetch data, did we successfully connect to the server?
     def connectedSuccessfully;
+    //last HTTP code from the server
+    def lastResponseCode;
+    //have we tried to fetch data so far in the lifetime of the server?
+    def doneFetch = false;
 
     List fetchRecalls(String searchQuery) {
         connectedSuccessfully = true;
         doneFetch = true;
+
         def host = configService.getString('recallsHost'),
             url = !searchQuery ?
                 // `_exists_:openfda` ensures all search hits includes a nested openfda object that contains essential data for frontend
@@ -30,6 +35,7 @@ class RecallsService extends BaseService {
                 return JSON.parse(inputStream, 'UTF-8').results
             }
         } catch (IOException e) {
+            //we got an exception, so our connection was not successful.
             connectedSuccessfully = false;
             return []
         } finally {

--- a/grails-app/services/io/xh/toolbox/app/RecallsService.groovy
+++ b/grails-app/services/io/xh/toolbox/app/RecallsService.groovy
@@ -6,7 +6,7 @@ import io.xh.hoist.json.JSON
 class RecallsService extends BaseService {
 
     def configService
-    def lastResponseCode;
+    def lastResponseCode
 
     List fetchRecalls(String searchQuery) {
 
@@ -27,7 +27,6 @@ class RecallsService extends BaseService {
                 return JSON.parse(inputStream, 'UTF-8').results
             }
         } catch (IOException e) {
-            //we got an exception, so our connection was not successful.
             lastResponseCode = null
             return []
         } finally {

--- a/src/main/groovy/io/xh/toolbox/portfolio/PortfolioDataSet.groovy
+++ b/src/main/groovy/io/xh/toolbox/portfolio/PortfolioDataSet.groovy
@@ -5,6 +5,7 @@ import java.time.LocalDate
 class PortfolioDataSet {
 
     LocalDate day
+    Date timeCreated = new Date()
 
     // Market Data
     // Map of symbol to instrument, marketPrices


### PR DESCRIPTION
Adds several new monitors to toolbox, including storage space used, presence of any "malicious files" (i.e. files with names containing .sh or .exe), status of connection to FDA website, and server memory usage.

Also corrects a few edge cases in the existing monitors where they could behave unexpectedly if the server has not yet fetched any news stories.

Implements new monitors per https://github.com/xh/toolbox/issues/244