### PR TITLE
pass groupSortFn directly to DataViewModel

### DIFF
--- a/client-app/src/desktop/tabs/home/widgets/roadmap/RoadmapModel.ts
+++ b/client-app/src/desktop/tabs/home/widgets/roadmap/RoadmapModel.ts
@@ -41,12 +41,10 @@ export class RoadmapModel extends HoistModel {
         selModel: 'disabled',
         rowBorders: true,
         showHover: true,
-        gridOptions: {
-            groupSortFn: (a, b) => {
-                a = toNumber(a);
-                b = toNumber(b);
-                return this.statusFilter === 'showUpcoming' ? a - b : b - a;
-            }
+        groupSortFn: (a, b) => {
+            a = toNumber(a);
+            b = toNumber(b);
+            return this.statusFilter === 'showUpcoming' ? a - b : b - a;
         }
     });
 


### PR DESCRIPTION
In light of ![this change](https://github.com/xh/toolbox/commit/8868ca0e5a5fab5ba7b95e0968f63dd60daa2504), we identified `groupSortFn` as a first-class parameter for the `DataViewModel`. This PR reverts the call, thanks to the additional parameters introduced ![here](https://github.com/xh/hoist-react/compare/improved-DataViewModel-api)