### PR TITLE
MySQL driver and datasource properties updated to v8

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## v3.0-SNAPSHOT - unreleased
 
+### Technical
+* MySQL driver and datasource properties updated to MySQL v8.
+
 ## v2.13.0 - 2021-01-11
 
 ### New Features

--- a/build.gradle
+++ b/build.gradle
@@ -58,8 +58,8 @@ if (inlineHoist) {
 }
 
 dependencies {
-    implementation "org.bitbucket.b_c:jose4j:0.7.2"
-    runtimeOnly "mysql:mysql-connector-java:5.1.47"
+    implementation "org.bitbucket.b_c:jose4j:0.7.9"
+    runtimeOnly "mysql:mysql-connector-java:8.0.27"
 
     // Support for reloading app on file change in dev environment
     developmentOnly(

--- a/grails-app/conf/runtime.groovy
+++ b/grails-app/conf/runtime.groovy
@@ -83,8 +83,8 @@ dataSource {
         //------------------------
         // Remove connections considered to be abandoned...
         removeAbandoned = true
-        // ...meaning those in use longer than this value...
-        removeAbandonedTimeout = 3 * MINUTES
+        // ...meaning those in use longer than this value (in seconds)...
+        removeAbandonedTimeout = 180
         // ...but don't necessarily abandon until we actually need space in the pool.
         abandonWhenPercentageFull = 90
 

--- a/grails-app/conf/runtime.groovy
+++ b/grails-app/conf/runtime.groovy
@@ -4,7 +4,6 @@ import org.hibernate.dialect.MySQL8Dialect
 import static io.xh.hoist.util.InstanceConfigUtils.getInstanceConfig
 import static io.xh.hoist.util.Utils.getAppCode
 import static io.xh.hoist.util.DateTimeUtils.HOURS
-import static io.xh.hoist.util.DateTimeUtils.MINUTES
 import static io.xh.hoist.util.DateTimeUtils.SECONDS
 import static java.sql.Connection.TRANSACTION_READ_COMMITTED
 
@@ -19,6 +18,9 @@ def dbHost = getInstanceConfig('dbHost') ?: 'localhost',
     dbSchema = getInstanceConfig('dbSchema') ?: appCode,
     dbUser = getInstanceConfig('dbUser') ?: appCode,
     dbPassword = getInstanceConfig('dbPassword')
+
+// Default dbPassword to appCode, but also support '' password if so specified.
+if (dbPassword == null) dbPassword = appCode
 
 dataSource {
     url = "jdbc:mysql://${dbHost}/${dbSchema}"
@@ -62,8 +64,8 @@ dataSource {
         testOnBorrow = true
         // ...but test each connection no more than once per this interval...
         validationInterval = 15 * SECONDS
-        // ...by issuing this query...
-        validationQuery = "/* ${appCode} connection validation */ SELECT 1"
+        // ...by issuing this query (special "ping" syntax understood by MySQL for this purpose)...
+        validationQuery = "/* ping */ SELECT 1"
         // ...giving it this long to complete (this one is in seconds!)
         validationQueryTimeout = 3
 

--- a/grails-app/conf/runtime.groovy
+++ b/grails-app/conf/runtime.groovy
@@ -1,4 +1,5 @@
 import io.xh.hoist.configuration.RuntimeConfig
+import org.hibernate.dialect.MySQL8Dialect
 
 import static io.xh.hoist.util.InstanceConfigUtils.getInstanceConfig
 import static io.xh.hoist.util.Utils.getAppCode
@@ -17,15 +18,14 @@ def dbHost = getInstanceConfig('dbHost') ?: 'localhost',
     dbCreateMode = getInstanceConfig('dbCreate') ?: 'update',
     dbSchema = getInstanceConfig('dbSchema') ?: appCode,
     dbUser = getInstanceConfig('dbUser') ?: appCode,
-    dbPassword = getInstanceConfig('dbPassword'),
-    sslSuffix = dbHost == 'localhost' ? '&useSSL=false' :  ''
+    dbPassword = getInstanceConfig('dbPassword')
 
 dataSource {
-    url = "jdbc:mysql://$dbHost/$dbSchema?useUnicode=yes&characterEncoding=UTF-8$sslSuffix"
+    url = "jdbc:mysql://${dbHost}/${dbSchema}"
     pooled = true
     jmxExport = true
-    driverClassName = "com.mysql.jdbc.Driver"
-    dialect = org.hibernate.dialect.MySQL5InnoDBDialect
+    driverClassName = 'com.mysql.cj.jdbc.Driver'
+    dialect = MySQL8Dialect
     dbCreate = dbCreateMode
     username = dbUser
     password = dbPassword
@@ -98,22 +98,24 @@ dataSource {
         //------------------------
         // MySQL-specific settings - would *not* apply to other databases, so please do not
         // leave these in place if you aren't using MySQL. Sourced from Grails docs example @
-        // https://docs.grails.org/3.3.9/guide/conf.html#dataSource (admittedly w/o much review).
+        // https://docs.grails.org/latest/guide/conf.html#dataSource (admittedly w/o much review).
         //------------------------
         dbProperties {
+            allowPublicKeyRetrieval = true
             autoReconnect = false
-            jdbcCompliantTruncation = false
-            zeroDateTimeBehavior = 'convertToNull'
-            cachePrepStmts = false
             cacheCallableStmts = false
+            cachePrepStmts = false
+            cacheResultSetMetadata = true
+            cacheServerConfiguration = true
+            connectTimeout = 15000
             dontTrackOpenResources = true
             holdResultsOpenOverStatementClose = true
-            useServerPrepStmts = false
-            cacheServerConfiguration = true
-            cacheResultSetMetadata = true
+            jdbcCompliantTruncation = false
             metadataCacheSize = 100
-            connectTimeout = 15000
             socketTimeout = 120000
+            useServerPrepStmts = false
+            useSSL = dbHost != 'localhost'
+            zeroDateTimeBehavior = 'convertToNull'
         }
     }
 }


### PR DESCRIPTION
+ Upgraded MySQL instances have better defaults re. character encoding (`utf8mb4` for proper unicode/emoji support), and in general we were due for an upgrade here.
+ Remove defaulted properties from JDBC URL, move `useSSL` flag to driver properties block along with the others.