### PR TITLE
Added two example monitors with a message to toolbox

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 * Demo for grid `Sparklines` renderer in Portfolio example
 * Added SlackAlertService to post StatusMonitor and ClientError alerts to the XH slack.
+* Added two simple StatusMonitors, `metric1337Monitor` and `divideByZeroMonitor`, for testing purposes.
 
 ## v2.19.0 - 2022-07-30
 

--- a/grails-app/services/io/xh/toolbox/MonitorDefinitionService.groovy
+++ b/grails-app/services/io/xh/toolbox/MonitorDefinitionService.groovy
@@ -39,6 +39,22 @@ class MonitorDefinitionService extends BaseService {
     }
 
     /**
+     * Always returns the value 1337 and a message
+     */
+    def metric1337Monitor(MonitorResult result) {
+        result.metric = 1337
+        result.message = 'This metric is always 1337!'
+    }
+
+    /**
+     * A monitor that attempts to divide by zero
+     */
+    def divideByZeroMonitor(MonitorResult result){
+        result.message = 'Trying to divide by zero'
+        result.metric = 1 / (1-1)
+    }
+
+    /**
      * Check when the last update to the news was fetched.
      * If no news stories have been fetched at all, we consider that a failure.
      */


### PR DESCRIPTION
Toolbox lacked any monitors with messages. 

One of them can be easily set to succeed / fail via the config as it returns a constant value, the other always throws an exception.

These can/should be disabled most of the time, but could be useful to have for testing monitor features.