### PR TITLE
Added example of inline editing inside of a modal

### DIFF
--- a/client-app/src/desktop/tabs/grids/InlineEditingPanel.tsx
+++ b/client-app/src/desktop/tabs/grids/InlineEditingPanel.tsx
@@ -12,6 +12,7 @@ import {gridOptionsPanel} from '../../common/grid/options/GridOptionsPanel';
 import './InlineEditingPanel.scss';
 import {InlineEditingPanelModel} from './InlineEditingPanelModel';
 import React from 'react';
+import classNames from 'classnames';
 
 export const inlineEditingPanel = hoistCmp.factory({
     model: creates(InlineEditingPanelModel),
@@ -47,12 +48,15 @@ export const inlineEditingPanel = hoistCmp.factory({
             item: panel({
                 title: 'Grids › Inline Editing',
                 icon: Icon.edit(),
-                className: `tb-grid-wrapper-panel tb-inline-editing-panel ${
+                className: classNames(
+                    model.isModal ? '' : 'tb-grid-wrapper-panel',
+                    'tb-inline-editing-panel',
                     model.fullRowEditing ? 'tb-inline-editing-panel--fullRow' : ''
-                }`,
+                ),
                 tbar: tbar(),
-                item: hframe(grid(), gridOptionsPanel()),
-                bbar: bbar()
+                item: hframe(grid({agOptions: {popupParent: null}}), gridOptionsPanel()),
+                bbar: bbar(),
+                model: model.panelModel
             })
         });
     }

--- a/client-app/src/desktop/tabs/grids/InlineEditingPanelModel.ts
+++ b/client-app/src/desktop/tabs/grids/InlineEditingPanelModel.ts
@@ -11,6 +11,7 @@ import {
     textAreaEditor,
     textEditor
 } from '@xh/hoist/desktop/cmp/grid';
+import {PanelModel} from '@xh/hoist/desktop/cmp/panel';
 import {fmtDate} from '@xh/hoist/format';
 import {Icon} from '@xh/hoist/icon';
 import {action, bindable, makeObservable, observable} from '@xh/hoist/mobx';
@@ -35,6 +36,13 @@ export class InlineEditingPanelModel extends HoistModel {
     @bindable
     clicksToEdit = 2;
 
+    @managed
+    panelModel: PanelModel;
+
+    get isModal() {
+        return this.panelModel?.isModal;
+    }
+
     get clicksToEditNote() {
         const {clicksToEdit} = this;
         if (clicksToEdit === 1) return 'Single-click a row above to edit';
@@ -45,6 +53,7 @@ export class InlineEditingPanelModel extends HoistModel {
     constructor() {
         super();
         makeObservable(this);
+        this.panelModel = this.createPanelModel();
         this.store = this.createStore();
         this.gridModel = this.createGridModel();
 
@@ -137,6 +146,13 @@ export class InlineEditingPanelModel extends HoistModel {
         this.store.revertRecords(record);
     }
 
+    private createPanelModel() {
+        return new PanelModel({
+            modalSupport: true,
+            collapsible: false,
+            resizable: false
+        });
+    }
     private createStore() {
         return new Store({
             validationIsComplex: false,


### PR DESCRIPTION
Added modal to the inline editing example, and included how to fix this:
```ts
grid({agOptions: {popupParent: null}})
```