### PR TITLE
Hide exception server logging

### DIFF
--- a/client-app/src/desktop/tabs/other/exceptions/ExceptionHandlerModel.ts
+++ b/client-app/src/desktop/tabs/other/exceptions/ExceptionHandlerModel.ts
@@ -6,7 +6,7 @@ export class ExceptionHandlerModel extends HoistModel {
     // For example options:
     @bindable title = '';
     @bindable message = '';
-    @bindable logOnServer = true;
+    @bindable logOnServer = false;
     @bindable showAlert = true;
     @bindable requireReload = false;
     @bindable alertType: 'dialog' | 'toast' = 'dialog';

--- a/client-app/src/desktop/tabs/other/exceptions/ExceptionHandlerPanel.tsx
+++ b/client-app/src/desktop/tabs/other/exceptions/ExceptionHandlerPanel.tsx
@@ -1,4 +1,4 @@
-import {creates, hoistCmp} from '@xh/hoist/core';
+import {creates, hoistCmp, XH} from '@xh/hoist/core';
 import {wrapper} from '../../../common';
 import {panel} from '@xh/hoist/desktop/cmp/panel';
 import {Icon} from '@xh/hoist/icon';
@@ -124,11 +124,13 @@ const displayOptions = hoistCmp.factory<ExceptionHandlerModel>(({model}) =>
                     placeholder: '[Exception Message]',
                     width: null
                 }),
-                switchInput({
-                    bind: 'logOnServer',
-                    label: 'Log On Server',
-                    labelSide: 'left'
-                }),
+                XH.getUser().isHoistAdmin
+                    ? switchInput({
+                          bind: 'logOnServer',
+                          label: 'Log On Server',
+                          labelSide: 'left'
+                      })
+                    : null,
                 switchInput({
                     bind: 'showAlert',
                     label: 'Show Alert',


### PR DESCRIPTION
Within `Other / Exception Handling`, the current workflow allows users quickly poking around to create real exception log files (enabled by default).

Instead, we display this toggle only for Hoist Admins, as others are unable to see the logs (via the Admin panel or otherwise) and default it to disabled.

Previously:
<img width="708" alt="image" src="https://github.com/xh/toolbox/assets/64061225/9304c749-7e66-4f12-8ff3-4a99aecc6c79">

Now (not admin):
<img width="708" alt="image" src="https://github.com/xh/toolbox/assets/64061225/97f397e2-972e-4a34-b7e8-86254e22ec69">
Now (admin:
<img width="708" alt="image" src="https://github.com/xh/toolbox/assets/64061225/af1dc059-fe87-4228-b7b8-291d0ada9da4">

