### PR TITLE
Switch to hframe to fix alignment

### DIFF
--- a/client-app/src/examples/news/NewsPanelItem.js
+++ b/client-app/src/examples/news/NewsPanelItem.js
@@ -1,5 +1,5 @@
 import {hoistCmp} from '@xh/hoist/core/index';
-import {hbox, box} from '@xh/hoist/cmp/layout/index';
+import {box, hframe} from '@xh/hoist/cmp/layout/index';
 import stockPhoto from '../../core/img/stock-news.png';
 import React from 'react';
 
@@ -9,7 +9,7 @@ export const newsPanelItem = hoistCmp.factory({
     render({record}) {
         const {title, text, imageUrl, published, source, author} = record.data;
 
-        return hbox({
+        return hframe({
             className: 'news-item',
             items: [
                 box({


### PR DESCRIPTION
Previously, a news item was an hbox. This lead to problems where not all news items had the same width. Switching the news-item to an hframe solves this.

Problem:

<img width="1907" alt="image" src="https://user-images.githubusercontent.com/48924151/75288443-61067b80-57ea-11ea-99b9-570865564daa.png">

After fix:

<img width="1907" alt="image" src="https://user-images.githubusercontent.com/48924151/75288457-6663c600-57ea-11ea-87d6-2733d20f31c7.png">
