### PR TITLE
Examples usages of GridModel.ensureSelectionVisible()

### DIFF
--- a/client-app/src/admin/AppModel.js
+++ b/client-app/src/admin/AppModel.js
@@ -30,7 +30,7 @@ export class AppModel extends BaseAppModel {
                 path: '/tests',
                 children: [
                     {name: 'localDate', path: '/localDate'},
-                    {name: 'performance', path: '/performance'},
+                    {name: 'grid', path: '/grid'},
                     {name: 'cube', path: '/cube'},
                     {name: 'webSockets', path: '/webSockets'},
                     {name: 'panelResizing', path: '/panelResizing'},

--- a/client-app/src/admin/tests/TestsTab.js
+++ b/client-app/src/admin/tests/TestsTab.js
@@ -21,7 +21,7 @@ export const TestsTab = hoistCmp(
             route: 'default.tests',
             tabs: [
                 {id: 'localDate', title: 'LocalDate API', content: LocalDateTestPanel},
-                {id: 'performance', title: 'Grid Performance', content: GridTestPanel},
+                {id: 'grid', title: 'Grid', content: GridTestPanel},
                 {id: 'cube', title: 'Cube Data', content: CubeDataPanel},
                 {id: 'webSockets', title: 'WebSockets', content: WebSocketTestPanel},
                 {id: 'panelResizing', title: 'Panel Resizing', content: PanelResizingTestPanel},

--- a/client-app/src/admin/tests/grids/GridTestPanel.js
+++ b/client-app/src/admin/tests/grids/GridTestPanel.js
@@ -66,6 +66,11 @@ export const GridTestPanel = hoistCmp({
                     icon: Icon.skull(),
                     onClick: () => model.tearDown()
                 }),
+                button({
+                    text: 'Scroll to Selected',
+                    icon: Icon.crosshairs(),
+                    onClick: () => model.gridModel.ensureSelectionVisible()
+                }),
                 toolbarSep(),
                 tooltip({
                     content: '# records to randomly change',

--- a/client-app/src/desktop/common/SampleColumnGroupsGrid.js
+++ b/client-app/src/desktop/common/SampleColumnGroupsGrid.js
@@ -49,7 +49,7 @@ export const sampleColumnGroupsGrid = hoistCmp.factory({
                 colChooserButton(),
                 exportButton(),
                 button({
-                    onClick: () => {model.gridModel.scrollToSelected()},
+                    onClick: () => {model.gridModel.ensureSelectionVisible()},
                     icon: Icon.crosshairs(),
                     title: 'Scroll to selected row'
                 })

--- a/client-app/src/desktop/common/SampleColumnGroupsGrid.js
+++ b/client-app/src/desktop/common/SampleColumnGroupsGrid.js
@@ -7,7 +7,7 @@
 import {boolCheckCol, emptyFlexCol, grid, gridCountLabel, GridModel} from '@xh/hoist/cmp/grid';
 import {filler, hframe} from '@xh/hoist/cmp/layout';
 import {creates, hoistCmp, HoistModel, LoadSupport, managed, XH} from '@xh/hoist/core';
-import {colChooserButton, exportButton, refreshButton} from '@xh/hoist/desktop/cmp/button';
+import {button, colChooserButton, exportButton, refreshButton} from '@xh/hoist/desktop/cmp/button';
 import {StoreContextMenu} from '@xh/hoist/desktop/cmp/contextmenu';
 import {switchInput} from '@xh/hoist/desktop/cmp/input';
 import {panel} from '@xh/hoist/desktop/cmp/panel';
@@ -47,7 +47,12 @@ export const sampleColumnGroupsGrid = hoistCmp.factory({
                 gridCountLabel(),
                 storeFilterField(),
                 colChooserButton(),
-                exportButton()
+                exportButton(),
+                button({
+                    onClick: () => {model.gridModel.scrollToSelected()},
+                    icon: Icon.crosshairs(),
+                    title: 'Scroll to selected row'
+                })
             ],
             ...props
         });

--- a/client-app/src/desktop/common/SampleGrid.js
+++ b/client-app/src/desktop/common/SampleGrid.js
@@ -74,7 +74,7 @@ export const [SampleGrid, sampleGrid] = hoistCmp.withFactory({
                 colChooserButton(),
                 exportButton(),
                 button({
-                    onClick: () => {model.gridModel.scrollToSelected()},
+                    onClick: () => {model.gridModel.ensureSelectionVisible()},
                     icon: Icon.crosshairs(),
                     title: 'Scroll to selected row'
                 })

--- a/client-app/src/desktop/common/SampleGrid.js
+++ b/client-app/src/desktop/common/SampleGrid.js
@@ -1,7 +1,7 @@
 import {grid, gridCountLabel} from '@xh/hoist/cmp/grid';
 import {filler, hbox, hframe, span, vframe} from '@xh/hoist/cmp/layout';
 import {hoistCmp, uses} from '@xh/hoist/core';
-import {colChooserButton, exportButton, refreshButton} from '@xh/hoist/desktop/cmp/button';
+import {button, colChooserButton, exportButton, refreshButton} from '@xh/hoist/desktop/cmp/button';
 import {select} from '@xh/hoist/desktop/cmp/input';
 import {panel} from '@xh/hoist/desktop/cmp/panel';
 import {storeFilterField} from '@xh/hoist/cmp/store';
@@ -72,7 +72,12 @@ export const [SampleGrid, sampleGrid] = hoistCmp.withFactory({
                 gridCountLabel({unit: 'companies'}),
                 storeFilterField(),
                 colChooserButton(),
-                exportButton()
+                exportButton(),
+                button({
+                    onClick: () => {model.gridModel.scrollToSelected()},
+                    icon: Icon.crosshairs(),
+                    title: 'Scroll to selected row'
+                })
             ]
         });
     }

--- a/client-app/src/desktop/common/SampleTreeGrid.js
+++ b/client-app/src/desktop/common/SampleTreeGrid.js
@@ -7,7 +7,7 @@
 import {grid, gridCountLabel} from '@xh/hoist/cmp/grid';
 import {filler, hframe} from '@xh/hoist/cmp/layout';
 import {hoistCmp, uses} from '@xh/hoist/core';
-import {colChooserButton, exportButton, refreshButton} from '@xh/hoist/desktop/cmp/button';
+import {button, colChooserButton, exportButton, refreshButton} from '@xh/hoist/desktop/cmp/button';
 import {dimensionChooser} from '@xh/hoist/desktop/cmp/dimensionchooser';
 import {select, switchInput} from '@xh/hoist/desktop/cmp/input';
 import {panel} from '@xh/hoist/desktop/cmp/panel';
@@ -17,6 +17,7 @@ import {toolbarSep} from '@xh/hoist/desktop/cmp/toolbar';
 import {SampleTreeGridModel} from './SampleTreeGridModel';
 
 import {gridStyleSwitches} from './GridStyleSwitches';
+import {Icon} from '@xh/hoist/icon/Icon';
 
 export const [SampleTreeGrid, sampleTreeGrid] = hoistCmp.withFactory({
 
@@ -34,7 +35,12 @@ export const [SampleTreeGrid, sampleTreeGrid] = hoistCmp.withFactory({
                 gridCountLabel({includeChildren: true}),
                 storeFilterField({filterOptions: {includeChildren: model.filterIncludeChildren}}),
                 colChooserButton(),
-                exportButton()
+                exportButton(),
+                button({
+                    onClick: () => {model.gridModel.scrollToSelected()},
+                    icon: Icon.crosshairs(),
+                    title: 'Scroll to selected row'
+                })
             ],
             mask: 'onLoad',
             bbar: [

--- a/client-app/src/desktop/common/SampleTreeGrid.js
+++ b/client-app/src/desktop/common/SampleTreeGrid.js
@@ -37,7 +37,7 @@ export const [SampleTreeGrid, sampleTreeGrid] = hoistCmp.withFactory({
                 colChooserButton(),
                 exportButton(),
                 button({
-                    onClick: () => {model.gridModel.scrollToSelected()},
+                    onClick: () => {model.gridModel.ensureSelectionVisible()},
                     icon: Icon.crosshairs(),
                     title: 'Scroll to selected row'
                 })

--- a/client-app/src/desktop/tabs/grids/DataViewPanel.js
+++ b/client-app/src/desktop/tabs/grids/DataViewPanel.js
@@ -3,7 +3,7 @@ import {hoistCmp, HoistModel, LoadSupport, managed, XH, creates} from '@xh/hoist
 import {Icon} from '@xh/hoist/icon';
 import {filler} from '@xh/hoist/cmp/layout';
 import {panel} from '@xh/hoist/desktop/cmp/panel';
-import {refreshButton} from '@xh/hoist/desktop/cmp/button';
+import {button, refreshButton} from '@xh/hoist/desktop/cmp/button';
 import {storeFilterField} from '@xh/hoist/cmp/store';
 import {dataView, DataViewModel} from '@xh/hoist/cmp/dataview';
 
@@ -40,6 +40,11 @@ export const DataViewPanel = hoistCmp({
                         model
                     }),
                     filler(),
+                    button({
+                        onClick: () => {model.dataViewModel.gridModel.scrollToSelected()},
+                        icon: Icon.crosshairs(),
+                        title: 'Scroll to selected row'
+                    }),
                     storeFilterField({store: model.dataViewModel.store})
                 ]
             })

--- a/client-app/src/desktop/tabs/grids/DataViewPanel.js
+++ b/client-app/src/desktop/tabs/grids/DataViewPanel.js
@@ -41,7 +41,7 @@ export const DataViewPanel = hoistCmp({
                     }),
                     filler(),
                     button({
-                        onClick: () => {model.dataViewModel.gridModel.scrollToSelected()},
+                        onClick: () => {model.dataViewModel.gridModel.ensureSelectionVisible()},
                         icon: Icon.crosshairs(),
                         title: 'Scroll to selected row'
                     }),

--- a/client-app/src/desktop/tabs/grids/RestGridPanel.js
+++ b/client-app/src/desktop/tabs/grids/RestGridPanel.js
@@ -22,7 +22,7 @@ import {useLocalModel} from '@xh/hoist/core/hooks';
 export const RestGridPanel = hoistCmp({
 
     render() {
-        const model = useLocalModel(() => new RestGridModel(modelSpec));
+        const restGridModel = useLocalModel(() => new RestGridModel(modelSpec));
         return wrapper({
             description: [
                 <p>
@@ -41,10 +41,10 @@ export const RestGridPanel = hoistCmp({
                 icon: Icon.edit(),
                 className: 'tb-grid-wrapper-panel',
                 item: restGrid({
-                    model: model,
+                    model: restGridModel,
                     extraToolbarItems: [
                         button({
-                            onClick: () => {model.gridModel.scrollToSelected()},
+                            onClick: () => {restGridModel.gridModel.scrollToSelected()},
                             icon: Icon.crosshairs(),
                             title: 'Scroll to selected row'
                         })

--- a/client-app/src/desktop/tabs/grids/RestGridPanel.js
+++ b/client-app/src/desktop/tabs/grids/RestGridPanel.js
@@ -3,15 +3,26 @@ import {hoistCmp} from '@xh/hoist/core';
 import {panel} from '@xh/hoist/desktop/cmp/panel';
 import {dateRenderer} from '@xh/hoist/format';
 import {Icon} from '@xh/hoist/icon';
-import {restGrid, addAction, editAction, viewAction, deleteAction, cloneAction} from '@xh/hoist/desktop/cmp/rest';
+import {
+    restGrid,
+    addAction,
+    editAction,
+    viewAction,
+    deleteAction,
+    cloneAction,
+    RestGridModel
+} from '@xh/hoist/desktop/cmp/rest';
 import {boolCheckCol, numberCol, emptyFlexCol} from '@xh/hoist/cmp/grid';
 import {wrapper} from '../../common/Wrapper';
 import {numberInput, textArea, switchInput} from '@xh/hoist/desktop/cmp/input';
 import {ExportFormat} from '@xh/hoist/cmp/grid/columns';
+import {button} from '@xh/hoist/desktop/cmp/button';
+import {useLocalModel} from '@xh/hoist/core/hooks';
 
 export const RestGridPanel = hoistCmp({
 
     render() {
+        const model = useLocalModel(() => new RestGridModel(modelSpec));
         return wrapper({
             description: [
                 <p>
@@ -29,7 +40,16 @@ export const RestGridPanel = hoistCmp({
                 title: 'Grids › REST Editor',
                 icon: Icon.edit(),
                 className: 'tb-grid-wrapper-panel',
-                item: restGrid({model: modelSpec})
+                item: restGrid({
+                    model: model,
+                    extraToolbarItems: [
+                        button({
+                            onClick: () => {model.gridModel.scrollToSelected()},
+                            icon: Icon.crosshairs(),
+                            title: 'Scroll to selected row'
+                        })
+                    ]
+                })
             })
         });
     }

--- a/client-app/src/desktop/tabs/grids/RestGridPanel.js
+++ b/client-app/src/desktop/tabs/grids/RestGridPanel.js
@@ -44,7 +44,7 @@ export const RestGridPanel = hoistCmp({
                     model: restGridModel,
                     extraToolbarItems: [
                         button({
-                            onClick: () => {restGridModel.gridModel.scrollToSelected()},
+                            onClick: () => {restGridModel.gridModel.ensureSelectionVisible()},
                             icon: Icon.crosshairs(),
                             title: 'Scroll to selected row'
                         })

--- a/client-app/src/desktop/tabs/inputs/tabs/TimeInputPanel.js
+++ b/client-app/src/desktop/tabs/inputs/tabs/TimeInputPanel.js
@@ -1,0 +1,70 @@
+import {useLocalModel} from '@xh/hoist/core/hooks';
+import {InputTestModel} from '../InputTestModel';
+import {PropTypes as T} from 'react-view';
+import {TimeInput} from '@xh/hoist/desktop/cmp/input';
+import {Icon} from '@xh/hoist/icon';
+import {hoistCmp} from '@xh/hoist/core';
+import {inputTestPanel} from '../InputTestPanel';
+
+export const TimeInputPanel = hoistCmp({
+
+    render() {
+        const model = useLocalModel(createModel);
+        return inputTestPanel({model});
+    }
+});
+
+function createModel() {
+    return new InputTestModel({
+        description:
+            [
+            ],
+        componentName: 'TimeInput',
+        props: {
+            /** Initial time the TimePicker will display. This should not be set if value is set. */
+            defaultValue: {value: null, type: T.Date},
+
+            /**
+             * The latest time the user can select. The year, month, and day parts of the Date object
+             * are ignored. While the maxTime will be later than the minTime in the basic case, it is
+             * also allowed to be earlier than the minTime. This is useful, for example, to express a
+             * time range that extends before and after midnight. If the maxTime and minTime are equal,
+             * then the valid time range is constrained to only that one value.
+             */
+            maxTime: {value: null, type: T.Date},
+
+            /**
+             * The earliest time the user can select. The year, month, and day parts of the Date object
+             * are ignored. While the minTime will be earlier than the maxTime in the basic case, it
+             * is also allowed to be later than the maxTime. This is useful, for example, to express
+             * a time range that extends before and after midnight. If the maxTime and minTime are
+             * equal, then the valid time range is constrained to only that one value.
+             */
+            mintime: {value: null, type: T.Date},
+
+            /** Whether all the text in each input should be selected on focus. */
+            selectOnFocus: {value: false, type: T.Boolean},
+
+            /** Whether to show arrows buttons for changing the time. */
+            showArrowButtons: {value: false, type: T.Boolean},
+
+            precision: {
+                value: 'precisions.MINUTE',
+                type: T.Enum,
+                enumName: 'precisions',
+                options: precisions
+            }
+        },
+        scope: {
+            TimeInput,
+            Icon,
+            precisions
+        }
+    });
+}
+
+const precisions = {
+    MILLISECOND: 'MILLISECOND',
+    MINUTE: 'MINUTE',
+    SECOND: 'SECOND'
+};


### PR DESCRIPTION
Adds a scroll button to the existing Grid Performance test page.

Also renames the Grid Performance tab to just Grid, since it relates to more than just performance.