### PR TITLE
Bug fix - `activeCol` was missing ColumnFilteringPanelModel's GridModel

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@
 * Demo for grid `Sparklines` renderer in Portfolio example
 * Added SlackAlertService to post StatusMonitor and ClientError alerts to the XH slack.
 
+### Bug Fixes
+
+* Added missing column 'Active' to `/grids/columnFiltering` grid.
+
 ## v2.19.0 - 2022-07-30
 
 ### New Features

--- a/client-app/src/desktop/tabs/grids/ColumnFilteringPanelModel.js
+++ b/client-app/src/desktop/tabs/grids/ColumnFilteringPanelModel.js
@@ -2,7 +2,7 @@ import {XH, HoistModel, managed} from '@xh/hoist/core';
 import {GridModel} from '@xh/hoist/cmp/grid';
 import {FilterChooserModel} from '@xh/hoist/cmp/filter';
 import {millionsRenderer, numberRenderer} from '@xh/hoist/format';
-import {cityCol, companyCol, profitLossCol, tradeDateCol, tradeVolumeCol} from '../../../core/columns';
+import {activeCol, cityCol, companyCol, profitLossCol, tradeDateCol, tradeVolumeCol} from '../../../core/columns';
 
 export class ColumnFilteringPanelModel extends HoistModel {
 
@@ -43,6 +43,7 @@ export class ColumnFilteringPanelModel extends HoistModel {
             colDefaults: {filterable: true},
             columns: [
                 {field: 'id', hidden: true},
+                activeCol,
                 companyCol,
                 cityCol,
                 tradeVolumeCol,


### PR DESCRIPTION
GridModel was missing a column definition for a field that was in the filterChooserModel and present in the data being loaded into the grid.

Motivated by having a boolean filterChooser field in testing of https://github.com/xh/hoist-react/pull/3149 .