### PR TITLE
Create reaction for groupRows toggle on grouped columns grid panel

### DIFF
--- a/client-app/src/desktop/common/grid/SampleColumnGroupsGrid.ts
+++ b/client-app/src/desktop/common/grid/SampleColumnGroupsGrid.ts
@@ -11,7 +11,6 @@ import {fmtMillions, fmtNumber} from '@xh/hoist/format';
 import {Icon} from '@xh/hoist/icon';
 import {bindable, makeObservable} from '@xh/hoist/mobx';
 import {createRef} from 'react';
-import {isEmpty} from 'lodash';
 import {gridOptionsPanel} from './options/GridOptionsPanel';
 import {
     actualGrossCol,
@@ -66,17 +65,19 @@ class SampleColumnGroupsGridModel extends HoistModel {
 
     @managed gridModel: GridModel;
     @bindable inMillions: boolean = false;
+    @bindable groupRows: boolean = true;
 
     panelRef = createRef<HTMLElement>();
-
-    get groupRows() {
-        return !isEmpty(this.gridModel?.groupBy);
-    }
 
     constructor() {
         super();
         makeObservable(this);
         this.gridModel = this.createGridModel();
+
+        this.addReaction(({
+            track: () => this.groupRows,
+            run: (groupRows) => this.gridModel.setGroupBy(groupRows ? ['state'] : null)
+        }));
 
         this.addReaction({
             track: () => this.inMillions,
@@ -110,7 +111,6 @@ class SampleColumnGroupsGridModel extends HoistModel {
                 idSpec: data => `${data.firstName}~${data.lastName}~${data.city}~${data.state}`
             },
             sortBy: 'lastName',
-            groupBy: 'state',
             emptyText: 'No records found...',
             colChooserModel: true,
             enableExport: true,

--- a/client-app/src/desktop/common/grid/SampleColumnGroupsGrid.ts
+++ b/client-app/src/desktop/common/grid/SampleColumnGroupsGrid.ts
@@ -76,7 +76,8 @@ class SampleColumnGroupsGridModel extends HoistModel {
 
         this.addReaction(({
             track: () => this.groupRows,
-            run: (groupRows) => this.gridModel.setGroupBy(groupRows ? ['state'] : null)
+            run: (groupRows) => {this.gridModel.setGroupBy(groupRows ? ['state'] : null)},
+            fireImmediately: true
         }));
 
         this.addReaction({


### PR DESCRIPTION
The "Group rows" toggle switch on the grouped columns example grid was not bound to any property on the model. 

This PR adds a bindable property and reaction to toggle row grouping for this grid.