### PR TITLE
Added new declare statement in Bootstrap.ts, for IntelliJ

### DIFF
--- a/client-app/src/Bootstrap.ts
+++ b/client-app/src/Bootstrap.ts
@@ -14,9 +14,7 @@ import {OauthService} from './core/svc/OauthService';
 import {TaskService} from './examples/todo/TaskService';
 
 declare module '@xh/hoist/core' {
-    // @ts-ignore - A 'duplicate declaration' that helps IntelliJ better recognize uses of app services from the `XH` singleton.
-    export const XH: XHApi;
-    // Tells typescript to *statically* assume that these services/fields exist on the `XH` singleton.
+    // Merge interface with XHApi class to include injected services.
     export interface XHApi {
         contactService: ContactService;
         gitHubService: GitHubService;
@@ -24,7 +22,9 @@ declare module '@xh/hoist/core' {
         portfolioService: PortfolioService;
         taskService: TaskService;
     }
-    //
+    // @ts-ignore - Help IntelliJ recognize uses of injected service methods on the `XH` singleton.
+    export const XH: XHApi;
+
     export interface HoistUser {
         profilePicUrl: string;
     }

--- a/client-app/src/Bootstrap.ts
+++ b/client-app/src/Bootstrap.ts
@@ -14,6 +14,9 @@ import {OauthService} from './core/svc/OauthService';
 import {TaskService} from './examples/todo/TaskService';
 
 declare module '@xh/hoist/core' {
+    // @ts-ignore - A 'duplicate declaration' that helps IntelliJ better recognize uses of app services from the `XH` singleton.
+    export const XH: XHApi;
+    // Tells typescript to *statically* assume that these services/fields exist on the `XH` singleton.
     export interface XHApi {
         contactService: ContactService;
         gitHubService: GitHubService;
@@ -21,6 +24,7 @@ declare module '@xh/hoist/core' {
         portfolioService: PortfolioService;
         taskService: TaskService;
     }
+    //
     export interface HoistUser {
         profilePicUrl: string;
     }


### PR DESCRIPTION
This is the new "declare" statement that I came up with, also added comments to hopefully explain our magic.

I ended up keeping the `interface` for XHApi because it will otherwise give `error TS2323: Cannot redeclare exported variable`.

The `XH` const re-declaration is annotated with `// @ts-ignore` as to not give the `error TS2323` like above, but IntelliJ is able to notice uses of service methods better due to it.

Without the XH line:
![image](https://user-images.githubusercontent.com/101586582/235265389-3b0d7f9b-1320-45d4-be2b-affa8f708196.png)

With the XH line:
![image](https://user-images.githubusercontent.com/101586582/235265414-439bb155-bbc3-48f5-80ae-ac0cb546f646.png)
