### PR TITLE
Stop news app items from overflowing their parent container

### DIFF
--- a/client-app/src/examples/news/NewsPanelItem.scss
+++ b/client-app/src/examples/news/NewsPanelItem.scss
@@ -1,4 +1,8 @@
 .tb-news-panel {
+  & .ag-row {
+    overflow: hidden;
+  }
+
   .news-item {
     p,
     span {


### PR DESCRIPTION
The news page loads visually correct initially, but on scrolling items out then back onto screen we would see the content of an individual item overflow the parent.

**_Initial:_**
<img width="840" alt="Screenshot 2025-03-13 at 3 00 12 PM" src="https://github.com/user-attachments/assets/2337bf40-8a64-43ff-8cd2-170d692cdc56" />


**_After scrolling out then back into view:_**
<img width="835" alt="Screenshot 2025-03-13 at 3 00 19 PM" src="https://github.com/user-attachments/assets/e435a2e4-b69e-4863-baa3-4b4a860eb44d" />

This is a side effect of the virtual pagination used by AG grid. Technically these items were already breaking out of their parent's container on load. We just dont see it because the items were stacked top to bottom in their containing DIV, and so each item's z-index was lower than the next item in the list, and said next item would cover the accidental overflow.

Once we start to scroll, AG grid starts shifting / pushing grid element into and out of the parent, and using translation CSS definitions to keep them visually positioned correct in the overall list. However, this does NOT manage relative z-indexing. So the top item in the list may become the last item in the element stack, and while its X/Y position is correct, its relative Z position no longer is.

The quickest fix here is to clip all overflow for each item on the parent itself.