### PR TITLE
Skip cache testing service inits in local dev by default

### DIFF
--- a/grails-app/services/io/xh/toolbox/admin/TestCacheService.groovy
+++ b/grails-app/services/io/xh/toolbox/admin/TestCacheService.groovy
@@ -8,6 +8,8 @@ import io.xh.hoist.cache.CacheEntryChanged
 import java.time.LocalDate
 
 import static io.xh.hoist.util.DateTimeUtils.SECONDS
+import static io.xh.hoist.util.InstanceConfigUtils.getInstanceConfig
+import static io.xh.hoist.util.Utils.isLocalDevelopment
 import static java.lang.Thread.sleep
 import static TestUtils.*
 
@@ -36,7 +38,12 @@ class TestCacheService extends BaseService {
 
     void init() {
         super.init()
-        initData()
+
+        if (isLocalDevelopment && !getInstanceConfig('initTestCacheServices')) {
+            logInfo("Disabled by default in local development mode - set initTestCacheServices instance config to override")
+        } else {
+            initData()
+        }
     }
 
     private void initData() {

--- a/grails-app/services/io/xh/toolbox/admin/TestCachedValueService.groovy
+++ b/grails-app/services/io/xh/toolbox/admin/TestCachedValueService.groovy
@@ -6,6 +6,8 @@ import io.xh.hoist.cachedvalue.CachedValue
 import io.xh.hoist.cachedvalue.CachedValueChanged
 
 import static io.xh.hoist.util.DateTimeUtils.SECONDS
+import static io.xh.hoist.util.InstanceConfigUtils.getInstanceConfig
+import static io.xh.hoist.util.Utils.getIsLocalDevelopment
 import static io.xh.toolbox.admin.TestUtils.generatePrice
 import static io.xh.toolbox.admin.TestUtils.generateResultSet
 
@@ -33,8 +35,13 @@ class TestCachedValueService extends BaseService {
 
     void init() {
         super.init()
-        if (isPrimary) initData()
-        resultValue.ensureAvailable()
+
+        if (isLocalDevelopment && !getInstanceConfig('initTestCacheServices')) {
+            logInfo("Disabled by default in local development mode - set initTestCacheServices instance config to override")
+        } else {
+            if (isPrimary) initData()
+            resultValue.ensureAvailable()
+        }
     }
 
     private void initData() {


### PR DESCRIPTION
- 15s wait introduced by TestCacheService seems unfortunate for every local start of toolbox - disable both of these services by default, but provide instance config to allow a dev who wants to run them locally to keep them on.