### PR TITLE
Tree column header has expand/collapse all icon

### DIFF
--- a/client-app/src/admin/tests/grids/GridTestModel.js
+++ b/client-app/src/admin/tests/grids/GridTestModel.js
@@ -199,7 +199,8 @@ export class GridTestModel extends HoistModel {
                 {
                     field: 'id',
                     width: 140,
-                    isTreeColumn: this.tree
+                    isTreeColumn: this.tree,
+                    headerHasExpandCollapse: true
                 },
                 {
                     field: 'symbol',

--- a/client-app/src/desktop/common/grid/SampleTreeGridModel.js
+++ b/client-app/src/desktop/common/grid/SampleTreeGridModel.js
@@ -31,10 +31,10 @@ export class SampleTreeGridModel extends HoistModel {
 
     get store() {return this.gridModel.store}
 
-    constructor({includeCheckboxes}) {
+    constructor({includeCheckboxes, headerHasExpandCollapse}) {
         super();
         makeObservable(this);
-        this.gridModel = this.createGridModel(includeCheckboxes);
+        this.gridModel = this.createGridModel(includeCheckboxes, headerHasExpandCollapse);
 
         this.addReaction({
             track: () => this.filterIncludesChildren,
@@ -101,7 +101,7 @@ export class SampleTreeGridModel extends HoistModel {
         XH.navigate(XH.routerState.name, {dims}, opts);
     }
 
-    createGridModel(includeCheckboxes) {
+    createGridModel(includeCheckboxes, headerHasExpandCollapse) {
         return new GridModel({
             treeMode: true,
             store: {
@@ -121,7 +121,7 @@ export class SampleTreeGridModel extends HoistModel {
                     width: 200,
                     field: 'name',
                     isTreeColumn: true,
-                    headerHasExpandCollapse: true,
+                    headerHasExpandCollapse,
                     ...(includeCheckboxes ? this.createCheckboxTreeColumn() : {})
                 },
                 {

--- a/client-app/src/desktop/common/grid/SampleTreeGridModel.js
+++ b/client-app/src/desktop/common/grid/SampleTreeGridModel.js
@@ -121,7 +121,7 @@ export class SampleTreeGridModel extends HoistModel {
                     width: 200,
                     field: 'name',
                     isTreeColumn: true,
-                    expandFromHeader: true,
+                    headerHasExpandCollapse: true,
                     ...(includeCheckboxes ? this.createCheckboxTreeColumn() : {})
                 },
                 {

--- a/client-app/src/desktop/common/grid/SampleTreeGridModel.js
+++ b/client-app/src/desktop/common/grid/SampleTreeGridModel.js
@@ -121,6 +121,7 @@ export class SampleTreeGridModel extends HoistModel {
                     width: 200,
                     field: 'name',
                     isTreeColumn: true,
+                    expandFromHeader: true,
                     ...(includeCheckboxes ? this.createCheckboxTreeColumn() : {})
                 },
                 {

--- a/client-app/src/desktop/tabs/grids/TreeGridPanel.js
+++ b/client-app/src/desktop/tabs/grids/TreeGridPanel.js
@@ -23,7 +23,7 @@ export const treeGridPanel = hoistCmp.factory(
             title: 'Grids › Tree',
             icon: Icon.grid(),
             className: 'tb-grid-wrapper-panel',
-            item: sampleTreeGrid({model: {includeCheckboxes: false}})
+            item: sampleTreeGrid({model: {includeCheckboxes: false, headerHasExpandCollapse: true}})
         })
     })
 );


### PR DESCRIPTION
See matching hoist-react PR

Tree grid example shows this optional icon; tree grid w/ checkbox example does not