### PR TITLE
Switch idSpec

### DIFF
--- a/client-app/src/examples/news/NewsPanelModel.js
+++ b/client-app/src/examples/news/NewsPanelModel.js
@@ -16,7 +16,7 @@ export class NewsPanelModel {
         sortBy: 'published',
         store: {
             fields: ['title', 'source', 'text', 'url', 'imageUrl', 'author', 'published'],
-            idSpec: 'url',
+            idSpec: XH.genId,
             filter: (rec) => {
                 const {textFilter, sourceFilter} = this,
                     searchMatch = !textFilter || textFilter.fn(rec),


### PR DESCRIPTION
Use XH.genId to ensure all news items will have a unique ID