### PR TITLE
demo branch for Hoist React PR for new select.enableTooltipsOnTags prop

### DIFF
--- a/client-app/src/admin/tests/Select/SelectTestPanel.ts
+++ b/client-app/src/admin/tests/Select/SelectTestPanel.ts
@@ -97,13 +97,14 @@ export const SelectTestPanel = hoistCmp({
                         }
                     }),
                     example({
-                        name: 'Select with leftIcon & enableMulti & enableClear & rsOptions: {hideSelectedOptions: false, closeMenuOnSelect: false}',
+                        name: 'Select with leftIcon & enableMulti & enableTooltipsOnTags & enableClear & rsOptions: {hideSelectedOptions: false, closeMenuOnSelect: false}',
                         bind: 'enableMultiMenuOpen',
                         selectProps: {
-                            width: 350,
+                            width: 200,
                             options: usStates,
                             leftIcon: Icon.globe(),
                             enableMulti: true,
+                            enableTooltipsOnTags: true,
                             placeholder: 'Select state(s)...',
                             enableClear: true,
                             hideSelectedOptions: false,

--- a/client-app/src/admin/tests/Select/SelectTestPanel.ts
+++ b/client-app/src/admin/tests/Select/SelectTestPanel.ts
@@ -97,14 +97,14 @@ export const SelectTestPanel = hoistCmp({
                         }
                     }),
                     example({
-                        name: 'Select with leftIcon & enableMulti & enableTooltipsOnTags & enableClear & rsOptions: {hideSelectedOptions: false, closeMenuOnSelect: false}',
+                        name: 'Select with leftIcon & enableMulti & enableTooltipsOnMulti & enableClear & rsOptions: {hideSelectedOptions: false, closeMenuOnSelect: false}',
                         bind: 'enableMultiMenuOpen',
                         selectProps: {
                             width: 200,
                             options: usStates,
                             leftIcon: Icon.globe(),
                             enableMulti: true,
-                            enableTooltipsOnTags: true,
+                            enableTooltipsOnMulti: true,
                             placeholder: 'Select state(s)...',
                             enableClear: true,
                             hideSelectedOptions: false,

--- a/client-app/src/admin/tests/Select/SelectTestPanel.ts
+++ b/client-app/src/admin/tests/Select/SelectTestPanel.ts
@@ -36,9 +36,9 @@ export const SelectTestPanel = hoistCmp({
                         selectProps: customerProps
                     }),
                     example({
-                        name: 'Select queryFn & enableCreate & optionRenderer',
+                        name: 'Select queryFn & enableCreate & optionRenderer & enableTooltips',
                         bind: 'asyncCreatableValue',
-                        selectProps: {...customerProps, enableCreate: true}
+                        selectProps: {...customerProps, enableCreate: true, enableTooltips: true}
                     }),
                     example({
                         name: 'Select (with grouped options)',
@@ -97,14 +97,14 @@ export const SelectTestPanel = hoistCmp({
                         }
                     }),
                     example({
-                        name: 'Select with leftIcon & enableMulti & enableTooltipsOnMulti & enableClear & rsOptions: {hideSelectedOptions: false, closeMenuOnSelect: false}',
+                        name: 'Select with leftIcon & enableMulti & enableTooltips & enableClear & rsOptions: {hideSelectedOptions: false, closeMenuOnSelect: false}',
                         bind: 'enableMultiMenuOpen',
                         selectProps: {
                             width: 200,
                             options: usStates,
                             leftIcon: Icon.globe(),
                             enableMulti: true,
-                            enableTooltipsOnMulti: true,
+                            enableTooltips: true,
                             placeholder: 'Select state(s)...',
                             enableClear: true,
                             hideSelectedOptions: false,


### PR DESCRIPTION
Issue: https://github.com/xh/hoist-react/issues/3366
PR: https://github.com/xh/hoist-react/pull/3367
The branch reduces width of the last select on the Select Test page in Admin, and has enableTooltipsOnTags: true on the select to demo tooltips on tags.