### PR TITLE
Set headerHasExpandCollapse: false on id column in SampleGridModel

### DIFF
--- a/client-app/src/desktop/common/grid/SampleGridModel.ts
+++ b/client-app/src/desktop/common/grid/SampleGridModel.ts
@@ -170,7 +170,7 @@ export class SampleGridModel extends HoistModel {
                 }
             },
             columns: [
-                {field: 'id', hidden: true},
+                {field: 'id', hidden: true, headerHasExpandCollapse: false},
                 {
                     ...actionCol,
                     width: calcActionColWidth(2),


### PR DESCRIPTION
## Summary
- Opts the `id` column out of hosting the grouped grid expand/collapse icon via `headerHasExpandCollapse: false`
- Companion to xh/hoist-react#4231

## Test plan
- [ ] Verify expand/collapse icon does not appear on id column even if unhidden

🤖 Generated with [Claude Code](https://claude.com/claude-code)