### PR TITLE
Navigator refactor

### DIFF
--- a/client-app/src/mobile/App.scss
+++ b/client-app/src/mobile/App.scss
@@ -25,7 +25,7 @@
   border-bottom: var(--xh-border-solid);
 }
 
-.toolbox-containers-page .xh-vframe {
+.toolbox-containers-page .xh-panel__content {
   & > .xh-hbox,
   & > .xh-vbox {
     flex: 1;

--- a/client-app/src/mobile/AppModel.js
+++ b/client-app/src/mobile/AppModel.js
@@ -33,7 +33,7 @@ export class AppModel {
 
     @managed
     navigatorModel = new NavigatorModel({
-        routes: [
+        pages: [
             {id: 'default', content: homePage},
             {id: 'grids', content: gridPage},
             {id: 'gridDetail', content: gridDetailPage},

--- a/client-app/src/mobile/containers/ContainersPage.js
+++ b/client-app/src/mobile/containers/ContainersPage.js
@@ -1,11 +1,10 @@
 import {hoistCmp, creates} from '@xh/hoist/core';
-import {page} from '@xh/hoist/mobile/cmp/page';
 import {tabContainer} from '@xh/hoist/cmp/tab';
 import {ContainersPageModel} from './ContainersPageModel';
 
 export const containersPage = hoistCmp.factory({
     model: creates(ContainersPageModel),
     render() {
-        return page(tabContainer());
+        return tabContainer();
     }
 });

--- a/client-app/src/mobile/containers/HBoxPage.js
+++ b/client-app/src/mobile/containers/HBoxPage.js
@@ -1,5 +1,5 @@
 import {hoistCmp} from '@xh/hoist/core';
-import {page} from '@xh/hoist/mobile/cmp/page';
+import {panel} from '@xh/hoist/mobile/cmp/panel';
 import {div, hbox, box} from '@xh/hoist/cmp/layout';
 
 export const hboxPage = hoistCmp.factory({
@@ -7,7 +7,7 @@ export const hboxPage = hoistCmp.factory({
 
         const defaults = {padding: 10, className: 'toolbox-containers-box'};
 
-        return page({
+        return panel({
             className: 'toolbox-containers-page',
             items: [
                 div({

--- a/client-app/src/mobile/containers/ToolbarPage.js
+++ b/client-app/src/mobile/containers/ToolbarPage.js
@@ -1,5 +1,5 @@
 import {XH, hoistCmp, creates} from '@xh/hoist/core';
-import {page} from '@xh/hoist/mobile/cmp/page';
+import {panel} from '@xh/hoist/mobile/cmp/panel';
 import {toolbar, toolbarSep} from '@xh/hoist/mobile/cmp/toolbar';
 import {button} from '@xh/hoist/mobile/cmp/button';
 import {select} from '@xh/hoist/mobile/cmp/input';
@@ -13,7 +13,7 @@ export const toolbarPage = hoistCmp.factory({
     model: creates(ToolbarPageModel),
 
     render({model}) {
-        return page({
+        return panel({
             className: 'toolbox-toolbar-page',
             items: [
                 div({

--- a/client-app/src/mobile/containers/VBoxPage.js
+++ b/client-app/src/mobile/containers/VBoxPage.js
@@ -1,5 +1,5 @@
 import {hoistCmp} from '@xh/hoist/core';
-import {page} from '@xh/hoist/mobile/cmp/page';
+import {panel} from '@xh/hoist/mobile/cmp/panel';
 import {div, vbox, box} from '@xh/hoist/cmp/layout';
 
 export const vboxPage = hoistCmp.factory({
@@ -7,7 +7,7 @@ export const vboxPage = hoistCmp.factory({
     render() {
         const defaults = {padding: 10, className: 'toolbox-containers-box'};
 
-        return page({
+        return panel({
             className: 'toolbox-containers-page',
             items: [
                 div({

--- a/client-app/src/mobile/dataview/DataViewPage.js
+++ b/client-app/src/mobile/dataview/DataViewPage.js
@@ -1,6 +1,6 @@
 import {hoistCmp, creates} from '@xh/hoist/core';
 
-import {page} from '@xh/hoist/mobile/cmp/page';
+import {panel} from '@xh/hoist/mobile/cmp/panel';
 import {dataView} from '@xh/hoist/cmp/dataview';
 import {refreshButton} from '@xh/hoist/mobile/cmp/button';
 import {filler} from '@xh/hoist/cmp/layout';
@@ -12,7 +12,7 @@ export const dataViewPage = hoistCmp.factory({
     model: creates(DataViewPageModel),
 
     render() {
-        return page({
+        return panel({
             title: 'DataView',
             icon: Icon.addressCard(),
             mask: 'onLoad',

--- a/client-app/src/mobile/form/FormPage.js
+++ b/client-app/src/mobile/form/FormPage.js
@@ -1,6 +1,6 @@
 import {hoistCmp, creates} from '@xh/hoist/core';
 import {div, filler, vbox} from '@xh/hoist/cmp/layout';
-import {page} from '@xh/hoist/mobile/cmp/page';
+import {panel} from '@xh/hoist/mobile/cmp/panel';
 import {toolbar} from '@xh/hoist/mobile/cmp/toolbar';
 import {button} from '@xh/hoist/mobile/cmp/button';
 import {Icon} from '@xh/hoist/icon';
@@ -28,7 +28,7 @@ export const formPage = hoistCmp.factory({
     model: creates(FormPageModel),
 
     render() {
-        return page({
+        return panel({
             title: 'Form',
             icon: Icon.edit(),
             scrollable: true,

--- a/client-app/src/mobile/grids/GridDetailPage.js
+++ b/client-app/src/mobile/grids/GridDetailPage.js
@@ -1,6 +1,6 @@
 import {hoistCmp, HoistModel, LoadSupport, useLocalModel, XH} from '@xh/hoist/core';
 import {div} from '@xh/hoist/cmp/layout';
-import {page} from '@xh/hoist/mobile/cmp/page';
+import {panel} from '@xh/hoist/mobile/cmp/panel';
 import {numberRenderer} from '@xh/hoist/format';
 import {Icon} from '@xh/hoist/icon';
 import {isNil, find} from 'lodash';
@@ -20,7 +20,7 @@ export const gridDetailPage = hoistCmp.factory({
             ]
         });
 
-        return page({
+        return panel({
             title: record?.company ?? '',
             mask: impl.loadModel,
             icon: Icon.fund(),

--- a/client-app/src/mobile/grids/GridPage.js
+++ b/client-app/src/mobile/grids/GridPage.js
@@ -1,6 +1,6 @@
 import {XH, hoistCmp, creates} from '@xh/hoist/core';
 
-import {page} from '@xh/hoist/mobile/cmp/page';
+import {panel} from '@xh/hoist/mobile/cmp/panel';
 import {grid} from '@xh/hoist/cmp/grid';
 import {filler} from '@xh/hoist/cmp/layout';
 import {colChooserButton} from '@xh/hoist/mobile/cmp/button';
@@ -17,7 +17,7 @@ export const gridPage = hoistCmp.factory({
 
     render({model}) {
         const {gridModel} = model;
-        return page({
+        return panel({
             title: 'Grids',
             icon: Icon.gridPanel(),
             mask: 'onLoad',

--- a/client-app/src/mobile/home/HomePage.js
+++ b/client-app/src/mobile/home/HomePage.js
@@ -1,12 +1,12 @@
 import {XH, hoistCmp} from '@xh/hoist/core';
 import {div} from '@xh/hoist/cmp/layout';
-import {page} from '@xh/hoist/mobile/cmp/page';
+import {panel} from '@xh/hoist/mobile/cmp/panel';
 import {button} from '@xh/hoist/mobile/cmp/button';
 import {Icon} from '@xh/hoist/icon';
 
 export const homePage = hoistCmp.factory({
     render() {
-        return page({
+        return panel({
             scrollable: true,
             className: 'toolbox-page xh-tiled-bg',
             items: [

--- a/client-app/src/mobile/icons/IconPage.js
+++ b/client-app/src/mobile/icons/IconPage.js
@@ -1,5 +1,5 @@
 import {hoistCmp} from '@xh/hoist/core';
-import {page} from '@xh/hoist/mobile/cmp/page';
+import {panel} from '@xh/hoist/mobile/cmp/panel';
 import {table, tbody, tr, th, td} from '@xh/hoist/cmp/layout';
 import {Icon} from '@xh/hoist/icon';
 
@@ -7,7 +7,7 @@ import './IconPage.scss';
 
 export const iconPage = hoistCmp.factory({
     render() {
-        return page({
+        return panel({
             scrollable: true,
             className: 'icon-page',
             item: table(

--- a/client-app/src/mobile/panels/PanelPage.js
+++ b/client-app/src/mobile/panels/PanelPage.js
@@ -2,46 +2,43 @@ import {relativeTimestamp} from '@xh/hoist/cmp/relativetimestamp';
 import {hoistCmp} from '@xh/hoist/core';
 import {Icon} from '@xh/hoist/icon/Icon';
 import {button} from '@xh/hoist/mobile/cmp/button';
-import {page} from '@xh/hoist/mobile/cmp/page';
-import {filler} from '@xh/hoist/cmp/layout';
 import {panel} from '@xh/hoist/mobile/cmp/panel';
+import {filler} from '@xh/hoist/cmp/layout';
 import {toolbar, toolbarSep} from '@xh/hoist/mobile/cmp/toolbar';
 import './PanelsPage.scss';
 
 export const panelPage = hoistCmp.factory({
     render() {
-        return page(
-            panel({
-                title: 'Hoist Panel',
-                icon: Icon.window(),
-                className: 'tb-panels-standard-panel',
-                headerItems: [
-                    relativeTimestamp({timestamp: Date.now(), options: {prefix: 'Rendered'}})
-                ],
-                items: [
-                    'This is a Panel with a header (including a title, icon, and headerItem) as well as top and bottom toolbars.'
-                ],
-                tbar: toolbar(
-                    button({
-                        icon: Icon.add(),
-                        text: 'New'
-                    }),
-                    toolbarSep(),
-                    button({
-                        icon: Icon.edit(),
-                        text: 'Edit',
-                        modifier: 'quiet'
-                    })
-                ),
-                bbar: toolbar(
-                    filler(),
-                    button({
-                        icon: Icon.questionCircle(),
-                        text: 'Another Button',
-                        modifier: 'quiet'
-                    })
-                )
-            })
-        );
+        return panel({
+            title: 'Hoist Panel',
+            icon: Icon.window(),
+            className: 'tb-panels-standard-panel',
+            headerItems: [
+                relativeTimestamp({timestamp: Date.now(), options: {prefix: 'Rendered'}})
+            ],
+            items: [
+                'This is a Panel with a header (including a title, icon, and headerItem) as well as top and bottom toolbars.'
+            ],
+            tbar: toolbar(
+                button({
+                    icon: Icon.add(),
+                    text: 'New'
+                }),
+                toolbarSep(),
+                button({
+                    icon: Icon.edit(),
+                    text: 'Edit',
+                    modifier: 'quiet'
+                })
+            ),
+            bbar: toolbar(
+                filler(),
+                button({
+                    icon: Icon.questionCircle(),
+                    text: 'Another Button',
+                    modifier: 'quiet'
+                })
+            )
+        });
     }
 });

--- a/client-app/src/mobile/panels/PanelsPage.js
+++ b/client-app/src/mobile/panels/PanelsPage.js
@@ -1,11 +1,10 @@
 import {tabContainer} from '@xh/hoist/cmp/tab';
 import {creates, hoistCmp} from '@xh/hoist/core';
-import {page} from '@xh/hoist/mobile/cmp/page';
 import {PanelsPageModel} from './PanelsPageModel';
 
 export const panelsPage = hoistCmp.factory({
     model: creates(PanelsPageModel),
     render() {
-        return page(tabContainer());
+        return tabContainer();
     }
 });

--- a/client-app/src/mobile/panels/ScrollablePanelPage.js
+++ b/client-app/src/mobile/panels/ScrollablePanelPage.js
@@ -1,9 +1,8 @@
 import {creates, hoistCmp} from '@xh/hoist/core';
 import {Icon} from '@xh/hoist/icon/Icon';
 import {switchInput} from '@xh/hoist/mobile/cmp/input';
-import {page} from '@xh/hoist/mobile/cmp/page';
-import {filler, p, span} from '@xh/hoist/cmp/layout';
 import {panel} from '@xh/hoist/mobile/cmp/panel';
+import {filler, p, span} from '@xh/hoist/cmp/layout';
 import {toolbar} from '@xh/hoist/mobile/cmp/toolbar';
 import {ScrollablePanelPageModel} from './ScrollablePanelPageModel';
 
@@ -22,19 +21,17 @@ export const scrollablePanelPage = hoistCmp.factory({
             );
         }
 
-        return page(
-            panel({
-                scrollable: true,
-                title: 'Scrollable Panel',
-                icon: Icon.favorite(),
-                className: 'tb-panels-scrollable-panel',
-                items,
-                bbar: toolbar(
-                    filler(),
-                    span('Add lots of content'),
-                    switchInput({bind: 'showLongContent'})
-                )
-            })
-        );
+        return panel({
+            scrollable: true,
+            title: 'Scrollable Panel',
+            icon: Icon.favorite(),
+            className: 'tb-panels-scrollable-panel',
+            items,
+            bbar: toolbar(
+                filler(),
+                span('Add lots of content'),
+                switchInput({bind: 'showLongContent'})
+            )
+        });
     }
 });

--- a/client-app/src/mobile/pinPad/PinPadPage.js
+++ b/client-app/src/mobile/pinPad/PinPadPage.js
@@ -1,9 +1,8 @@
 import {hoistCmp, HoistModel, creates, managed} from '@xh/hoist/core';
-import {page} from '@xh/hoist/mobile/cmp/page';
+import {panel} from '@xh/hoist/mobile/cmp/panel';
 import {pinPad, PinPadModel} from '@xh/hoist/mobile/cmp/pinpad';
 import {bindable} from '@xh/hoist/mobx';
 import {p} from '@xh/hoist/cmp/layout';
-import {panel} from '@xh/hoist/mobile/cmp/panel';
 import {wait} from '@xh/hoist/promise';
 
 import './PinPadPage.scss';
@@ -13,7 +12,7 @@ export const pinPadPage = hoistCmp.factory({
     model: creates(() => new Model()),
 
     render({model}) {
-        return page(!model.loggedIn ? pinPad() : secretPlans());
+        return !model.loggedIn ? pinPad() : secretPlans();
     }
 });
 

--- a/client-app/src/mobile/popups/PopupsPage.js
+++ b/client-app/src/mobile/popups/PopupsPage.js
@@ -1,12 +1,12 @@
 import {XH, hoistCmp} from '@xh/hoist/core';
 import {div, span, code} from '@xh/hoist/cmp/layout';
-import {page} from '@xh/hoist/mobile/cmp/page';
+import {panel} from '@xh/hoist/mobile/cmp/panel';
 import {button} from '@xh/hoist/mobile/cmp/button';
 import {Icon} from '@xh/hoist/icon';
 
 export const popupsPage = hoistCmp.factory({
     render() {
-        return page({
+        return panel({
             title: 'Popups',
             icon: Icon.comment(),
             className: 'toolbox-page xh-tiled-bg',

--- a/client-app/src/mobile/treegrids/TreeGridDetailPage.js
+++ b/client-app/src/mobile/treegrids/TreeGridDetailPage.js
@@ -1,6 +1,6 @@
 import {hoistCmp, HoistModel, LoadSupport, useLocalModel, XH} from '@xh/hoist/core';
 import {div} from '@xh/hoist/cmp/layout';
-import {page} from '@xh/hoist/mobile/cmp/page';
+import {panel} from '@xh/hoist/mobile/cmp/panel';
 import {numberRenderer} from '@xh/hoist/format';
 import {capitalize} from 'lodash';
 import {Icon} from '@xh/hoist/icon';
@@ -12,7 +12,7 @@ export const treeGridDetailPage = hoistCmp.factory({
         impl.setId(decodeURIComponent(id));
         const {position} = impl;
         
-        return page({
+        return panel({
             title: position ? renderPageTitle(position) : null,
             icon: Icon.portfolio(),
             mask: impl.loadModel,

--- a/client-app/src/mobile/treegrids/TreeGridPage.js
+++ b/client-app/src/mobile/treegrids/TreeGridPage.js
@@ -1,5 +1,5 @@
 import {XH, hoistCmp, creates} from '@xh/hoist/core';
-import {page} from '@xh/hoist/mobile/cmp/page';
+import {panel} from '@xh/hoist/mobile/cmp/panel';
 import {grid} from '@xh/hoist/cmp/grid';
 import {filler} from '@xh/hoist/cmp/layout';
 import {dimensionChooser} from '@xh/hoist/mobile/cmp/dimensionchooser';
@@ -12,7 +12,7 @@ export const treeGridPage = hoistCmp.factory({
     model: creates(TreeGridPageModel),
 
     render() {
-        return page({
+        return panel({
             title: 'Tree Grids',
             icon: Icon.grid(),
             mask: 'onLoad',


### PR DESCRIPTION
+ NavigatorModel.routes > NavigatorModel.pages
+ NavigatorModel.pages > NavigatorModel.stack
+ NavigatorPageModel > PageModel
+ Removed `Page` from mobile toolkit. Navigator and TabContainer now wrap their content in an Onsen Page.
+ Fixed Toolbox 'Containers' page styling

See hoist-react PR: https://github.com/xh/hoist-react/pull/1732