### PR TITLE
Autosize with row and cell class names example.

### DIFF
--- a/client-app/src/desktop/common/grid/SampleGrid.scss
+++ b/client-app/src/desktop/common/grid/SampleGrid.scss
@@ -10,15 +10,25 @@
       margin-right: 4px;
     }
   }
+}
 
-  // To demo Column.cellClassRules
-  .ag-row:not(.ag-row-pinned) {
-    .tb-sample-grid__high-volume-cell {
-      color: var(--xh-intent-warning-darker);
-      border-left: 4px solid var(--xh-intent-warning-darker) !important;
-      background-color: var(--xh-intent-warning-trans1);
-    }
+// To demo GridModel.rowClassRules
+.tb-sample-grid__bolded-row {
+  font-weight: bold;
+
+  .ag-cell,
+  .xh-grid-autosize-cell {
+    padding-left: 10px !important;
+    padding-right: 10px !important;
   }
+}
+
+// To demo Column.cellClassRules
+.tb-sample-grid__high-volume-cell {
+  padding-left: 70px !important;
+  color: var(--xh-intent-warning-darker);
+  border-left: 4px solid var(--xh-intent-warning-darker) !important;
+  background-color: var(--xh-intent-warning-trans1);
 }
 
 .tb-sample-grid-tooltip {

--- a/client-app/src/desktop/common/grid/SampleGridModel.js
+++ b/client-app/src/desktop/common/grid/SampleGridModel.js
@@ -131,6 +131,9 @@ export class SampleGridModel extends HoistModel {
                 return a < b ? -1 : 1;
             }
         },
+        rowClassRules: {
+            'tb-sample-grid__bolded-row': ({data: record}) => record.get('city') === 'San Francisco'
+        },
         colDefaults: {
             tooltipElement: (v, {record, gridModel}) => {
                 if (record.isSummary) return null;
@@ -203,8 +206,7 @@ export class SampleGridModel extends HoistModel {
             },
             {
                 field: 'city',
-                minWidth: 150,
-                maxWidth: 200,
+                width: 150,
                 tooltip: (val, {record}) => `${record.data.company} is located in ${val}`
             },
             {


### PR DESCRIPTION
An example of how row and cell class names can interfere with autosizing.

See hoist-react PR: https://github.com/xh/hoist-react/pull/2671