### PR TITLE
Remove use of `xh-hardeners` partial

### DIFF
--- a/docker/nginx/app.conf
+++ b/docker/nginx/app.conf
@@ -69,7 +69,10 @@ server {
     location ^~ /api/ {
         proxy_pass http://localhost:8080/;
         include includes/xh-proxy.conf;
-        include includes/xh-hardeners.conf;
+
+        # Set Cookie policy to enforce HTTPS via "Secure", but also allow cross-site access.
+        # This supports accepting e.g. JSESSIONID from a remote Hoist app to allow Config Differ to continue to work.
+        proxy_cookie_path / "/; HTTPOnly; Secure; SameSite=None";
     }
 
     # Static JS/CSS/etc assets not matching a more specific entry-point selector above.


### PR DESCRIPTION
- That partial includes a call to `add_header` for `X-Frame-Options`, already set in our top-level config.
- As per nginx docs @ https://nginx.org/en/docs/http/ngx_http_headers_module.html: "There could be several add_header directives. These directives are inherited from the previous configuration level if and only if there are no add_header directives defined on the current level."
- This change inlines the one remaining directive from `xh-hardeners.conf` for `proxy_cookie_path` and otherwise allows the top-level headers to flow through as expected.