### PR TITLE
Move createLocalAdminUserIfNeeded to before services init

### DIFF
--- a/grails-app/init/io/xh/toolbox/BootStrap.groovy
+++ b/grails-app/init/io/xh/toolbox/BootStrap.groovy
@@ -23,6 +23,7 @@ class BootStrap {
 
         ensureRequiredConfigsCreated()
         ensureRequiredPrefsCreated()
+        createLocalAdminUserIfNeeded()
 
         def services = xhServices.findAll {
             it.class.canonicalName.startsWith(this.class.package.name)
@@ -30,7 +31,6 @@ class BootStrap {
         parallelInit(services)
 
         JavaTest.helloWorld()
-        createLocalAdminUserIfNeeded()
     }
 
     def destroy = {}
@@ -58,16 +58,6 @@ class BootStrap {
             }
 
             log.info("Local admin user available as per instanceConfig | $adminUsername")
-
-            configService.ensureRequiredConfigsCreated(
-                jsLicenses: [
-                    groupName: 'Toolbox',
-                    valueType: 'json',
-                    defaultValue: [agGrid: null],
-                    clientVisible: true,
-                    note: 'Provide any js licenses needed by client here.'
-                ]
-            )
         } else {
             log.warn("Default admin user not created. To provide admin access, specify credentials in a toolbox.yml instance config file.")
         }
@@ -181,6 +171,13 @@ class BootStrap {
                     ],
                     clientVisible: true,
                     groupName: 'Toolbox'
+            ],
+            jsLicenses: [
+                    groupName: 'Toolbox',
+                    valueType: 'json',
+                    defaultValue: [agGrid: null],
+                    clientVisible: true,
+                    note: 'Provide any js licenses needed by client here.'
             ]
         ])
     }


### PR DESCRIPTION
& Move jsLicenses config into ensureRequiredConfigsCreated

I run with H2, so the DB gets recreated every time.  Maybe that helped find this issue?

Without this fix, user.hasRole(..  in RoleAdminService.ensureUserHasRoles throws an NPE because there is no user.

and then this error shows up in the UI:
![Screenshot 2024-01-10 at 5 04 37 PM](https://github.com/xh/toolbox/assets/2573928/cf13f8a5-4ba1-4225-9835-966b32affc26)
