### PR TITLE
Add Weather Dashboard example app

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 ## 9.0-SNAPSHOT - unreleased
 
+### New Features
+
+* Added Weather Dashboard example app — a full-stack weather dashboard backed by the OpenWeatherMap
+  API, featuring a `DashCanvas` layout with multiple chart types and a grid summary view. Server-side
+  caching via Hoist `Cache`, city persistence via `@persist`, and `ViewManager` support for saved
+  layouts. This example was coded entirely by AI (Claude) without any human-written application code.
+
 ## 8.0.0 - 2026-02-03
 
 ### New Features

--- a/client-app/src/Bootstrap.ts
+++ b/client-app/src/Bootstrap.ts
@@ -139,6 +139,10 @@ import 'highcharts/modules/exporting';
 import 'highcharts/modules/heatmap';
 import 'highcharts/modules/treemap';
 
+// `highcharts-more` must be imported before `solid-gauge`
+import 'highcharts/highcharts-more';
+import 'highcharts/modules/solid-gauge';
+
 // `treegraph` must be imported after `treemap`
 import 'highcharts/modules/treegraph';
 

--- a/client-app/src/apps/weather.ts
+++ b/client-app/src/apps/weather.ts
@@ -1,0 +1,20 @@
+import '../Bootstrap';
+
+import {XH} from '@xh/hoist/core';
+import {AppContainer} from '@xh/hoist/desktop/appcontainer';
+import {AppComponent} from '../examples/weather/AppComponent';
+import {AppModel} from '../examples/weather/AppModel';
+import {AuthModel} from '../core/AuthModel';
+
+XH.renderApp({
+    clientAppCode: 'weather',
+    clientAppName: 'XH Weather',
+    componentClass: AppComponent,
+    modelClass: AppModel,
+    containerClass: AppContainer,
+    authModelClass: AuthModel,
+    isMobileApp: false,
+    enableLogout: true,
+    showBrowserContextMenu: true,
+    checkAccess: () => true
+});

