### PR TITLE
NumberFormatsPanel: better display of number tests

### DIFF
--- a/client-app/src/desktop/tabs/other/formats/NumberFormatsPanel.js
+++ b/client-app/src/desktop/tabs/other/formats/NumberFormatsPanel.js
@@ -32,7 +32,7 @@ export const numberFormatsPanel = hoistCmp.factory({
                 title: 'Other › Number Formats',
                 icon: Icon.print(),
                 className: 'tbox-formats-tab',
-                height: 600,
+                height: 610,
                 item: hframe(
                     paramsPanel(),
                     resultsPanel({

--- a/client-app/src/desktop/tabs/other/formats/NumberFormatsPanel.js
+++ b/client-app/src/desktop/tabs/other/formats/NumberFormatsPanel.js
@@ -32,7 +32,7 @@ export const numberFormatsPanel = hoistCmp.factory({
                 title: 'Other › Number Formats',
                 icon: Icon.print(),
                 className: 'tbox-formats-tab',
-                height: 610,
+                height: 625,
                 item: hframe(
                     paramsPanel(),
                     resultsPanel({

--- a/client-app/src/desktop/tabs/other/formats/NumberFormatsPanel.js
+++ b/client-app/src/desktop/tabs/other/formats/NumberFormatsPanel.js
@@ -23,11 +23,6 @@ export const numberFormatsPanel = hoistCmp.factory({
                     methods delegate to <code>fmtNumber</code> and set useful defaults.
                 </p>,
                 <p>
-                    <code>fmtNumber</code> is backed by <a href="https://numbrojs.com/" target="_blank">numbro.js </a>
-                    and makes the full numbro API available via the <code>formatConfig</code> property, which takes a
-                    numbro configuration object.
-                </p>,
-                <p>
                     All hoist formatting functions support the <code>asElement</code> option to produce either a React
                     element, or a raw HTML string. This allows them to be useful in both React and non-React
                     contexts.
@@ -37,11 +32,17 @@ export const numberFormatsPanel = hoistCmp.factory({
                 title: 'Other › Number Formats',
                 icon: Icon.print(),
                 className: 'tbox-formats-tab',
-                height: 550,
+                height: 600,
                 item: hframe(
                     paramsPanel(),
                     resultsPanel({
-                        tryItInput: numberInput({selectOnFocus: true, placeholder: 'Enter a value to test'})
+                        // numberInput cannot accept a value greater than Number.MAX_SAFE_INTEGER
+                        // so cannot be used for testing the formatting of values bigger than that.
+                        tryItInput: numberInput({
+                            precision: 12, // max decimal precision allowed by fmtNumber
+                            selectOnFocus: true,
+                            placeholder: 'Enter a value to test'
+                        })
                     })
                 )
             })

--- a/client-app/src/desktop/tabs/other/formats/NumberFormatsPanelModel.js
+++ b/client-app/src/desktop/tabs/other/formats/NumberFormatsPanelModel.js
@@ -1,8 +1,7 @@
 import {HoistModel} from '@xh/hoist/core';
 import {bindable, makeObservable} from '@xh/hoist/mobx';
 import * as formatFunctions from '@xh/hoist/format/FormatNumber';
-import {fmtNumber} from '@xh/hoist/format/FormatNumber';
-import {nilAwareFormat} from './Util';
+import {nilAwareNumberWriter} from './Util';
 
 export class NumberFormatsPanelModel extends HoistModel {
 
@@ -27,6 +26,8 @@ export class NumberFormatsPanelModel extends HoistModel {
         123456789.12,
         1234567890.12,
         1.23456e14,
+        123456789012345.1,  // exceeds # of significant digits that JS can handle. Vanilla JS .toFixed(6) produces incorrect result: '123456789012345.093750'
+        '9007199254740999', // exceeds Number.MAX_SAFE_INTEGER by 8 (must be passed in as a string or else JS will round it before it is passed in)
         null,
         undefined
     ];
@@ -49,7 +50,7 @@ export class NumberFormatsPanelModel extends HoistModel {
     get testResults() {
         return this.testData.map(data => ({
             data,
-            formattedData: nilAwareFormat(data, fmtNumber),
+            formattedData: nilAwareNumberWriter(data),
             result: this.getResult(data)
         }));
     }

--- a/client-app/src/desktop/tabs/other/formats/NumberFormatsPanelModel.js
+++ b/client-app/src/desktop/tabs/other/formats/NumberFormatsPanelModel.js
@@ -1,7 +1,8 @@
+import BigNumber from 'bignumber.js';
 import {HoistModel} from '@xh/hoist/core';
 import {bindable, makeObservable} from '@xh/hoist/mobx';
 import * as formatFunctions from '@xh/hoist/format/FormatNumber';
-import {nilAwareNumberWriter} from './Util';
+import {typeAwareNumberWriter} from './Util';
 
 export class NumberFormatsPanelModel extends HoistModel {
 
@@ -28,6 +29,7 @@ export class NumberFormatsPanelModel extends HoistModel {
         1.23456e14,
         123456789012345.1,  // exceeds # of significant digits that JS can handle. Vanilla JS .toFixed(6) produces incorrect result: '123456789012345.093750'
         '9007199254740999', // exceeds Number.MAX_SAFE_INTEGER by 8 (must be passed in as a string or else JS will round it before it is passed in)
+        BigNumber('8589934592.123456'),  // 8589934592.123456 exceeds the number of safe decimal places JS tolerates.  (8589934592.123456 has value 8589934592.123455 in JS console)
         null,
         undefined
     ];
@@ -50,7 +52,7 @@ export class NumberFormatsPanelModel extends HoistModel {
     get testResults() {
         return this.testData.map(data => ({
             data,
-            formattedData: nilAwareNumberWriter(data),
+            formattedData: typeAwareNumberWriter(data),
             result: this.getResult(data)
         }));
     }

--- a/client-app/src/desktop/tabs/other/formats/ResultsPanel.js
+++ b/client-app/src/desktop/tabs/other/formats/ResultsPanel.js
@@ -11,7 +11,7 @@ export const resultsPanel = hoistCmp.factory(
         return panel({
             title: 'Input › Output',
             compactHeader: true,
-            width: 400,
+            width: 450,
             flex: 'none',
             className: 'tbox-formats-tab__panel',
             item: table(

--- a/client-app/src/desktop/tabs/other/formats/ResultsPanel.js
+++ b/client-app/src/desktop/tabs/other/formats/ResultsPanel.js
@@ -11,7 +11,7 @@ export const resultsPanel = hoistCmp.factory(
         return panel({
             title: 'Input › Output',
             compactHeader: true,
-            width: 450,
+            width: 460,
             flex: 'none',
             className: 'tbox-formats-tab__panel',
             item: table(

--- a/client-app/src/desktop/tabs/other/formats/Util.js
+++ b/client-app/src/desktop/tabs/other/formats/Util.js
@@ -1,4 +1,6 @@
 import {cloneElement} from 'react';
+import {isString} from 'lodash';
+import BigNumber from 'bignumber.js';
 import {hoistCmp} from '@xh/hoist/core';
 import {formGroup} from '@xh/hoist/kit/blueprint';
 import {code, span} from '@xh/hoist/cmp/layout';
@@ -17,7 +19,9 @@ export function nilAwareFormat(val, formatter) {
     return formatter(val);
 }
 
-export function nilAwareNumberWriter(val) {
+export function typeAwareNumberWriter(val) {
+    if (BigNumber.isBigNumber(val)) return code(`BigNumber('${val}')`);
+    if (isString(val)) return code(`'${val}'`);
     if (val === Math.PI) return code('Math.PI');
     if (val === Math.E) return code('Math.E');
     if (val === undefined) return code('undefined');

--- a/client-app/src/desktop/tabs/other/formats/Util.js
+++ b/client-app/src/desktop/tabs/other/formats/Util.js
@@ -16,3 +16,11 @@ export function nilAwareFormat(val, formatter) {
     if (val === null) return code('null');
     return formatter(val);
 }
+
+export function nilAwareNumberWriter(val) {
+    if (val === Math.PI) return code('Math.PI');
+    if (val === Math.E) return code('Math.E');
+    if (val === undefined) return code('undefined');
+    if (val === null) return code('null');
+    return code(val.toString());
+}


### PR DESCRIPTION
This branch updates the number tests in the number format panel to include a large float and and unsafe int, both of which are correctly handled by the BigNumber library which replaces numbro for standard formatting.

Corresponding hoist-react PR: https://github.com/xh/hoist-react/pull/2785
Corresponding hoist-react issue: https://github.com/xh/hoist-react/issues/2780