### PR TITLE
Roadmap fixes

### DIFF
--- a/client-app/src/admin/AppModel.js
+++ b/client-app/src/admin/AppModel.js
@@ -30,8 +30,8 @@ export class AppModel extends BaseAppModel {
                 name: 'roadmap',
                 path: '/roadmap',
                 children: [
-                    {name: 'project', path: '/project'},
-                    {name: 'phase', path: '/phase'}
+                    {name: 'projects', path: '/projects'},
+                    {name: 'phases', path: '/phases'}
                 ]
             },
             {

--- a/client-app/src/admin/AppModel.js
+++ b/client-app/src/admin/AppModel.js
@@ -27,6 +27,14 @@ export class AppModel extends BaseAppModel {
         return [
             ...super.getTabRoutes(),
             {
+                name: 'roadmap',
+                path: '/roadmap',
+                children: [
+                    {name: 'project', path: '/project'},
+                    {name: 'phase', path: '/phase'}
+                ]
+            },
+            {
                 name: 'tests',
                 path: '/tests',
                 children: [
@@ -44,14 +52,6 @@ export class AppModel extends BaseAppModel {
             {
                 name: 'wip',
                 path: '/wip'
-            },
-            {
-                name: 'roadmap',
-                path: '/roadmap',
-                children: [
-                    {name: 'project', path: '/project'},
-                    {name: 'phase', path: '/phase'}
-                ]
             }
         ];
     }
@@ -59,9 +59,9 @@ export class AppModel extends BaseAppModel {
     createTabs() {
         return [
             ...super.createTabs(),
+            {id: 'roadmap', title: 'Roadmap', icon: Icon.mapSigns(), content: roadmapTab},
             {id: 'tests', icon: Icon.stopwatch(), content: TestsTab},
-            {id: 'wip', title: 'WIP', icon: Icon.experiment(), content: WipTab},
-            {id: 'roadmap', title: 'Roadmap', icon: Icon.mapSigns(), content: roadmapTab}
+            {id: 'wip', title: 'WIP', icon: Icon.experiment(), content: WipTab}
         ];
     }
 }

--- a/client-app/src/admin/roadmap/PhaseRestPanel.js
+++ b/client-app/src/admin/roadmap/PhaseRestPanel.js
@@ -1,6 +1,5 @@
 import {panel} from '@xh/hoist/desktop/cmp/panel';
 import {addAction, cloneAction, deleteAction, editAction, restGrid, viewAction} from '@xh/hoist/desktop/cmp/rest';
-import {emptyFlexCol} from '@xh/hoist/cmp/grid';
 import {hoistCmp} from '@xh/hoist/core';
 import {boolCheckCol} from '@xh/hoist/cmp/grid/columns';
 
@@ -47,11 +46,11 @@ const modelSpec = {
     filterFields: ['name', 'sortOrder'],
     sortBy: 'sortOrder',
     columns: [
-
         {
             field: 'sortOrder',
-            width: 120,
-            align: 'center'
+            headerName: 'Sort',
+            align: 'right',
+            width: 80
         },
         {
             field: 'name',
@@ -61,14 +60,13 @@ const modelSpec = {
             field: 'displayed',
             headerName: 'Display?',
             ...boolCheckCol,
-            width: 150
+            width: 100
         },
         {
             field: 'projectNames',
             headerName: 'Projects',
-            width: 400
-        },
-        {...emptyFlexCol}
+            flex: 1
+        }
     ],
     editors: [
         {field: 'name', label: 'Name'},

--- a/client-app/src/admin/roadmap/ProjectRestPanel.js
+++ b/client-app/src/admin/roadmap/ProjectRestPanel.js
@@ -76,6 +76,7 @@ const modelSpec = {
     unit: 'project',
     filterFields: ['name', 'status', 'category'],
     sortBy: 'sortOrder',
+    groupBy: 'phaseName',
     columns: [
         {
             field: 'sortOrder',
@@ -133,10 +134,12 @@ const modelSpec = {
         {field: 'sortOrder'},
         {field: 'description',
             formField: {
-                item: textArea()
+                item: textArea({
+                    height: 150
+                })
             }},
         {field: 'gitLinks',
-            label: 'Github Links as Text Separated by Commas',
+            label: 'Github Links (Enter One Per New Line, As Text Not String)',
             formField: {
                 item: codeInput()
             }

--- a/client-app/src/admin/roadmap/ProjectRestPanel.js
+++ b/client-app/src/admin/roadmap/ProjectRestPanel.js
@@ -1,7 +1,6 @@
 import {panel} from '@xh/hoist/desktop/cmp/panel';
 import {addAction, cloneAction, deleteAction, editAction, restGrid, viewAction} from '@xh/hoist/desktop/cmp/rest';
 import {dateTimeRenderer} from '@xh/hoist/format';
-import {emptyFlexCol} from '@xh/hoist/cmp/grid';
 import {codeInput, textArea} from '@xh/hoist/desktop/cmp/input';
 import {hoistCmp} from '@xh/hoist/core';
 
@@ -80,51 +79,51 @@ const modelSpec = {
     columns: [
         {
             field: 'sortOrder',
-            width: 100
+            headerName: 'Sort',
+            align: 'right',
+            width: 80
         },
         {
             field: 'category',
-            width: 100
+            width: 150
         },
         {
             field: 'name',
             headerName: 'Title',
             tooltip,
-            width: 200
+            width: 300
         },
         {
             field: 'description',
             tooltip,
-            width: 300
+            flex: 1
         },
         {
             field: 'phaseName',
-            width: 100
+            width: 100,
+            hidden: true
         },
         {
             field: 'releaseVersion',
             headerName: 'Release',
             tooltip,
-            width: 100
+            width: 150
         },
         {
             field: 'status',
-            width: 100
+            width: 150
         },
         {
             field: 'lastUpdated',
-            headerName: 'Last Updated',
             renderer: dateTimeRenderer(),
-            width: 200,
+            width: 150,
             tooltip,
             align: 'right'
         },
         {
             field: 'lastUpdatedBy',
-            headerName: 'By:',
-            width: 100
-        },
-        {...emptyFlexCol}
+            width: 150
+        }
     ],
     editors: [
         {field: 'name', label: 'Title'},
@@ -132,17 +131,16 @@ const modelSpec = {
         {field: 'phaseName'},
         {field: 'status'},
         {field: 'sortOrder'},
-        {field: 'description',
+        {
+            field: 'description',
             formField: {
-                item: textArea({
-                    height: 150
-                })
-            }},
-        {field: 'gitLinks',
-            label: 'Github Links (Enter One Per New Line, As Text Not String)',
-            formField: {
-                item: codeInput()
+                item: textArea({height: 150})
             }
+        },
+        {
+            field: 'gitLinks',
+            label: 'Github Links (one per line)',
+            formField: {item: codeInput()}
         },
         {field: 'releaseVersion'},
         {field: 'lastUpdated', label: 'Last Updated'},

--- a/client-app/src/admin/roadmap/RoadmapTab.js
+++ b/client-app/src/admin/roadmap/RoadmapTab.js
@@ -7,6 +7,7 @@
 
 import {hoistCmp} from '@xh/hoist/core';
 import {tabContainer} from '@xh/hoist/cmp/tab';
+import {Icon} from '@xh/hoist/icon/Icon';
 import {projectRestPanel} from './ProjectRestPanel';
 import {phaseRestPanel} from './PhaseRestPanel';
 
@@ -16,8 +17,8 @@ export const roadmapTab = hoistCmp(
         model: {
             route: 'default.roadmap',
             tabs: [
-                {id: 'project', title: 'Projects', content: projectRestPanel},
-                {id: 'phase', title: 'Phases', content: phaseRestPanel}
+                {id: 'projects', icon: Icon.checkCircle(), content: projectRestPanel},
+                {id: 'phases', icon: Icon.calendar(), content: phaseRestPanel}
             ],
             switcherPosition: 'left'
         }

--- a/client-app/src/desktop/tabs/home/HomeTab.scss
+++ b/client-app/src/desktop/tabs/home/HomeTab.scss
@@ -6,7 +6,7 @@
 }
 
 .tb-welcome {
-  width: 625px;
+  width: 575px;
   height: 525px;
 
   &__logo {

--- a/client-app/src/desktop/tabs/home/HomeTab.scss
+++ b/client-app/src/desktop/tabs/home/HomeTab.scss
@@ -1,4 +1,7 @@
 .tb-home {
+  width: 100%;
+  justify-content: center;
+
   > .xh-panel {
     border: var(--xh-border-solid);
     margin: var(--xh-pad-double-px);
@@ -6,7 +9,8 @@
 }
 
 .tb-welcome {
-  width: 575px;
+  flex: 1;
+  max-width: 575px;
   height: 525px;
 
   &__logo {

--- a/client-app/src/desktop/tabs/home/roadmap/RoadmapModel.js
+++ b/client-app/src/desktop/tabs/home/roadmap/RoadmapModel.js
@@ -1,9 +1,9 @@
 import {HoistModel, LoadSupport, managed, XH} from '@xh/hoist/core';
 import {bindable} from '@xh/hoist/mobx';
 import {DataViewModel} from '@xh/hoist/cmp/dataview';
-import {roadmapGroupRow} from './RoadmapView';
 import {roadmapViewItem} from './RoadmapViewItem';
 import './RoadmapView.scss';
+import {convertIconToSvg, Icon} from '@xh/hoist/icon';
 
 @HoistModel
 @LoadSupport
@@ -25,7 +25,17 @@ export class RoadmapModel {
         sortBy: 'sortOrder',
         groupBy: 'sortedPhase',
         groupRowHeight: 32,
-        groupRowElementRenderer: ({node}) => roadmapGroupRow({node}),
+        groupSortFn: (a, b) => {
+            if (this.statusFilter === 'showUpcoming') {
+                return a >= b ? 1 : -1;
+            } else {
+                return a >= b ? -1 : 1;
+            }
+        },
+        groupRowRenderer: ({node}) => {
+            const projectRec = node.allLeafChildren[0].data;
+            return convertIconToSvg(Icon.calendar()) + ' ' + projectRec.data.phaseName;
+        },
         emptyText: 'No projects found...',
         selModel: 'disabled',
         rowBorders: true,
@@ -55,7 +65,7 @@ export class RoadmapModel {
         const showReleased = this.statusFilter === 'showReleased';
         const projects = rawData.flatMap(phase => {
             return phase.projects.map(project => {
-                return {...project, sortedPhase: showReleased ? 1000 - phase.sortOrder : phase.sortOrder};
+                return {...project, sortedPhase: phase.sortOrder};
             });
         });
 

--- a/client-app/src/desktop/tabs/home/roadmap/RoadmapModel.js
+++ b/client-app/src/desktop/tabs/home/roadmap/RoadmapModel.js
@@ -35,14 +35,7 @@ export class RoadmapModel {
     constructor() {
         this.addReaction({
             track: () => this.statusFilter,
-            run: (filter) => this.dataViewModel.store.setFilter(
-                (record) => {
-                    const {status} = record.data,
-                        showReleased = filter === 'showReleased';
-                    return showReleased ? status === 'RELEASED' : status !== 'RELEASED';
-                }
-            ),
-            fireImmediately: true
+            run: () => this.loadAsync()
         });
 
     }
@@ -59,10 +52,16 @@ export class RoadmapModel {
     }
 
     processData(rawData) {
-        return rawData.flatMap(phase => {
+        const showReleased = this.statusFilter === 'showReleased';
+        const projects = rawData.flatMap(phase => {
             return phase.projects.map(project => {
-                return {...project, sortedPhase: phase.sortOrder + '_' + phase.name};
+                return {...project, sortedPhase: showReleased ? 1000 - phase.sortOrder : phase.sortOrder};
             });
+        });
+
+        return projects.filter(project => {
+            const {status} = project;
+            return showReleased ? status === 'RELEASED' : status !== 'RELEASED';
         });
     }
 }

--- a/client-app/src/desktop/tabs/home/roadmap/RoadmapView.js
+++ b/client-app/src/desktop/tabs/home/roadmap/RoadmapView.js
@@ -1,5 +1,5 @@
 import {dataView} from '@xh/hoist/cmp/dataview';
-import {filler, hbox} from '@xh/hoist/cmp/layout';
+import {filler} from '@xh/hoist/cmp/layout';
 import {storeFilterField} from '@xh/hoist/cmp/store';
 import {creates, hoistCmp} from '@xh/hoist/core';
 import {button} from '@xh/hoist/desktop/cmp/button';
@@ -47,21 +47,4 @@ const bbar = hoistCmp.factory(
         filler(),
         storeFilterField({store: model.dataViewModel.store})
     )
-);
-
-// Custom group renderer
-export const roadmapGroupRow = hoistCmp.factory(
-    ({node}) => {
-        const projectRec = node.allLeafChildren[0].data;
-        return hbox(
-            {
-                className: 'roadmap-group-row',
-                onClick: () => node.setExpanded(!node.expanded),
-                items: [
-                    Icon.calendar({className: 'xh-white', prefix: 'fal'}),
-                    projectRec.data.phaseName
-                ]
-            }
-        );
-    }
 );

--- a/client-app/src/desktop/tabs/home/roadmap/RoadmapView.scss
+++ b/client-app/src/desktop/tabs/home/roadmap/RoadmapView.scss
@@ -36,7 +36,9 @@
       > span {
         color: var(--xh-blue-gray);
         background-color: var(--xh-blue-gray-light);
+        border: var(--xh-border-solid);
         border-radius: calc(var(--xh-border-radius) * 1px);
+        padding: 0 4px;
       }
     }
 
@@ -45,6 +47,10 @@
       opacity: 0.8;
       font-size: var(--xh-font-size-small-px);
     }
+  }
+
+  .ag-group-child-count {
+    display: none;
   }
 }
 

--- a/client-app/src/desktop/tabs/home/roadmap/RoadmapView.scss
+++ b/client-app/src/desktop/tabs/home/roadmap/RoadmapView.scss
@@ -48,15 +48,6 @@
   }
 }
 
-.roadmap-group-row {
-  width: 100%;  // ensure entire group row surface takes click handler
-  align-items: center;
-
-  svg {
-    margin: 0 var(--xh-pad-half-px) 0 var(--xh-pad-px);
-  }
-}
-
 .tb-roadmap__popover {
   background-color: var(--xh-bg-alt);
   padding: var(--xh-pad-half-px);

--- a/client-app/src/desktop/tabs/home/roadmap/RoadmapView.scss
+++ b/client-app/src/desktop/tabs/home/roadmap/RoadmapView.scss
@@ -15,7 +15,6 @@
       font-size: var(--xh-font-size-large-px);
       font-weight: bold;
       margin: auto 0;
-      white-space: nowrap;
 
       svg {
         margin-right: var(--xh-pad-px);

--- a/client-app/src/desktop/tabs/home/roadmap/RoadmapView.scss
+++ b/client-app/src/desktop/tabs/home/roadmap/RoadmapView.scss
@@ -1,5 +1,5 @@
 .tb-roadmap {
-  width: 475px;
+  width: 650px;
   height: 525px;
 
   .tb-roadmap-item {
@@ -15,6 +15,7 @@
       font-size: var(--xh-font-size-large-px);
       font-weight: bold;
       margin: auto 0;
+      white-space: nowrap;
 
       svg {
         margin-right: var(--xh-pad-px);

--- a/client-app/src/desktop/tabs/home/roadmap/RoadmapView.scss
+++ b/client-app/src/desktop/tabs/home/roadmap/RoadmapView.scss
@@ -1,6 +1,12 @@
 .tb-roadmap {
-  width: 650px;
+  flex: 1;
+  max-width: 650px;
   height: 525px;
+
+  // Group header calendar icons
+  .ag-group-value svg {
+    margin-right: 4px;
+  }
 
   .tb-roadmap-item {
     flex: 1;

--- a/client-app/src/desktop/tabs/home/roadmap/RoadmapView.scss
+++ b/client-app/src/desktop/tabs/home/roadmap/RoadmapView.scss
@@ -33,6 +33,12 @@
       min-height: 0;
       margin: 0 0 var(--xh-pad-px) 0;
       overflow: hidden;
+
+      > span {
+        color: var(--xh-blue-gray);
+        background-color: var(--xh-blue-gray-light);
+        border-radius: calc(var(--xh-border-radius) * 1px);
+      }
     }
 
     &__footer {

--- a/client-app/src/desktop/tabs/home/roadmap/RoadmapView.scss
+++ b/client-app/src/desktop/tabs/home/roadmap/RoadmapView.scss
@@ -66,6 +66,6 @@
   }
 
   &--description {
-    max-width: 300px;
+    max-width: 400px;
   }
 }

--- a/client-app/src/desktop/tabs/home/roadmap/RoadmapViewItem.js
+++ b/client-app/src/desktop/tabs/home/roadmap/RoadmapViewItem.js
@@ -1,7 +1,7 @@
 import {library} from '@fortawesome/fontawesome-svg-core';
 import {fab} from '@fortawesome/free-brands-svg-icons';
 import {faCodeMerge} from '@fortawesome/pro-regular-svg-icons';
-import {div, filler, span} from '@xh/hoist/cmp/layout';
+import {br, div, filler, span} from '@xh/hoist/cmp/layout';
 import {hbox, vbox} from '@xh/hoist/cmp/layout/index';
 import {relativeTimestamp} from '@xh/hoist/cmp/relativetimestamp';
 import {hoistCmp, XH} from '@xh/hoist/core/index';
@@ -64,7 +64,9 @@ export const roadmapViewItem = hoistCmp.factory({
                             interactionKind: 'hover',
                             position: 'left-top',
                             target: span(' [...]'),
-                            content: description
+                            content: div({
+                                items: breakUpDescription(description)
+                            })
                         })
                     ]
                 }),
@@ -111,4 +113,12 @@ function getGitMenuItems(gitLinks) {
             onClick: () => window.open(link)
         });
     });
+}
+
+function breakUpDescription(description) {
+    return description.split('\n')
+        .reduce((ret, newLine) => {
+            ret.push(span(newLine), br());
+            return ret;
+        }, []);
 }

--- a/client-app/src/desktop/tabs/home/roadmap/RoadmapViewItem.js
+++ b/client-app/src/desktop/tabs/home/roadmap/RoadmapViewItem.js
@@ -58,8 +58,8 @@ export const roadmapViewItem = hoistCmp.factory({
                 span({
                     className: 'tb-roadmap-item__description',
                     items: [
-                        truncate(description, {length: 230, omission: ' '}),
-                        description.length > 230 ? popover({
+                        truncate(description, {length: 255, omission: ' '}),
+                        description.length > 255 ? popover({
                             popoverClassName: 'tb-roadmap__popover tb-roadmap__popover--description',
                             minimal: true,
                             interactionKind: 'hover',

--- a/client-app/src/desktop/tabs/home/roadmap/RoadmapViewItem.js
+++ b/client-app/src/desktop/tabs/home/roadmap/RoadmapViewItem.js
@@ -26,7 +26,16 @@ export const roadmapViewItem = hoistCmp.factory({
                 hbox(
                     div({
                         className: 'tb-roadmap-item__title',
-                        items: [getCategoryIcon(category), name]
+                        items: [
+                            getCategoryIcon(category),
+                            name.length > 55 ?
+                                popover({
+                                    popoverClassName: 'tb-roadmap__popover',
+                                    minimal: true,
+                                    target: truncate(name, {length: 55, omission: ' ...'}),
+                                    content: name
+                                }) : name
+                        ]
                     }),
                     filler(),
                     popover({

--- a/client-app/src/desktop/tabs/home/roadmap/RoadmapViewItem.js
+++ b/client-app/src/desktop/tabs/home/roadmap/RoadmapViewItem.js
@@ -1,7 +1,7 @@
 import {library} from '@fortawesome/fontawesome-svg-core';
 import {fab} from '@fortawesome/free-brands-svg-icons';
 import {faCodeMerge} from '@fortawesome/pro-regular-svg-icons';
-import {div, filler} from '@xh/hoist/cmp/layout';
+import {div, filler, span} from '@xh/hoist/cmp/layout';
 import {hbox, vbox} from '@xh/hoist/cmp/layout/index';
 import {relativeTimestamp} from '@xh/hoist/cmp/relativetimestamp';
 import {hoistCmp, XH} from '@xh/hoist/core/index';
@@ -46,14 +46,18 @@ export const roadmapViewItem = hoistCmp.factory({
                         content: capitalizeWords(status)
                     })
                 ),
-                popover({
+                span({
                     className: 'tb-roadmap-item__description',
-                    popoverClassName: 'tb-roadmap__popover tb-roadmap__popover--description',
-                    minimal: true,
-                    interactionKind: 'hover',
-                    position: 'left-top',
-                    target: truncate(description, {length: 230, omission: ' [...]'}),
-                    content: description
+                    items: [truncate(description, {length: 230, omission: ' '}),
+                        popover({
+                            popoverClassName: 'tb-roadmap__popover tb-roadmap__popover--description',
+                            minimal: true,
+                            interactionKind: 'hover',
+                            position: 'left-top',
+                            target: span(' [...]'),
+                            content: description
+                        })
+                    ]
                 }),
                 hbox({
                     className: 'tb-roadmap-item__footer',

--- a/client-app/src/desktop/tabs/home/roadmap/RoadmapViewItem.js
+++ b/client-app/src/desktop/tabs/home/roadmap/RoadmapViewItem.js
@@ -58,13 +58,13 @@ export const roadmapViewItem = hoistCmp.factory({
                 span({
                     className: 'tb-roadmap-item__description',
                     items: [
-                        truncate(description, {length: 255, omission: ' '}),
-                        description.length > 255 ? popover({
+                        truncate(description, {length: 290, separator: ' ', omission: ' '}),
+                        description.length > 290 ? popover({
                             popoverClassName: 'tb-roadmap__popover tb-roadmap__popover--description',
                             minimal: true,
                             interactionKind: 'hover',
                             position: 'left-top',
-                            target: span(' [...]'),
+                            target: span(' ...'),
                             content: div({
                                 items: breakUpDescription(description)
                             })

--- a/client-app/src/desktop/tabs/home/roadmap/RoadmapViewItem.js
+++ b/client-app/src/desktop/tabs/home/roadmap/RoadmapViewItem.js
@@ -57,8 +57,9 @@ export const roadmapViewItem = hoistCmp.factory({
                 ),
                 span({
                     className: 'tb-roadmap-item__description',
-                    items: [truncate(description, {length: 230, omission: ' '}),
-                        popover({
+                    items: [
+                        truncate(description, {length: 230, omission: ' '}),
+                        description.length > 230 ? popover({
                             popoverClassName: 'tb-roadmap__popover tb-roadmap__popover--description',
                             minimal: true,
                             interactionKind: 'hover',
@@ -67,7 +68,7 @@ export const roadmapViewItem = hoistCmp.factory({
                             content: div({
                                 items: breakUpDescription(description)
                             })
-                        })
+                        }) : ''
                     ]
                 }),
                 hbox({

--- a/client-app/src/desktop/tabs/home/roadmap/RoadmapViewItem.js
+++ b/client-app/src/desktop/tabs/home/roadmap/RoadmapViewItem.js
@@ -52,7 +52,7 @@ export const roadmapViewItem = hoistCmp.factory({
                     minimal: true,
                     interactionKind: 'hover',
                     position: 'left-top',
-                    target: truncate(description, {length: 220}),
+                    target: truncate(description, {length: 230, omission: ' [...]'}),
                     content: description
                 }),
                 hbox({
@@ -91,7 +91,7 @@ function getGitMenuItems(gitLinks) {
         return [menuItem({text: 'No linked Github issues yet.'})];
     }
 
-    return gitLinks.split(',').map(link => {
+    return gitLinks.split('\n').map(link => {
         return menuItem({
             text: link,
             icon: fontAwesomeIcon({icon: ['fab', 'github']}),

--- a/grails-app/domain/io/xh/toolbox/roadmap/Project.groovy
+++ b/grails-app/domain/io/xh/toolbox/roadmap/Project.groovy
@@ -26,7 +26,7 @@ class Project implements JSONFormat {
     }
 
     static constraints = {
-        name(blank: false, maxSize: 50)
+        name(blank: false, maxSize: 100)
         status(inList: Project.STATUSES)
         releaseVersion(nullable: true)
         gitLinks(nullable: true)

--- a/grails-app/domain/io/xh/toolbox/roadmap/Project.groovy
+++ b/grails-app/domain/io/xh/toolbox/roadmap/Project.groovy
@@ -28,7 +28,6 @@ class Project implements JSONFormat {
     static constraints = {
         name(blank: false, maxSize: 50)
         status(inList: Project.STATUSES)
-        category(inList: Project.CATEGORIES)
         releaseVersion(nullable: true)
         gitLinks(nullable: true)
         lastUpdatedBy(nullable: true, maxSize: 50)


### PR DESCRIPTION
This PR addresses most of follow-up Roadmap issues in https://github.com/xh/toolbox/issues/361
 - Changed way description truncates and popover appears on hover over [...] element
 - Title char limit increased to 100 but truncates at 55, conditionally rendering a popover if exceeds length.
- Added line breaks to popover description, not in dataView display.
- Fixed Category constraint - can now add new category. Still need to specify icon in roadmapCategories config, else defaults to experiment (flask) icon.
- Changed widths of Welcome and Roadmap panels on home tab
- Reordered top level tabs in Admin
- Increased size of textArea in REST editor for Project description
- Github Links should now be entered as new lines instead of comma separated

Upcoming/released filtering and phase reordering is still a WIP!
