### PR TITLE
DockContainer Render Mode / Refresh Mode

### DIFF
--- a/client-app/src/desktop/tabs/containers/DockContainerPanel.js
+++ b/client-app/src/desktop/tabs/containers/DockContainerPanel.js
@@ -5,8 +5,7 @@ import {Icon} from '@xh/hoist/icon';
 import {panel} from '@xh/hoist/desktop/cmp/panel';
 import {button} from '@xh/hoist/desktop/cmp/button';
 import {dockContainer, DockContainerModel} from '@xh/hoist/cmp/dock';
-import {wrapper, sampleGrid, SampleGridModel} from '../../common';
-import {LoadSupport} from '@xh/hoist/core/mixins';
+import {wrapper, sampleGrid} from '../../common';
 
 export const dockContainerPanel = hoistCmp.factory({
     model: creates(() => new Model()),
@@ -87,13 +86,10 @@ const btnCfg = {
 };
 
 @HoistModel
-@LoadSupport
 class Model {
 
     @managed
     dockContainerModel = new DockContainerModel();
-    @managed
-    sampleGridModel = new SampleGridModel();
 
     addView(...args) {
         this.dockContainerModel.addView(...args);
@@ -124,7 +120,4 @@ class Model {
         });
     }
 
-    async doLoadAsync(loadSpec) {
-        await this.sampleGridModel.loadAsync(loadSpec);
-    }
 }


### PR DESCRIPTION
DockContainer example defers to DockContainer's managed refresh to refresh grid.

See hoist-react PR: https://github.com/xh/hoist-react/pull/1753