### PR TITLE
Roadmap Improvements

### DIFF
--- a/client-app/src/admin/roadmap/ProjectRestPanel.js
+++ b/client-app/src/admin/roadmap/ProjectRestPanel.js
@@ -3,6 +3,7 @@ import {addAction, cloneAction, deleteAction, editAction, restGrid, viewAction} 
 import {dateTimeRenderer} from '@xh/hoist/format';
 import {codeInput, textArea} from '@xh/hoist/desktop/cmp/input';
 import {hoistCmp} from '@xh/hoist/core';
+import {toNumber} from 'lodash';
 
 export const projectRestPanel = hoistCmp.factory({
     render() {
@@ -80,9 +81,7 @@ const modelSpec = {
     filterFields: ['name', 'status', 'category'],
     sortBy: ['phaseOrder', 'sortOrder'],
     groupBy: 'phaseOrder',
-    groupSortFn: (a, b) => {
-        return parseInt(a, 10) >= parseInt(b, 10) ? 1 : -1;
-    },
+    groupSortFn: (a, b) => toNumber(a) - toNumber(b),
     groupRowRenderer: ({node}) => {
         const projectRec = node.allLeafChildren[0].data;
         return projectRec.data.phaseName;

--- a/client-app/src/admin/roadmap/ProjectRestPanel.js
+++ b/client-app/src/admin/roadmap/ProjectRestPanel.js
@@ -35,6 +35,10 @@ const modelSpec = {
                 required: true
             },
             {
+                name: 'phaseOrder',
+                editable: false
+            },
+            {
                 name: 'phaseName',
                 required: true,
                 lookupName: 'phases',
@@ -74,8 +78,15 @@ const modelSpec = {
     },
     unit: 'project',
     filterFields: ['name', 'status', 'category'],
-    sortBy: 'sortOrder',
-    groupBy: 'phaseName',
+    sortBy: ['phaseOrder', 'sortOrder'],
+    groupBy: 'phaseOrder',
+    groupSortFn: (a, b) => {
+        return parseInt(a, 10) >= parseInt(b, 10) ? 1 : -1;
+    },
+    groupRowRenderer: ({node}) => {
+        const projectRec = node.allLeafChildren[0].data;
+        return projectRec.data.phaseName;
+    },
     columns: [
         {
             field: 'sortOrder',
@@ -100,7 +111,10 @@ const modelSpec = {
         },
         {
             field: 'phaseName',
-            width: 100,
+            hidden: true
+        },
+        {
+            field: 'phaseOrder',
             hidden: true
         },
         {

--- a/client-app/src/desktop/tabs/home/roadmap/RoadmapModel.js
+++ b/client-app/src/desktop/tabs/home/roadmap/RoadmapModel.js
@@ -4,6 +4,7 @@ import {DataViewModel} from '@xh/hoist/cmp/dataview';
 import {roadmapViewItem} from './RoadmapViewItem';
 import './RoadmapView.scss';
 import {Icon} from '@xh/hoist/icon';
+import {toNumber} from 'lodash';
 
 @HoistModel
 @LoadSupport
@@ -26,13 +27,9 @@ export class RoadmapModel {
         groupBy: 'sortedPhase',
         groupRowHeight: 32,
         groupSortFn: (a, b) => {
-            a = parseInt(a, 10);
-            b = parseInt(b, 10);
-            if (this.statusFilter === 'showUpcoming') {
-                return a >= b ? 1 : -1;
-            } else {
-                return a >= b ? -1 : 1;
-            }
+            a = toNumber(a);
+            b = toNumber(b);
+            return this.statusFilter === 'showUpcoming' ? a - b : b - a;
         },
         groupRowRenderer: ({node}) => {
             const projectRec = node.allLeafChildren[0].data;

--- a/client-app/src/desktop/tabs/home/roadmap/RoadmapModel.js
+++ b/client-app/src/desktop/tabs/home/roadmap/RoadmapModel.js
@@ -26,6 +26,8 @@ export class RoadmapModel {
         groupBy: 'sortedPhase',
         groupRowHeight: 32,
         groupSortFn: (a, b) => {
+            a = parseInt(a, 10);
+            b = parseInt(b, 10);
             if (this.statusFilter === 'showUpcoming') {
                 return a >= b ? 1 : -1;
             } else {

--- a/client-app/src/desktop/tabs/home/roadmap/RoadmapViewItem.js
+++ b/client-app/src/desktop/tabs/home/roadmap/RoadmapViewItem.js
@@ -17,9 +17,7 @@ export const roadmapViewItem = hoistCmp.factory({
     model: null,
 
     render({record}) {
-        const {category, name, description, releaseVersion, status, gitLinks, lastUpdated} = record.data,
-            gitIcon = Icon.icon({iconName: 'github', prefix: 'fab', size: '2x'});
-
+        const {category, name, description, releaseVersion, status, gitLinks, lastUpdated} = record.data;
         return vbox({
             className: 'tb-roadmap-item',
             items: [
@@ -38,11 +36,7 @@ export const roadmapViewItem = hoistCmp.factory({
                         ]
                     }),
                     filler(),
-                    popover({
-                        minimal: true,
-                        target: button({icon: gitIcon}),
-                        content: menu({items: getGitMenuItems(gitLinks)})
-                    }),
+                    getGitIcon(gitLinks),
                     popover({
                         popoverClassName: 'tb-roadmap__popover',
                         minimal: true,
@@ -102,10 +96,24 @@ function getCategoryIcon(category) {
     return Icon[iconName]({className: 'xh-blue', prefix: 'fal'});
 }
 
-function getGitMenuItems(gitLinks) {
-    if (!gitLinks) {
-        return [menuItem({text: 'No linked Github issues yet.'})];
+function getGitIcon(gitLinks) {
+    if (!gitLinks) return null;
+    const gitLinksList = gitLinks.split('\n'),
+        gitIcon = Icon.icon({iconName: 'github', prefix: 'fab', size: '2x'});
+
+    if (gitLinksList.length === 1) {
+        return button({icon: gitIcon, onClick: () => window.open(gitLinksList[0])});
+    } else {
+        return popover({
+            minimal: true,
+            target: button({icon: gitIcon}),
+            content: menu({items: getGitMenuItems(gitLinks)})
+        });
     }
+}
+
+function getGitMenuItems(gitLinks) {
+    if (!gitLinks) return;
 
     return gitLinks.split('\n').map(link => {
         return menuItem({

--- a/grails-app/domain/io/xh/toolbox/roadmap/Project.groovy
+++ b/grails-app/domain/io/xh/toolbox/roadmap/Project.groovy
@@ -44,6 +44,7 @@ class Project implements JSONFormat {
                 gitLinks: gitLinks,
                 sortOrder: sortOrder,
                 phaseName: phase.name,
+                phaseOrder: phase.sortOrder,
                 lastUpdatedBy: lastUpdatedBy,
                 lastUpdated: lastUpdated,
         ]


### PR DESCRIPTION
This PR addresses https://github.com/xh/toolbox/issues/423.
- Sort projects by sorted phase groups, then project sort order in admin rest grid
- Change alphanumeric sort to integer sort in roadmap and rest grid
- Handle Github icon rendering based on number of links