### PR TITLE
UserService methods can now return User rather than HoistUser

### DIFF
--- a/grails-app/services/io/xh/toolbox/security/AuthenticationService.groovy
+++ b/grails-app/services/io/xh/toolbox/security/AuthenticationService.groovy
@@ -2,7 +2,6 @@ package io.xh.toolbox.security
 
 import grails.gorm.transactions.ReadOnly
 import io.xh.hoist.security.BaseAuthenticationService
-import io.xh.hoist.user.HoistUser
 import io.xh.toolbox.user.User
 import io.xh.toolbox.user.UserService
 
@@ -73,7 +72,7 @@ class AuthenticationService extends BaseAuthenticationService  {
     // Implementation
     //------------------------
     @ReadOnly
-    private HoistUser lookupUser(String username, String password) {
+    private User lookupUser(String username, String password) {
         def user = User.findByEmailAndEnabled(username, true)
         return user?.checkPassword(password) ? user : null
     }

--- a/grails-app/services/io/xh/toolbox/user/UserService.groovy
+++ b/grails-app/services/io/xh/toolbox/user/UserService.groovy
@@ -4,7 +4,6 @@ import io.xh.hoist.email.EmailService
 import grails.gorm.transactions.ReadOnly
 import grails.gorm.transactions.Transactional
 import io.xh.hoist.user.BaseUserService
-import io.xh.hoist.user.HoistUser
 import io.xh.hoist.util.Utils
 import io.xh.toolbox.security.TokenValidationResult
 
@@ -13,12 +12,12 @@ class UserService extends BaseUserService {
     EmailService emailService
 
     @ReadOnly
-    List<HoistUser> list(boolean activeOnly) {
+    List<User> list(boolean activeOnly) {
         return activeOnly ? User.findAllByEnabled(true) : User.list()
     }
 
     @ReadOnly
-    HoistUser find(String username) {
+    User find(String username) {
         return User.findByEmail(username)
     }
 
@@ -37,7 +36,7 @@ class UserService extends BaseUserService {
      * explicitly linked/registered to multiple social providers. That's overkill for Toolbox.
      */
     @Transactional
-    HoistUser getOrCreateFromTokenResult(TokenValidationResult tokenResult) {
+    User getOrCreateFromTokenResult(TokenValidationResult tokenResult) {
         def email = tokenResult.email,
             name = tokenResult.name,
             profilePicUrl = tokenResult.picture,


### PR DESCRIPTION
Companion to https://github.com/xh/hoist-core/pull/360

Toolbox's `UserService.groovy` is now allowed to use its own `User` type, rather than being forced to refer to User by `HoistUser`.