### PR TITLE
Implement Error Handling in LineChart Panel in Portfolio example.

### DIFF
--- a/client-app/src/core/svc/PortfolioService.ts
+++ b/client-app/src/core/svc/PortfolioService.ts
@@ -3,6 +3,11 @@ import {LocalDate} from '@xh/hoist/utils/datetime';
 import {PositionSession} from '../positions/PositionSession';
 import {mapValues} from 'lodash';
 
+export class DataNotAvailableError extends Error {
+    constructor(symbol?: string) {
+        super(`Data not available for symbol: ${symbol}`);
+    }
+}
 export class PortfolioService extends HoistService {
     static instance: PortfolioService;
 
@@ -101,6 +106,9 @@ export class PortfolioService extends HoistService {
 
     async getLineChartSeriesAsync({symbol, dimension = 'volume', loadSpec}) {
         const mktData = await XH.fetchJson({url: `portfolio/prices/${symbol}`, loadSpec});
+        if (mktData) {
+            throw new DataNotAvailableError(symbol);
+        }
         return {
             name: symbol,
             type: 'line',

--- a/client-app/src/core/svc/PortfolioService.ts
+++ b/client-app/src/core/svc/PortfolioService.ts
@@ -3,11 +3,6 @@ import {LocalDate} from '@xh/hoist/utils/datetime';
 import {PositionSession} from '../positions/PositionSession';
 import {mapValues} from 'lodash';
 
-export class DataNotAvailableError extends Error {
-    constructor(symbol?: string) {
-        super(`Data not available for symbol: ${symbol}`);
-    }
-}
 export class PortfolioService extends HoistService {
     static instance: PortfolioService;
 
@@ -106,9 +101,6 @@ export class PortfolioService extends HoistService {
 
     async getLineChartSeriesAsync({symbol, dimension = 'volume', loadSpec}) {
         const mktData = await XH.fetchJson({url: `portfolio/prices/${symbol}`, loadSpec});
-        if (mktData) {
-            throw new DataNotAvailableError(symbol);
-        }
         return {
             name: symbol,
             type: 'line',

--- a/client-app/src/examples/portfolio/detail/charts/LineChart.ts
+++ b/client-app/src/examples/portfolio/detail/charts/LineChart.ts
@@ -3,14 +3,13 @@ import {creates, hoistCmp, HoistModel, lookup, managed, XH} from '@xh/hoist/core
 import {fmtDate} from '@xh/hoist/format';
 import {ChartsPanelModel} from './ChartsPanelModel';
 import {panel} from '@xh/hoist/desktop/cmp/panel';
-import {bindable} from '@xh/hoist/mobx';
 import {errorMessage} from '@xh/hoist/dynamics/desktop';
 
 export const lineChart = hoistCmp.factory({
     model: creates(() => LineChartModel),
     render({model}) {
-        if (model.error) {
-            return errorMessage({error: model.error});
+        if (model.lastLoadException) {
+            return errorMessage({error: model.lastLoadException});
         }
         return panel({
             item: chart(),
@@ -22,7 +21,6 @@ export const lineChart = hoistCmp.factory({
 
 class LineChartModel extends HoistModel {
     @lookup(ChartsPanelModel) parentModel;
-    @bindable.ref error;
 
     get symbol() {
         return this.parentModel.symbol;
@@ -76,14 +74,14 @@ class LineChartModel extends HoistModel {
 
         try {
             const series = await XH.portfolioService.getLineChartSeriesAsync({symbol, loadSpec});
-            if (!loadSpec.isObsolete) {
+            if (!loadSpec.isStale) {
                 chartModel.setSeries(series);
             }
-            this.error = null;
         } catch (e) {
-            this.error = e;
+            if (loadSpec.isAutoRefresh || loadSpec.isStale) return;
             chartModel.clear();
             XH.handleException(e, {showAlert: false});
+            throw e;
         }
     }
 }

--- a/client-app/src/examples/portfolio/detail/charts/LineChart.ts
+++ b/client-app/src/examples/portfolio/detail/charts/LineChart.ts
@@ -3,7 +3,6 @@ import {creates, hoistCmp, HoistModel, lookup, managed, XH} from '@xh/hoist/core
 import {fmtDate} from '@xh/hoist/format';
 import {ChartsPanelModel} from './ChartsPanelModel';
 import {panel} from '@xh/hoist/desktop/cmp/panel';
-import {DataNotAvailableError} from '../../../../core/svc/PortfolioService';
 import {bindable} from '@xh/hoist/mobx';
 import {errorMessage} from '@xh/hoist/dynamics/desktop';
 
@@ -69,6 +68,7 @@ class LineChartModel extends HoistModel {
 
     override async doLoadAsync(loadSpec) {
         const {symbol, chartModel} = this;
+        this.error = null;
 
         if (!symbol) {
             chartModel.clear();
@@ -82,13 +82,9 @@ class LineChartModel extends HoistModel {
                 chartModel.setSeries(series);
             }
         } catch (e) {
-            if (e instanceof DataNotAvailableError) {
-                this.error = e;
-                XH.handleException(e, {showAlert: false});
-                return;
-            }
+            this.error = e;
             chartModel.clear();
-            XH.handleException(e);
+            XH.handleException(e, {showAlert: false});
         }
     }
 }

--- a/client-app/src/examples/portfolio/detail/charts/LineChart.ts
+++ b/client-app/src/examples/portfolio/detail/charts/LineChart.ts
@@ -68,7 +68,6 @@ class LineChartModel extends HoistModel {
 
     override async doLoadAsync(loadSpec) {
         const {symbol, chartModel} = this;
-        this.error = null;
 
         if (!symbol) {
             chartModel.clear();
@@ -77,10 +76,10 @@ class LineChartModel extends HoistModel {
 
         try {
             const series = await XH.portfolioService.getLineChartSeriesAsync({symbol, loadSpec});
-
             if (!loadSpec.isObsolete) {
                 chartModel.setSeries(series);
             }
+            this.error = null;
         } catch (e) {
             this.error = e;
             chartModel.clear();

--- a/client-app/src/examples/portfolio/detail/charts/OHLCChart.ts
+++ b/client-app/src/examples/portfolio/detail/charts/OHLCChart.ts
@@ -86,7 +86,6 @@ class OHLCChartModel extends HoistModel {
 
     override async doLoadAsync(loadSpec) {
         const {symbol, chartModel} = this;
-        this.error = null;
 
         if (!symbol) {
             chartModel.clear();
@@ -98,6 +97,7 @@ class OHLCChartModel extends HoistModel {
             if (!loadSpec.isObsolete) {
                 chartModel.setSeries(series);
             }
+            this.error = null;
         } catch (e) {
             this.error = e;
             chartModel.clear();

--- a/grails-app/controllers/io/xh/toolbox/portfolio/PortfolioController.groovy
+++ b/grails-app/controllers/io/xh/toolbox/portfolio/PortfolioController.groovy
@@ -1,5 +1,6 @@
 package io.xh.toolbox.portfolio
 
+import io.xh.hoist.exception.DataNotAvailableException
 import io.xh.hoist.security.AccessAll
 import io.xh.toolbox.BaseController
 
@@ -48,6 +49,9 @@ class PortfolioController extends BaseController {
     // List of MarketPrices for the given instrument identified by its symbol
     def prices() {
         List<MarketPrice> historicalPrices = portfolioService.getData().historicalPrices[params.id]
+        if (!historicalPrices) {
+            throw new DataNotAvailableException("No historical prices available for ${params.id}")
+        }
         MarketPrice intradayPrices = portfolioService.getData().intradayPrices[params.id]
         List<MarketPrice> allPrices = intradayPrices ? historicalPrices.dropRight(1)+[intradayPrices] : historicalPrices
         renderJSON(allPrices)


### PR DESCRIPTION
**Before:**
<img width="699" alt="Screenshot 2024-03-12 at 12 12 24 PM" src="https://github.com/xh/toolbox/assets/163027616/7cb980b0-2864-43c9-a1f8-51f742c0b3ff">

**After**
<img width="699" alt="Screenshot 2024-03-12 at 12 11 56 PM" src="https://github.com/xh/toolbox/assets/163027616/9ada2cd5-a847-4e68-98f9-a7cba251ca87">


**Commit History:**
feature(portfolio-ex): added error handling to line chart panel when market data is null
feat(portfolio-ex): throw error from portfolio controller and render error message in chart panels


**Note:**
My first PR, just trying to get used to the workflow. 