### PR TITLE
Remove duplicate updates

### DIFF
--- a/client-app/src/desktop/common/grid/SampleTreeGridModel.js
+++ b/client-app/src/desktop/common/grid/SampleTreeGridModel.js
@@ -189,7 +189,7 @@ export class SampleTreeGridModel {
             ];
 
         store.modifyRecords(updates);
-        rec.forEachAncestor(it => store.modifyRecords(it, {isChecked: calcAggState(it)}));
+        rec.forEachAncestor(it => store.modifyRecords({id: it.id, isChecked: calcAggState(it)}));
     }
 }
 

--- a/client-app/src/desktop/common/grid/SampleTreeGridModel.js
+++ b/client-app/src/desktop/common/grid/SampleTreeGridModel.js
@@ -185,7 +185,6 @@ export class SampleTreeGridModel {
         const {store} = this,
             isChecked = !rec.data.isChecked,
             updates = [
-                {id: rec.id, isChecked},
                 ...rec.allDescendants.map(({id}) => ({id, isChecked}))
             ];
 


### PR DESCRIPTION
`allDescendants` already includes the parent. Therefore, we do not need to explicitly update `rec`; updating `allDescendants` will catch `rec` at the same time.

We also made an incorrect call to modifyRecords. It expects to receive an object with the ID to upgrade.