### PR TITLE
Added composite build settings.gradle file for running hoist inline

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -43,19 +43,10 @@ springBoot {
     mainClass = xhAppPackage + ".Application"
 }
 
-if (parseBoolean(runHoistInline)) {
-    println "${xhAppName}: running with Hoist Core INLINE...."
-    grails.plugins {
-        implementation project(":hoist-core")
-    }
-} else {
-    println "${xhAppName}: running with Hoist Core PACKAGED at v${hoistCoreVersion}...."
-    dependencies {
-        implementation "io.xh:hoist-core:$hoistCoreVersion"
-    }
-}
-
 dependencies {
+    // If `runHoistInline` is true, `hoistCoreVersion` will be ignored and local hoist-core will be used instead.
+    implementation "io.xh:hoist-core:$hoistCoreVersion"
+
     // For server-side JWT validation.
     implementation "org.bitbucket.b_c:jose4j:0.9.6"
 

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,0 +1,11 @@
+import static java.lang.Boolean.parseBoolean
+
+rootProject.name = 'toolbox'
+
+// Composite build setup for compiling hoist-core locally
+if (parseBoolean(runHoistInline)) {
+    println "${xhAppName}: running with Hoist Core INLINE...."
+    includeBuild '../hoist-core'
+}else {
+    println "${xhAppName}: running with Hoist Core PACKAGED at v${hoistCoreVersion}...."
+}


### PR DESCRIPTION
Added a `settings.gradle` file to the toolbox app.

It is capable of running toolbox as a normal hoist app, in addition to being able to run toolbox with local hoist using the gradle composite build (`includeBuild`).

With this, the wrapper directory containing both toolbox and hoist-core no longer needs to have gradle installed nor have its own `settings.gradle` file.