### PR TITLE
Restore SampleGridModel's groupBy select input when restoring grid defaults

### DIFF
--- a/client-app/src/desktop/common/grid/SampleGridModel.js
+++ b/client-app/src/desktop/common/grid/SampleGridModel.js
@@ -236,6 +236,7 @@ export class SampleGridModel extends HoistModel {
 
     restoreDefaultsFn() {
         // Reset defaults to Display Options panel
+        this.setGroupBy(false);
         this.gridModel.setSizingMode(XH.sizingMode);
         this.gridModel.setHideHeaders(false);
         this.gridModel.setStripeRows(true);


### PR DESCRIPTION
Resolves #583 