--- a/client-app/src/desktop/tabs/examples/ExamplesTabModel.tsx
+++ b/client-app/src/desktop/tabs/examples/ExamplesTabModel.tsx
@@ -35,6 +35,26 @@ export class ExamplesTabModel extends HoistModel {
             ]
         },
         {
+            title: 'Weather',
+            icon: Icon.sun(),
+            path: 'weather',
+            srcPath: 'weather',
+            text: [
+                <p>
+                    A weather dashboard backed by the OpenWeatherMap API, with server-side caching
+                    and auto-refresh.
+                </p>,
+                <p>
+                    Uses a <code>DashCanvas</code> layout with multiple chart types and a{' '}
+                    <code>Grid</code> summary view.
+                </p>,
+                <p>
+                    ✨This example was coded entirely by AI (Claude) without any human-written
+                    application code.
+                </p>
+            ]
+        },
+        {
             title: 'Contact',
             icon: Icon.users(),
             path: 'contact',

--- a/client-app/src/examples/weather/AppComponent.ts
+++ b/client-app/src/examples/weather/AppComponent.ts
@@ -1,0 +1,48 @@
+import {relativeTimestamp} from '@xh/hoist/cmp/relativetimestamp';
+import {hoistCmp, uses} from '@xh/hoist/core';
+import {appBar, appBarSeparator} from '@xh/hoist/desktop/cmp/appbar';
+import {select} from '@xh/hoist/desktop/cmp/input';
+import {panel} from '@xh/hoist/desktop/cmp/panel';
+import {dashCanvas} from '@xh/hoist/desktop/cmp/dash';
+import {viewManager} from '@xh/hoist/desktop/cmp/viewmanager';
+import {Icon} from '@xh/hoist/icon';
+import {AppModel} from './AppModel';
+import {CITIES} from './WeatherDashModel';
+import '../../core/Toolbox.scss';
+import './Weather.scss';
+
+export const AppComponent = hoistCmp({
+    displayName: 'App',
+    model: uses(AppModel),
+
+    render({model}) {
+        const {weatherDashModel} = model;
+        return panel({
+            tbar: appBar({
+                icon: Icon.sun({size: '2x', prefix: 'fal'}),
+                leftItems: [
+                    select({
+                        model: weatherDashModel,
+                        bind: 'selectedCity',
+                        options: CITIES,
+                        enableFilter: true,
+                        width: 200
+                    }),
+                    appBarSeparator(),
+                    viewManager()
+                ],
+                rightItems: [
+                    relativeTimestamp({
+                        model: weatherDashModel,
+                        bind: 'lastLoadCompleted',
+                        prefix: 'Updated:'
+                    }),
+                    appBarSeparator()
+                ],
+                appMenuButtonProps: {hideLogoutItem: false}
+            }),
+            item: dashCanvas({model: weatherDashModel.dashCanvasModel}),
+            className: 'weather-app'
+        });
+    }
+});

--- a/client-app/src/examples/weather/AppModel.ts
+++ b/client-app/src/examples/weather/AppModel.ts
@@ -1,0 +1,37 @@
+import {managed, XH} from '@xh/hoist/core';
+import {ViewManagerModel} from '@xh/hoist/cmp/viewmanager';
+import {
+    autoRefreshAppOption,
+    themeAppOption,
+    sizingModeAppOption
+} from '@xh/hoist/desktop/cmp/appOption';
+import {BaseAppModel} from '../../BaseAppModel';
+import {WeatherDashModel} from './WeatherDashModel';
+
+export class AppModel extends BaseAppModel {
+    static instance: AppModel;
+    @managed weatherDashModel: WeatherDashModel;
+    @managed weatherViewManager: ViewManagerModel;
+
+    override async initAsync() {
+        await super.initAsync();
+
+        this.weatherViewManager = await ViewManagerModel.createAsync({
+            type: 'weatherDashboard',
+            typeDisplayName: 'Layout',
+            enableDefault: true,
+            manageGlobal: XH.getUser().isHoistAdmin
+        });
+
+        this.weatherDashModel = new WeatherDashModel(this.weatherViewManager);
+        this.loadAsync();
+    }
+
+    override async doLoadAsync(loadSpec) {
+        await this.weatherDashModel.loadAsync(loadSpec);
+    }
+
+    override getAppOptions() {
+        return [themeAppOption(), sizingModeAppOption(), autoRefreshAppOption()];
+    }
+}

--- a/client-app/src/examples/weather/Icons.ts
+++ b/client-app/src/examples/weather/Icons.ts
@@ -1,0 +1,17 @@
+import {library} from '@fortawesome/fontawesome-svg-core';
+import {
+    faCloudRain,
+    faDropletPercent,
+    faCalendarDays,
+    faTemperatureHalf,
+    faWind
+} from '@fortawesome/pro-regular-svg-icons';
+import {Icon} from '@xh/hoist/icon';
+
+library.add(faCloudRain, faDropletPercent, faCalendarDays, faTemperatureHalf, faWind);
+
+export const temperatureIcon = (opts = {}) => Icon.icon({iconName: 'temperature-half', ...opts});
+export const cloudRainIcon = (opts = {}) => Icon.icon({iconName: 'cloud-rain', ...opts});
+export const windIcon = (opts = {}) => Icon.icon({iconName: 'wind', ...opts});
+export const dropletPercentIcon = (opts = {}) => Icon.icon({iconName: 'droplet-percent', ...opts});
+export const calendarDaysIcon = (opts = {}) => Icon.icon({iconName: 'calendar-days', ...opts});

--- a/client-app/src/examples/weather/Types.ts
+++ b/client-app/src/examples/weather/Types.ts
@@ -1,0 +1,31 @@
+export interface CurrentWeatherResponse {
+    weather: WeatherCondition[];
+    main: {temp: number; feels_like: number; humidity: number; pressure: number};
+    wind: {speed: number; gust?: number};
+}
+
+export interface ForecastResponse {
+    list: ForecastItem[];
+}
+
+export interface ForecastItem {
+    dt: number;
+    main: {
+        temp: number;
+        feels_like: number;
+        humidity: number;
+        pressure: number;
+        temp_max: number;
+        temp_min: number;
+    };
+    weather: WeatherCondition[];
+    wind: {speed: number; gust?: number};
+    rain?: {'3h': number};
+    pop: number;
+}
+
+export interface WeatherCondition {
+    main: string;
+    description: string;
+    icon: string;
+}

--- a/client-app/src/examples/weather/Weather.scss
+++ b/client-app/src/examples/weather/Weather.scss
@@ -1,0 +1,36 @@
+.weather-app {
+  height: 100%;
+}
+
+.weather-current-conditions {
+  height: 100%;
+
+  &__gauge {
+    flex: 1;
+    min-height: 0;
+    width: 100%;
+    max-width: 400px;
+  }
+
+  &__details {
+    padding: 4px 12px 8px;
+    align-items: center;
+    justify-content: center;
+    gap: 8px;
+  }
+
+  &__icon {
+    width: 48px;
+    height: 48px;
+  }
+
+  &__text {
+    font-size: 12px;
+    gap: 2px;
+  }
+
+  &__description {
+    font-weight: 600;
+    font-size: 13px;
+  }
+}

--- a/client-app/src/examples/weather/WeatherDashModel.ts
+++ b/client-app/src/examples/weather/WeatherDashModel.ts
@@ -1,0 +1,157 @@
+import {HoistModel, LoadSpec, managed, persist, XH} from '@xh/hoist/core';
+import {ViewManagerModel} from '@xh/hoist/cmp/viewmanager';
+import {DashCanvasModel} from '@xh/hoist/desktop/cmp/dash';
+import {bindable, makeObservable, observable, runInAction} from '@xh/hoist/mobx';
+import {Icon} from '@xh/hoist/icon';
+
+import {
+    calendarDaysIcon,
+    cloudRainIcon,
+    dropletPercentIcon,
+    temperatureIcon,
+    windIcon
+} from './Icons';
+import {CurrentWeatherResponse, ForecastResponse} from './Types';
+import {currentConditionsWidget} from './widgets/CurrentConditionsWidget';
+import {tempForecastWidget} from './widgets/TempForecastWidget';
+import {precipForecastWidget} from './widgets/PrecipForecastWidget';
+import {windForecastWidget} from './widgets/WindForecastWidget';
+import {humidityPressureWidget} from './widgets/HumidityPressureWidget';
+import {conditionsSummaryWidget} from './widgets/ConditionsSummaryWidget';
+
+export const CITIES = [
+    'Atlanta',
+    'Austin',
+    'Boston',
+    'Chicago',
+    'Dallas',
+    'Denver',
+    'Houston',
+    'Las Vegas',
+    'London',
+    'Los Angeles',
+    'Miami',
+    'Minneapolis',
+    'Nashville',
+    'New York',
+    'Paris',
+    'Philadelphia',
+    'Phoenix',
+    'Portland',
+    'San Antonio',
+    'San Diego',
+    'San Francisco',
+    'Seattle',
+    'Sydney',
+    'Tokyo',
+    'Toronto'
+];
+
+export class WeatherDashModel extends HoistModel {
+    override persistWith = {localStorageKey: 'xhWeatherDash'};
+
+    @bindable @persist selectedCity: string = 'New York';
+    @observable.ref currentWeather: CurrentWeatherResponse = null;
+    @observable.ref forecast: ForecastResponse = null;
+
+    viewManagerModel: ViewManagerModel;
+    @managed dashCanvasModel: DashCanvasModel;
+
+    constructor(viewManagerModel: ViewManagerModel) {
+        super();
+        makeObservable(this);
+
+        this.viewManagerModel = viewManagerModel;
+        this.dashCanvasModel = new DashCanvasModel({
+            persistWith: {viewManagerModel},
+            viewSpecDefaults: {
+                unique: true
+            },
+            viewSpecs: [
+                {
+                    id: 'currentConditions',
+                    title: 'Current Conditions',
+                    icon: Icon.sun(),
+                    content: currentConditionsWidget,
+                    width: 4,
+                    height: 5
+                },
+                {
+                    id: 'tempForecast',
+                    title: 'Temperature Forecast',
+                    icon: temperatureIcon(),
+                    content: tempForecastWidget,
+                    width: 8,
+                    height: 5
+                },
+                {
+                    id: 'precipForecast',
+                    title: 'Precipitation',
+                    icon: cloudRainIcon(),
+                    content: precipForecastWidget,
+                    width: 6,
+                    height: 5
+                },
+                {
+                    id: 'windForecast',
+                    title: 'Wind',
+                    icon: windIcon(),
+                    content: windForecastWidget,
+                    width: 6,
+                    height: 5
+                },
+                {
+                    id: 'humidityPressure',
+                    title: 'Humidity & Pressure',
+                    icon: dropletPercentIcon(),
+                    content: humidityPressureWidget,
+                    width: 6,
+                    height: 5
+                },
+                {
+                    id: 'conditionsSummary',
+                    title: '5-Day Summary',
+                    icon: calendarDaysIcon(),
+                    content: conditionsSummaryWidget,
+                    width: 6,
+                    height: 5
+                }
+            ],
+            initialState: [
+                {viewSpecId: 'currentConditions', layout: {x: 0, y: 0, w: 4, h: 5}},
+                {viewSpecId: 'tempForecast', layout: {x: 4, y: 0, w: 8, h: 5}},
+                {viewSpecId: 'precipForecast', layout: {x: 0, y: 5, w: 6, h: 5}},
+                {viewSpecId: 'windForecast', layout: {x: 6, y: 5, w: 6, h: 5}},
+                {viewSpecId: 'humidityPressure', layout: {x: 0, y: 10, w: 6, h: 5}},
+                {viewSpecId: 'conditionsSummary', layout: {x: 6, y: 10, w: 6, h: 5}}
+            ]
+        });
+
+        this.addReaction({
+            track: () => this.selectedCity,
+            run: () => this.loadAsync()
+        });
+    }
+
+    override async doLoadAsync(loadSpec: LoadSpec) {
+        const {selectedCity} = this;
+        if (!selectedCity) return;
+
+        try {
+            const [currentWeather, forecast] = await Promise.all([
+                XH.fetchJson({url: 'weather/current', params: {city: selectedCity}, loadSpec}),
+                XH.fetchJson({url: 'weather/forecast', params: {city: selectedCity}, loadSpec})
+            ]);
+
+            if (loadSpec.isStale) return;
+
+            runInAction(() => {
+                this.currentWeather = currentWeather;
+                this.forecast = forecast;
+            });
+        } catch (e) {
+            if (loadSpec.isAutoRefresh || loadSpec.isStale) return;
+            XH.handleException(e);
+        }
+    }
+}

--- a/client-app/src/examples/weather/widgets/ConditionsSummaryWidget.ts
+++ b/client-app/src/examples/weather/widgets/ConditionsSummaryWidget.ts
@@ -1,0 +1,143 @@
+import {grid, GridModel} from '@xh/hoist/cmp/grid';
+import {img} from '@xh/hoist/cmp/layout';
+import {creates, hoistCmp, HoistModel, managed} from '@xh/hoist/core';
+import {panel} from '@xh/hoist/desktop/cmp/panel';
+import {makeObservable} from '@xh/hoist/mobx';
+import {groupBy} from 'lodash';
+import {ForecastResponse} from '../Types';
+import {AppModel} from '../AppModel';
+
+export const conditionsSummaryWidget = hoistCmp.factory({
+    model: creates(() => ConditionsSummaryModel),
+
+    render() {
+        return panel({
+            item: grid()
+        });
+    }
+});
+
+class ConditionsSummaryModel extends HoistModel {
+    @managed gridModel: GridModel;
+
+    constructor() {
+        super();
+        makeObservable(this);
+    }
+
+    override onLinked() {
+        this.gridModel = this.createGridModel();
+
+        this.addReaction({
+            track: () => AppModel.instance.weatherDashModel.forecast,
+            run: data => this.updateGrid(data),
+            fireImmediately: true
+        });
+    }
+
+    private createGridModel(): GridModel {
+        return new GridModel({
+            sortBy: 'date',
+            emptyText: 'No forecast data available.',
+            columns: [
+                {
+                    field: 'date',
+                    headerName: 'Day',
+                    width: 120,
+                    renderer: v => {
+                        const d = new Date(v);
+                        return d.toLocaleDateString('en-US', {
+                            weekday: 'short',
+                            month: 'short',
+                            day: 'numeric'
+                        });
+                    }
+                },
+                {
+                    field: 'icon',
+                    headerName: '',
+                    width: 50,
+                    rendererIsComplex: true,
+                    renderer: (v, {record}) => {
+                        return img({
+                            src: `https://openweathermap.org/img/wn/${v}.png`,
+                            alt: record.data.conditions,
+                            width: 32,
+                            height: 32
+                        });
+                    },
+                    exportValue: (v, {record}) => record.data.conditions
+                },
+                {
+                    field: 'conditions',
+                    headerName: 'Conditions',
+                    flex: 1
+                },
+                {
+                    field: 'high',
+                    headerName: 'High',
+                    width: 70,
+                    align: 'right',
+                    renderer: v => `${v}°F`
+                },
+                {
+                    field: 'low',
+                    headerName: 'Low',
+                    width: 70,
+                    align: 'right',
+                    renderer: v => `${v}°F`
+                },
+                {
+                    field: 'humidity',
+                    headerName: 'Humidity',
+                    width: 80,
+                    align: 'right',
+                    renderer: v => `${v}%`
+                },
+                {
+                    field: 'wind',
+                    headerName: 'Wind',
+                    width: 80,
+                    align: 'right',
+                    renderer: v => `${v} mph`
+                }
+            ]
+        });
+    }
+
+    private updateGrid(data: ForecastResponse) {
+        if (!data?.list) {
+            this.gridModel.clear();
+            return;
+        }
+
+        const items = data.list,
+            byDay = groupBy(items, item => {
+                const d = new Date(item.dt * 1000);
+                return `${d.getFullYear()}-${d.getMonth()}-${d.getDate()}`;
+            });
+
+        const rows = Object.entries(byDay).map(([_key, dayItems], idx) => {
+            const highs = dayItems.map(it => it.main.temp_max),
+                lows = dayItems.map(it => it.main.temp_min),
+                humidities = dayItems.map(it => it.main.humidity),
+                winds = dayItems.map(it => it.wind?.speed ?? 0),
+                midItem = dayItems[Math.floor(dayItems.length / 2)],
+                conditions = midItem.weather?.[0]?.main ?? '',
+                icon = midItem.weather?.[0]?.icon ?? '01d';
+
+            return {
+                id: idx,
+                date: dayItems[0].dt * 1000,
+                icon,
+                conditions,
+                high: Math.round(Math.max(...highs)),
+                low: Math.round(Math.min(...lows)),
+                humidity: Math.round(humidities.reduce((a, b) => a + b, 0) / humidities.length),
+                wind: Math.round(winds.reduce((a, b) => a + b, 0) / winds.length)
+            };
+        });
+
+        this.gridModel.loadData(rows);
+    }
+}

--- a/client-app/src/examples/weather/widgets/CurrentConditionsWidget.ts
+++ b/client-app/src/examples/weather/widgets/CurrentConditionsWidget.ts
@@ -1,0 +1,160 @@
+import {chart, ChartModel} from '@xh/hoist/cmp/chart';
+import {div, hbox, img, vbox} from '@xh/hoist/cmp/layout';
+import {creates, hoistCmp, HoistModel, managed} from '@xh/hoist/core';
+import {makeObservable} from '@xh/hoist/mobx';
+import {CurrentWeatherResponse} from '../Types';
+import {AppModel} from '../AppModel';
+
+export const currentConditionsWidget = hoistCmp.factory({
+    model: creates(() => CurrentConditionsModel),
+
+    render({model}) {
+        const {currentWeather} = AppModel.instance.weatherDashModel;
+        if (!currentWeather) return null;
+
+        const description = currentWeather.weather?.[0]?.description ?? '',
+            iconCode = currentWeather.weather?.[0]?.icon,
+            feelsLike = currentWeather.main?.feels_like,
+            humidity = currentWeather.main?.humidity,
+            wind = currentWeather.wind?.speed;
+
+        return vbox({
+            className: 'weather-current-conditions',
+            alignItems: 'center',
+            flex: 1,
+            items: [
+                chart({className: 'weather-current-conditions__gauge'}),
+                hbox({
+                    className: 'weather-current-conditions__details',
+                    items: [
+                        iconCode
+                            ? img({
+                                  className: 'weather-current-conditions__icon',
+                                  src: `https://openweathermap.org/img/wn/${iconCode}@2x.png`,
+                                  alt: description
+                              })
+                            : null,
+                        vbox({
+                            className: 'weather-current-conditions__text',
+                            items: [
+                                div({
+                                    className: 'weather-current-conditions__description',
+                                    item: description.charAt(0).toUpperCase() + description.slice(1)
+                                }),
+                                div({
+                                    item: [
+                                        feelsLike != null
+                                            ? `Feels like ${Math.round(feelsLike)}°F`
+                                            : null,
+                                        humidity != null ? `Humidity: ${humidity}%` : null,
+                                        wind != null ? `Wind: ${Math.round(wind)} mph` : null
+                                    ]
+                                        .filter(Boolean)
+                                        .join(' · ')
+                                })
+                            ]
+                        })
+                    ]
+                })
+            ]
+        });
+    }
+});
+
+class CurrentConditionsModel extends HoistModel {
+    @managed chartModel: ChartModel;
+
+    constructor() {
+        super();
+        makeObservable(this);
+    }
+
+    override onLinked() {
+        this.chartModel = this.createChartModel();
+
+        this.addReaction({
+            track: () => AppModel.instance.weatherDashModel.currentWeather,
+            run: data => this.updateChart(data),
+            fireImmediately: true
+        });
+    }
+
+    private createChartModel(): ChartModel {
+        return new ChartModel({
+            highchartsConfig: {
+                chart: {
+                    type: 'solidgauge'
+                },
+                title: {text: null},
+                pane: {
+                    center: ['50%', '70%'],
+                    size: '130%',
+                    startAngle: -90,
+                    endAngle: 90,
+                    background: {
+                        innerRadius: '60%',
+                        outerRadius: '100%',
+                        shape: 'arc',
+                        borderWidth: 0,
+                        backgroundColor: '#eeeeee'
+                    }
+                },
+                yAxis: {
+                    min: -20,
+                    max: 120,
+                    lineWidth: 0,
+                    tickWidth: 0,
+                    minorTickInterval: null,
+                    tickAmount: 2,
+                    labels: {
+                        y: 16,
+                        style: {fontSize: '12px'}
+                    },
+                    stops: [
+                        [0.15, '#2196F3'],
+                        [0.4, '#f7931c'],
+                        [0.6, '#FF9800'],
+                        [0.85, '#F44336']
+                    ]
+                },
+                tooltip: {enabled: false},
+                credits: {enabled: false},
+                plotOptions: {
+                    solidgauge: {
+                        dataLabels: {
+                            y: -25,
+                            borderWidth: 0,
+                            useHTML: true,
+                            format: '<div style="text-align:center"><span style="font-size:24px">{y}°F</span></div>'
+                        }
+                    }
+                },
+                series: [
+                    {
+                        name: 'Temperature',
+                        data: [0],
+                        innerRadius: '60%',
+                        dataLabels: {
+                            format: '<div style="text-align:center"><span style="font-size:24px">{y}°F</span></div>'
+                        }
+                    }
+                ]
+            }
+        });
+    }
+
+    private updateChart(data: CurrentWeatherResponse) {
+        if (!data?.main) return;
+        const temp = Math.round(data.main.temp);
+        this.chartModel.setSeries([
+            {
+                name: 'Temperature',
+                data: [temp],
+                innerRadius: '60%',
+                dataLabels: {
+                    format: `<div style="text-align:center"><span style="font-size:24px">{y}°F</span></div>`
+                }
+            }
+        ]);
+    }
+}

--- a/client-app/src/examples/weather/widgets/HumidityPressureWidget.ts
+++ b/client-app/src/examples/weather/widgets/HumidityPressureWidget.ts
@@ -1,0 +1,112 @@
+import {chart, ChartModel} from '@xh/hoist/cmp/chart';
+import {creates, hoistCmp, HoistModel, managed} from '@xh/hoist/core';
+import {panel} from '@xh/hoist/desktop/cmp/panel';
+import {fmtDate} from '@xh/hoist/format';
+import {makeObservable} from '@xh/hoist/mobx';
+import {ForecastResponse} from '../Types';
+import {AppModel} from '../AppModel';
+
+export const humidityPressureWidget = hoistCmp.factory({
+    model: creates(() => HumidityPressureModel),
+
+    render() {
+        return panel({
+            item: chart()
+        });
+    }
+});
+
+class HumidityPressureModel extends HoistModel {
+    @managed chartModel: ChartModel;
+
+    constructor() {
+        super();
+        makeObservable(this);
+    }
+
+    override onLinked() {
+        this.chartModel = this.createChartModel();
+
+        this.addReaction({
+            track: () => AppModel.instance.weatherDashModel.forecast,
+            run: data => this.updateChart(data),
+            fireImmediately: true
+        });
+    }
+
+    private createChartModel(): ChartModel {
+        return new ChartModel({
+            highchartsConfig: {
+                chart: {zoomType: 'x'},
+                title: {text: null},
+                xAxis: {
+                    type: 'datetime',
+                    labels: {
+                        formatter: function () {
+                            return fmtDate(this.value, {fmt: 'ddd ha'});
+                        }
+                    }
+                },
+                yAxis: [
+                    {
+                        title: {text: 'Humidity (%)'},
+                        max: 100,
+                        min: 0,
+                        labels: {format: '{value}%'}
+                    },
+                    {
+                        title: {text: 'Pressure (hPa)'},
+                        opposite: true,
+                        labels: {format: '{value} hPa'}
+                    }
+                ],
+                tooltip: {
+                    shared: true,
+                    xDateFormat: '%A %b %e, %l:%M %p'
+                },
+                legend: {enabled: true},
+                credits: {enabled: false}
+            }
+        });
+    }
+
+    private updateChart(data: ForecastResponse) {
+        if (!data?.list) return;
+
+        const items = data.list,
+            humidityData = [],
+            pressureData = [];
+
+        items.forEach(item => {
+            const time = item.dt * 1000,
+                humidity = item.main?.humidity ?? 0,
+                pressure = item.main?.pressure ?? 0;
+
+            humidityData.push([time, humidity]);
+            pressureData.push([time, pressure]);
+        });
+
+        this.chartModel.setSeries([
+            {
+                name: 'Humidity',
+                type: 'spline',
+                data: humidityData,
+                yAxis: 0,
+                color: '#7cb5ec',
+                lineWidth: 2,
+                marker: {enabled: false},
+                tooltip: {valueSuffix: '%'}
+            },
+            {
+                name: 'Pressure',
+                type: 'spline',
+                data: pressureData,
+                yAxis: 1,
+                color: '#90ed7d',
+                lineWidth: 2,
+                marker: {enabled: false},
+                tooltip: {valueSuffix: ' hPa'}
+            }
+        ]);
+    }
+}

--- a/client-app/src/examples/weather/widgets/PrecipForecastWidget.ts
+++ b/client-app/src/examples/weather/widgets/PrecipForecastWidget.ts
@@ -1,0 +1,126 @@
+import {chart, ChartModel} from '@xh/hoist/cmp/chart';
+import {placeholder} from '@xh/hoist/cmp/layout';
+import {creates, hoistCmp, HoistModel, managed} from '@xh/hoist/core';
+import {panel} from '@xh/hoist/desktop/cmp/panel';
+import {fmtDate} from '@xh/hoist/format';
+import {Icon} from '@xh/hoist/icon';
+import {bindable, makeObservable} from '@xh/hoist/mobx';
+import {ForecastResponse} from '../Types';
+import {AppModel} from '../AppModel';
+
+export const precipForecastWidget = hoistCmp.factory({
+    model: creates(() => PrecipForecastModel),
+
+    render({model}) {
+        return panel({
+            item: model.hasData
+                ? chart()
+                : placeholder({
+                      items: [Icon.sun(), 'No precipitation expected in the forecast period']
+                  })
+        });
+    }
+});
+
+class PrecipForecastModel extends HoistModel {
+    @managed chartModel: ChartModel;
+    @bindable hasData: boolean = false;
+
+    constructor() {
+        super();
+        makeObservable(this);
+    }
+
+    override onLinked() {
+        this.chartModel = this.createChartModel();
+
+        this.addReaction({
+            track: () => AppModel.instance.weatherDashModel.forecast,
+            run: data => this.updateChart(data),
+            fireImmediately: true
+        });
+    }
+
+    private createChartModel(): ChartModel {
+        return new ChartModel({
+            highchartsConfig: {
+                chart: {zoomType: 'x'},
+                title: {text: null},
+                xAxis: {
+                    type: 'datetime',
+                    labels: {
+                        formatter: function () {
+                            return fmtDate(this.value, {fmt: 'ddd ha'});
+                        }
+                    }
+                },
+                yAxis: [
+                    {
+                        title: {text: 'Probability (%)'},
+                        max: 100,
+                        min: 0,
+                        labels: {format: '{value}%'}
+                    },
+                    {
+                        title: {text: 'Volume (mm)'},
+                        min: 0,
+                        opposite: true,
+                        labels: {format: '{value} mm'}
+                    }
+                ],
+                tooltip: {
+                    shared: true,
+                    xDateFormat: '%A %b %e, %l:%M %p'
+                },
+                legend: {enabled: true},
+                credits: {enabled: false}
+            }
+        });
+    }
+
+    private updateChart(data: ForecastResponse) {
+        if (!data?.list) return;
+
+        const items = data.list,
+            probData = [],
+            volumeData = [];
+
+        let anyPrecip = false;
+
+        items.forEach(item => {
+            const time = item.dt * 1000,
+                pop = Math.round((item.pop ?? 0) * 100),
+                rain = item.rain?.['3h'] ?? 0;
+
+            if (pop > 0 || rain > 0) anyPrecip = true;
+
+            probData.push([time, pop]);
+            volumeData.push([time, Math.round(rain * 10) / 10]);
+        });
+
+        this.hasData = anyPrecip;
+
+        if (anyPrecip) {
+            this.chartModel.setSeries([
+                {
+                    name: 'Probability',
+                    type: 'column',
+                    data: probData,
+                    yAxis: 0,
+                    color: 'rgba(135, 175, 220, 0.6)',
+                    borderWidth: 0,
+                    tooltip: {valueSuffix: '%'}
+                },
+                {
+                    name: 'Rain Volume',
+                    type: 'column',
+                    data: volumeData,
+                    yAxis: 1,
+                    color: '#2171b5',
+                    borderWidth: 0,
+                    tooltip: {valueSuffix: ' mm'}
+                }
+            ]);
+        }
+    }
+}

--- a/client-app/src/examples/weather/widgets/TempForecastWidget.ts
+++ b/client-app/src/examples/weather/widgets/TempForecastWidget.ts
@@ -1,0 +1,101 @@
+import {chart, ChartModel} from '@xh/hoist/cmp/chart';
+import {creates, hoistCmp, HoistModel, managed} from '@xh/hoist/core';
+import {panel} from '@xh/hoist/desktop/cmp/panel';
+import {fmtDate} from '@xh/hoist/format';
+import {makeObservable} from '@xh/hoist/mobx';
+import {ForecastResponse} from '../Types';
+import {AppModel} from '../AppModel';
+
+export const tempForecastWidget = hoistCmp.factory({
+    model: creates(() => TempForecastModel),
+
+    render() {
+        return panel({
+            item: chart()
+        });
+    }
+});
+
+class TempForecastModel extends HoistModel {
+    @managed chartModel: ChartModel;
+
+    constructor() {
+        super();
+        makeObservable(this);
+    }
+
+    override onLinked() {
+        this.chartModel = this.createChartModel();
+
+        this.addReaction({
+            track: () => AppModel.instance.weatherDashModel.forecast,
+            run: data => this.updateChart(data),
+            fireImmediately: true
+        });
+    }
+
+    private createChartModel(): ChartModel {
+        return new ChartModel({
+            highchartsConfig: {
+                chart: {zoomType: 'x'},
+                title: {text: null},
+                xAxis: {
+                    type: 'datetime',
+                    labels: {
+                        formatter: function () {
+                            return fmtDate(this.value, {fmt: 'ddd ha'});
+                        }
+                    }
+                },
+                yAxis: {
+                    title: {text: 'Temperature (°F)'},
+                    labels: {format: '{value}°'}
+                },
+                tooltip: {
+                    shared: true,
+                    valueSuffix: '°F',
+                    xDateFormat: '%A %b %e, %l:%M %p'
+                },
+                legend: {enabled: true},
+                credits: {enabled: false}
+            }
+        });
+    }
+
+    private updateChart(data: ForecastResponse) {
+        if (!data?.list) return;
+
+        const items = data.list,
+            tempData = [],
+            feelsLikeData = [];
+
+        items.forEach(item => {
+            const time = item.dt * 1000,
+                temp = item.main.temp,
+                feelsLike = item.main.feels_like;
+
+            tempData.push([time, Math.round(temp)]);
+            feelsLikeData.push([time, Math.round(feelsLike)]);
+        });
+
+        this.chartModel.setSeries([
+            {
+                name: 'Temperature',
+                type: 'spline',
+                data: tempData,
+                color: '#7cb5ec',
+                lineWidth: 2,
+                marker: {enabled: false}
+            },
+            {
+                name: 'Feels Like',
+                type: 'spline',
+                data: feelsLikeData,
+                color: '#f45b5b',
+                lineWidth: 2,
+                dashStyle: 'ShortDash',
+                marker: {enabled: false}
+            }
+        ]);
+    }
+}

--- a/grails-app/controllers/io/xh/toolbox/weather/WeatherController.groovy
+++ b/grails-app/controllers/io/xh/toolbox/weather/WeatherController.groovy
@@ -1,0 +1,22 @@
+package io.xh.toolbox.weather
+
+import io.xh.hoist.security.AccessAll
+import io.xh.toolbox.BaseController
+
+@AccessAll
+class WeatherController extends BaseController {
+
+    def weatherService
+
+    def current() {
+        def city = params.city
+        if (!city) throw new RuntimeException('Required parameter "city" not provided.')
+        renderJSON(weatherService.getCurrentWeather(city))
+    }
+
+    def forecast() {
+        def city = params.city
+        if (!city) throw new RuntimeException('Required parameter "city" not provided.')
+        renderJSON(weatherService.getForecast(city))
+    }
+}

--- a/grails-app/init/io/xh/toolbox/BootStrap.groovy
+++ b/grails-app/init/io/xh/toolbox/BootStrap.groovy
@@ -182,6 +182,13 @@ class BootStrap implements LogSupport {
                     clientVisible: false,
                     groupName: 'Toolbox - Example Apps'
             ],
+            weatherApiKey: [
+                    valueType: 'string',
+                    defaultValue: 'UNCONFIGURED',
+                    clientVisible: false,
+                    groupName: 'Toolbox - Example Apps',
+                    note: 'API key for OpenWeatherMap (https://openweathermap.org/api). Sign up for a free key.'
+            ],
             newsRefreshMins: [
                     valueType: 'int',
                     defaultValue: 60,

--- a/grails-app/services/io/xh/toolbox/app/WeatherService.groovy
+++ b/grails-app/services/io/xh/toolbox/app/WeatherService.groovy
@@ -1,0 +1,82 @@
+package io.xh.toolbox.app
+
+import io.xh.hoist.BaseService
+import io.xh.hoist.cache.Cache
+import io.xh.hoist.config.ConfigService
+import io.xh.hoist.exception.DataNotAvailableException
+import io.xh.hoist.http.JSONClient
+import org.apache.hc.client5.http.classic.methods.HttpGet
+
+import static io.xh.hoist.util.DateTimeUtils.MINUTES
+
+class WeatherService extends BaseService {
+
+    static clearCachesConfigs = ['weatherApiKey']
+
+    ConfigService configService
+
+    private Cache<String, Map> _currentWeatherCache = createCache(
+        name: 'currentWeather', expireTime: 10 * MINUTES
+    )
+    private Cache<String, Map> _forecastCache = createCache(
+        name: 'forecast', expireTime: 30 * MINUTES
+    )
+
+    Map getCurrentWeather(String city) {
+        _currentWeatherCache.getOrCreate(city) { loadCurrentWeather(city) }
+    }
+
+    Map getForecast(String city) {
+        _forecastCache.getOrCreate(city) { loadForecast(city) }
+    }
+
+    //------------------------
+    // Implementation
+    //------------------------
+    private Map loadCurrentWeather(String city) {
+        def apiKey = getApiKey(),
+            encodedCity = URLEncoder.encode(city, 'UTF-8'),
+            url = "https://api.openweathermap.org/data/2.5/weather?q=${encodedCity}&appid=${apiKey}&units=imperial",
+            response = client.executeAsMap(new HttpGet(url))
+
+        logDebug("Loaded current weather for ${city}.")
+        return response
+    }
+
+    private Map loadForecast(String city) {
+        def apiKey = getApiKey(),
+            encodedCity = URLEncoder.encode(city, 'UTF-8'),
+            url = "https://api.openweathermap.org/data/2.5/forecast?q=${encodedCity}&appid=${apiKey}&units=imperial",
+            response = client.executeAsMap(new HttpGet(url))
+
+        logDebug("Loaded forecast for ${city}.")
+        return response
+    }
+
+    private String getApiKey() {
+        def key = configService.getString('weatherApiKey')
+        if (key == 'UNCONFIGURED') {
+            throw new DataNotAvailableException(
+                'Weather API key not configured. Set the "weatherApiKey" config in the Admin console ' +
+                'with a valid OpenWeatherMap API key (https://openweathermap.org/api).'
+            )
+        }
+        return key
+    }
+
+    private JSONClient _jsonClient
+    private JSONClient getClient() {
+        _jsonClient ?= new JSONClient()
+    }
+
+    void clearCaches() {
+        _jsonClient = null
+        _currentWeatherCache.clear()
+        _forecastCache.clear()
+        super.clearCaches()
+    }
+
+    Map getAdminStats() {[
+        config: configForAdminStats('weatherApiKey')
+    ]}
+}


### PR DESCRIPTION
## Summary
- Full-stack Weather Dashboard example app backed by the OpenWeatherMap API
- `DashCanvas` layout with multiple chart types (gauge, spline, column, dual-axis) and a grid summary view
- Server-side caching via Hoist `Cache`, city persistence via `@persist`, `ViewManager` for saved layouts
- This example was coded entirely by AI (Claude) without any human-written application code

## Review cleanup included
- `loadSpec` passed to fetch calls
- Cities alpha-sorted
- Dedicated `Icons.ts` and `Types.ts` files
- `mask: 'onLoad'` removed from widgets that don't load
- Exception handling simplified (errors surface to user)
- `weatherApiKey` auto-created in Bootstrap with `UNCONFIGURED` sentinel
- `ConcurrentHashMap` replaced with Hoist `Cache`
- Controller requires `city` param

## Test plan
- [ ] Reload app — city persists in localStorage across reloads
- [ ] Switch cities — all widgets update, no stale data
- [ ] Set `weatherApiKey` to `UNCONFIGURED` — confirm descriptive error surfaces
- [ ] Confirm dashboard layout saves/restores via ViewManager

🤖 Generated with [Claude Code](https://claude.com/claude-code)