### PR TITLE
Disable swipe to refresh/go back on mobile charts to allow for dragging

### DIFF
--- a/client-app/src/mobile/charts/ChartPageModel.js
+++ b/client-app/src/mobile/charts/ChartPageModel.js
@@ -55,8 +55,11 @@ export class ChartPageModel extends HoistModel {
     getChartModelCfg() {
         return {
             chart: {
-                type: 'ohlc'
+                type: 'ohlc',
+                zoomType: 'x'
             },
+            rangeSelector: {enabled: true, selected: 5},
+            navigator: {enabled: true},
             title: {text: null},
             legend: {enabled: false},
             scrollbar: {enabled: false},


### PR DESCRIPTION
Add more features to mobile chart example to test interaction of dragging and swiping.
See hoist-react PR.