### PR TITLE
allow horizontal scrolling of the main tab switcher

### DIFF
--- a/client-app/src/desktop/AppComponent.ts
+++ b/client-app/src/desktop/AppComponent.ts
@@ -21,7 +21,7 @@ export const AppComponent = hoistCmp({
             tbar: appBar({
                 icon: img({src: xhLogo, onClick: () => model.goHome()}),
                 title: null,
-                leftItems: [tabSwitcher()],
+                leftItems: [tabSwitcher({enableOverflow: true})],
                 rightItems: [
                     webSocketIndicator({iconOnly: true, marginRight: 4}),
                     appBarSeparator()


### PR DESCRIPTION
allow the tab switcher to overflow at smaller screen widths, enabling users to access all tabs. The admin panel's switcher already has overflow enabled.