### PR TITLE
Reduce news load

### DIFF
--- a/client-app/src/examples/news/App.js
+++ b/client-app/src/examples/news/App.js
@@ -6,6 +6,7 @@ import {ContextMenuItem as CM} from '@xh/hoist/desktop/cmp/contextmenu';
 import {newsPanel} from './NewsPanel';
 import {relativeTimestamp} from '@xh/hoist/cmp/relativetimestamp';
 import {AppModel} from './AppModel';
+import {a} from '@xh/hoist/cmp/layout';
 
 export const App = hoistCmp({
     displayName: 'App',
@@ -18,6 +19,12 @@ export const App = hoistCmp({
                 icon: Icon.news({size: '2x', prefix: 'fal'}),
                 title: 'News Feed',
                 hideRefreshButton: false,
+                leftItems: [
+                    a({
+                        item: 'powered by NewsAPI.org',
+                        href: 'https://newsapi.org/'
+                    })
+                ],
                 rightItems: [
                     relativeTimestamp({
                         model: model.newsPanelModel,

--- a/grails-app/init/io/xh/toolbox/BootStrap.groovy
+++ b/grails-app/init/io/xh/toolbox/BootStrap.groovy
@@ -72,11 +72,6 @@ class BootStrap {
                 defaultValue: 60,
                 groupName: 'Toolbox - Example Apps',
             ],
-            newsDelayMins: [
-                valueType: 'int',
-                defaultValue: 5,
-                groupName: 'Toolbox - Example Apps',
-            ],
             newsSources: [
                 valueType: 'json',
                 defaultValue: [

--- a/grails-app/init/io/xh/toolbox/BootStrap.groovy
+++ b/grails-app/init/io/xh/toolbox/BootStrap.groovy
@@ -72,6 +72,11 @@ class BootStrap {
                 defaultValue: 60,
                 groupName: 'Toolbox - Example Apps',
             ],
+            newsDelayMins: [
+                valueType: 'int',
+                defaultValue: 10,
+                groupName: 'Toolbox - Example Apps',
+            ],
             newsSources: [
                 valueType: 'json',
                 defaultValue: [

--- a/grails-app/init/io/xh/toolbox/BootStrap.groovy
+++ b/grails-app/init/io/xh/toolbox/BootStrap.groovy
@@ -74,7 +74,7 @@ class BootStrap {
             ],
             newsDelayMins: [
                 valueType: 'int',
-                defaultValue: 10,
+                defaultValue: 5,
                 groupName: 'Toolbox - Example Apps',
             ],
             newsSources: [

--- a/grails-app/services/io/xh/toolbox/app/NewsService.groovy
+++ b/grails-app/services/io/xh/toolbox/app/NewsService.groovy
@@ -19,7 +19,9 @@ class NewsService extends BaseService {
         createTimer(
                 runFn: this.&loadAllNews,
                 interval: 'newsRefreshMins',
-                intervalUnits: MINUTES
+                intervalUnits: MINUTES,
+                delay: 'newsRefreshMins',
+                delayUnits: MINUTES
         )
         super.init()
     }

--- a/grails-app/services/io/xh/toolbox/app/NewsService.groovy
+++ b/grails-app/services/io/xh/toolbox/app/NewsService.groovy
@@ -20,7 +20,7 @@ class NewsService extends BaseService {
                 runFn: this.&loadAllNews,
                 interval: 'newsRefreshMins',
                 intervalUnits: MINUTES,
-                delay: 'newsRefreshMins',
+                delay: 'newsDelayMins',
                 delayUnits: MINUTES
         )
         super.init()

--- a/grails-app/services/io/xh/toolbox/app/NewsService.groovy
+++ b/grails-app/services/io/xh/toolbox/app/NewsService.groovy
@@ -10,21 +10,21 @@ import static io.xh.hoist.util.DateTimeUtils.MINUTES
 
 class NewsService extends BaseService {
 
-    public List<NewsItem> _newsItems
+    private List<NewsItem> _newsItems
+    private Timer newsTimer
 
     static clearCachesConfigs = ['newsSources', 'newsApiKey']
     def configService
-    def timerStarted = false
 
     List<NewsItem> getNewsItems() {
-        if(!timerStarted) {
-            createTimer(
+        // to avoid hitting the API too frequently, we only start our timer when the NewsService is actually used.
+        if (!newsTimer) {
+            newsTimer = createTimer(
                     runFn: this.&loadAllNews,
                     interval: 'newsRefreshMins',
                     intervalUnits: MINUTES,
                     runImmediatelyAndBlock: true
             )
-            timerStarted = true;
         }
         return _newsItems ?  _newsItems : Collections.emptyList()
     }
@@ -38,7 +38,7 @@ class NewsService extends BaseService {
     }
 
     int getLoadedSourcesCount() {
-        return _newsItems.collect{it.source}.unique().size()
+        return newsItems.collect{it.source}.unique().size()
     }
 
     boolean getAllSourcesLoaded() {
@@ -46,8 +46,7 @@ class NewsService extends BaseService {
     }
 
     Date getLastTimestamp() {
-        if (!_newsItems) return null
-        return _newsItems.get(0).published
+        return newsItems ? newsItems[0].published : null
     }
 
 

--- a/grails-app/services/io/xh/toolbox/app/NewsService.groovy
+++ b/grails-app/services/io/xh/toolbox/app/NewsService.groovy
@@ -97,10 +97,7 @@ class NewsService extends BaseService {
             }
         }
 
-        def grouped = response.articles.groupBy{it.source.id}
-        grouped.each{ k, v ->
-            log.debug("Loaded ${v.size} news items from ${k}")
-        }
+        log.debug("Loaded ${articles.size()} news items.")
 
         return ret
     }

--- a/grails-app/services/io/xh/toolbox/app/NewsService.groovy
+++ b/grails-app/services/io/xh/toolbox/app/NewsService.groovy
@@ -14,19 +14,18 @@ class NewsService extends BaseService {
 
     static clearCachesConfigs = ['newsSources', 'newsApiKey']
     def configService
-
-    void init() {
-        createTimer(
-                runFn: this.&loadAllNews,
-                interval: 'newsRefreshMins',
-                intervalUnits: MINUTES,
-                delay: 'newsDelayMins',
-                delayUnits: MINUTES
-        )
-        super.init()
-    }
+    def timerStarted = false
 
     List<NewsItem> getNewsItems() {
+        if(!timerStarted) {
+            createTimer(
+                    runFn: this.&loadAllNews,
+                    interval: 'newsRefreshMins',
+                    intervalUnits: MINUTES,
+                    runImmediatelyAndBlock: true
+            )
+            timerStarted = true;
+        }
         return _newsItems ?  _newsItems : Collections.emptyList()
     }
 

--- a/grails-app/services/io/xh/toolbox/app/NewsService.groovy
+++ b/grails-app/services/io/xh/toolbox/app/NewsService.groovy
@@ -4,6 +4,7 @@ import io.xh.hoist.BaseService
 import io.xh.hoist.json.JSON
 import io.xh.toolbox.NewsItem
 import org.grails.web.json.JSONArray
+import io.xh.hoist.util.Timer
 
 import static io.xh.hoist.util.DateTimeUtils.MINUTES
 

--- a/grails-app/services/io/xh/toolbox/app/NewsService.groovy
+++ b/grails-app/services/io/xh/toolbox/app/NewsService.groovy
@@ -74,7 +74,7 @@ class NewsService extends BaseService {
             response = JSON.parse(url.openStream(), 'UTF-8')
 
         if (response.status != 'ok') {
-            log.error("Unable to fetch news! ${response.message}")
+            log.error("Unable to fetch news: ${response.message}")
             return Collections.emptyList()
         }
 
@@ -97,8 +97,8 @@ class NewsService extends BaseService {
         }
 
         def grouped = response.articles.groupBy{it.source.id}
-        for(sourceCode in grouped.keySet()) {
-            log.debug("Loaded ${grouped[sourceCode].size} news items from ${sourceCode}")
+        grouped.each{ k, v ->
+            log.debug("Loaded ${v.size} news items from ${k}")
         }
 
         return ret


### PR DESCRIPTION
This is meant to solve this issue:
https://github.com/xh/toolbox/issues/228

I reduce load on the NewsAPI two ways:

1. Use the v2 api to fetch from all sources with one request.
https://newsapi.org/docs/v2-migration#multiple-sources
2. ~~Add in a five-minute delay before we fetch news for the first time, which should reduce load from development machines where we frequently restart the server.~~
3. Make the NewsService start fetching lazily. It will still fetch news stories every hour, but it only starts fetching once someone actually accesses the NewsService (either by viewing the page or by running the monitors). This makes the startup delay irrelevant, so I removed the delay.