### PR TITLE
Use Field.description instead of Column.chooserDescription

### DIFF
--- a/client-app/src/admin/tests/columnFilters/store/StoreColumnFilterPanelModel.ts
+++ b/client-app/src/admin/tests/columnFilters/store/StoreColumnFilterPanelModel.ts
@@ -62,17 +62,20 @@ export class StoreColumnFilterPanelModel extends HoistModel {
                     {
                         name: 'profit_loss',
                         displayName: 'P&L',
-                        type: 'number'
+                        type: 'number',
+                        description: 'Annual Profit & Loss YTD (EBITDA)'
                     },
                     {
                         name: 'trade_date',
                         displayName: 'Date',
-                        type: 'localDate'
+                        type: 'localDate',
+                        description: 'Date of last trade (including related derivatives)'
                     },
                     {
                         name: 'trade_volume',
                         displayName: 'Volume (Sales Quantity)',
-                        type: 'number'
+                        type: 'number',
+                        description: 'Daily Volume of Shares (Estimated, avg. YTD)'
                     },
                     {
                         name: 'active',
@@ -126,8 +129,7 @@ export class StoreColumnFilterPanelModel extends HoistModel {
                         precision: 1,
                         label: true
                     }),
-                    excelFormat: ExcelFormat.NUM_DELIMITED,
-                    chooserDescription: 'Daily Volume of Shares (Estimated, avg. YTD)'
+                    excelFormat: ExcelFormat.NUM_DELIMITED
                 },
                 {
                     field: 'profit_loss',
@@ -139,14 +141,12 @@ export class StoreColumnFilterPanelModel extends HoistModel {
                         ledger: true,
                         colorSpec: true
                     }),
-                    excelFormat: ExcelFormat.LEDGER_COLOR,
-                    chooserDescription: 'Annual Profit & Loss YTD (EBITDA)'
+                    excelFormat: ExcelFormat.LEDGER_COLOR
                 },
                 {
                     field: 'trade_date',
                     ...localDateCol,
-                    width: 150,
-                    chooserDescription: 'Date of last trade (including related derivatives)'
+                    width: 150
                 }
             ]
         });

--- a/client-app/src/core/columns/Trades.ts
+++ b/client-app/src/core/columns/Trades.ts
@@ -6,7 +6,8 @@ export const profitLossCol: ColumnSpec = {
     field: {
         name: 'profit_loss',
         type: 'number',
-        displayName: 'P&L'
+        displayName: 'P&L',
+        description: 'Annual Profit & Loss YTD (EBITDA)'
     },
     width: 130,
     align: 'right',
@@ -17,8 +18,7 @@ export const profitLossCol: ColumnSpec = {
         ledger: true,
         colorSpec: true
     }),
-    excelFormat: ExcelFormat.LEDGER_COLOR,
-    chooserDescription: 'Annual Profit & Loss YTD (EBITDA)'
+    excelFormat: ExcelFormat.LEDGER_COLOR
 };
 
 export const winLoseCol: ColumnSpec = {
@@ -30,7 +30,8 @@ export const tradeVolumeCol: ColumnSpec = {
     field: {
         name: 'trade_volume',
         type: 'number',
-        displayName: 'Volume'
+        displayName: 'Volume',
+        description: 'Daily Volume of Shares (Estimated, avg. YTD)'
     },
     width: 110,
     align: 'right',
@@ -42,8 +43,7 @@ export const tradeVolumeCol: ColumnSpec = {
     cellClassRules: {
         'tb-sample-grid__high-volume-cell': ({value}) => value >= 9000000000
     },
-    excelFormat: ExcelFormat.NUM_DELIMITED,
-    chooserDescription: 'Daily Volume of Shares (Estimated, avg. YTD)'
+    excelFormat: ExcelFormat.NUM_DELIMITED
 };
 
 export const tradeDateCol: ColumnSpec = {
@@ -51,9 +51,9 @@ export const tradeDateCol: ColumnSpec = {
     field: {
         name: 'trade_date',
         type: 'localDate',
-        displayName: 'Date'
-    },
-    chooserDescription: 'Date of last trade (including related derivatives)'
+        displayName: 'Date',
+        description: 'Date of last trade (including related derivatives)'
+    }
 };
 
 export const dayOfWeekCol: ColumnSpec = {

--- a/client-app/src/desktop/tabs/grids/ExternalSortGridPanelModel.ts
+++ b/client-app/src/desktop/tabs/grids/ExternalSortGridPanelModel.ts
@@ -69,18 +69,27 @@ export class ExternalSortGridPanelModel extends HoistModel {
                     }
                 },
                 {
-                    field: 'trade_volume',
+                    field: {
+                        name: 'trade_volume',
+                        type: 'number',
+                        displayName: 'Volume',
+                        description: 'Daily Volume of Shares (Estimated, avg. YTD)'
+                    },
                     width: 150,
                     tooltip: val => fmtNumberTooltip(val),
                     renderer: millionsRenderer({
                         precision: 1,
                         label: true
                     }),
-                    excelFormat: ExcelFormat.NUM_DELIMITED,
-                    chooserDescription: 'Daily Volume of Shares (Estimated, avg. YTD)'
+                    excelFormat: ExcelFormat.NUM_DELIMITED
                 },
                 {
-                    field: 'profit_loss',
+                    field: {
+                        name: 'profit_loss',
+                        type: 'number',
+                        displayName: 'P&L',
+                        description: 'Annual Profit & Loss YTD (EBITDA)'
+                    },
                     width: 150,
                     absSort: true,
                     tooltip: val => fmtNumberTooltip(val, {ledger: true}),
@@ -89,14 +98,17 @@ export class ExternalSortGridPanelModel extends HoistModel {
                         ledger: true,
                         colorSpec: true
                     }),
-                    excelFormat: ExcelFormat.LEDGER_COLOR,
-                    chooserDescription: 'Annual Profit & Loss YTD (EBITDA)'
+                    excelFormat: ExcelFormat.LEDGER_COLOR
                 },
                 {
-                    field: 'trade_date',
+                    field: {
+                        name: 'trade_date',
+                        type: 'localDate',
+                        displayName: 'Date',
+                        description: 'Date of last trade (including related derivatives)'
+                    },
                     ...localDateCol,
-                    width: 150,
-                    chooserDescription: 'Date of last trade (including related derivatives)'
+                    width: 150
                 }
             ]
         });


### PR DESCRIPTION
## Summary

* Adopts the new `Field.description` property from xh/hoist-react#4227, moving descriptive text from column-level `chooserDescription` to field-level `description` where it automatically flows through to both `headerTooltip` and `chooserDescription`.
* Updates `Trades.ts` shared column specs, `StoreColumnFilterPanelModel`, and `ExternalSortGridPanelModel`.

## Test plan

- [ ] Verify column chooser shows descriptions for P&L, Volume, and Date columns
- [ ] Verify header tooltips appear on hover for those same columns
- [ ] Confirm `dayOfWeekCol` still shows its column-specific `chooserDescription`

🤖 Generated with [Claude Code](https://claude.com/claude-code)