### PR TITLE
Add hoist-core MCP server integration

### DIFF
--- a/.claude/start-hoist-core-mcp.sh
+++ b/.claude/start-hoist-core-mcp.sh
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+# Wrapper to start the hoist-core MCP server in the correct mode based on gradle.properties.
+#
+# - If runHoistInline=true: starts in local mode (builds from source in ../hoist-core)
+# - Otherwise: starts in version mode using hoistCoreVersion from gradle.properties
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+PROJECT_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+PROPS="$PROJECT_DIR/gradle.properties"
+
+if [ ! -f "$PROPS" ]; then
+    echo "[hoist-core-mcp] ERROR: gradle.properties not found at $PROPS" >&2
+    exit 1
+fi
+
+BOOTSTRAP="$PROJECT_DIR/../hoist-core/mcp/bootstrap.sh"
+if [ ! -f "$BOOTSTRAP" ]; then
+    echo "[hoist-core-mcp] ERROR: bootstrap.sh not found at $BOOTSTRAP" >&2
+    exit 1
+fi
+
+RUN_INLINE=$(grep '^runHoistInline=' "$PROPS" | cut -d= -f2 | tr -d '[:space:]')
+HOIST_VERSION=$(grep '^hoistCoreVersion=' "$PROPS" | cut -d= -f2 | tr -d '[:space:]')
+
+if [ "$RUN_INLINE" = "true" ]; then
+    exec bash "$BOOTSTRAP"
+else
+    if [ -z "$HOIST_VERSION" ]; then
+        echo "[hoist-core-mcp] ERROR: hoistCoreVersion not found in gradle.properties" >&2
+        exit 1
+    fi
+    exec bash "$BOOTSTRAP" --version "$HOIST_VERSION"
+fi

--- a/.claude/start-hoist-react-mcp.sh
+++ b/.claude/start-hoist-react-mcp.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+# Wrapper to start the hoist-react MCP server, preferring a local checkout over node_modules.
+#
+# - If ../hoist-react/mcp/server.ts exists: runs from local repo (local mode)
+# - Otherwise: runs from client-app/node_modules/@xh/hoist (installed mode)
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+PROJECT_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+
+LOCAL_SERVER="$PROJECT_DIR/../hoist-react/bin/hoist-mcp.mjs"
+LOCAL_SIGNAL="$PROJECT_DIR/../hoist-react/mcp/server.ts"
+INSTALLED_SERVER="$PROJECT_DIR/client-app/node_modules/@xh/hoist/bin/hoist-mcp.mjs"
+
+if [ -f "$LOCAL_SIGNAL" ]; then
+    echo "[hoist-react-mcp] Local hoist-react checkout detected — starting in local mode" >&2
+    exec node "$LOCAL_SERVER"
+else
+    echo "[hoist-react-mcp] No local checkout — starting from node_modules" >&2
+    exec node "$INSTALLED_SERVER"
+fi

--- a/.mcp.json
+++ b/.mcp.json
@@ -11,8 +11,8 @@
       "args": [".claude/start-hoist-core-mcp.sh"]
     },
     "github": {
-      "command": "npx",
-      "args": ["-y", "@modelcontextprotocol/server-github"],
+      "command": "docker",
+      "args": ["run", "--rm", "-i", "-e", "GITHUB_PERSONAL_ACCESS_TOKEN", "ghcr.io/github/github-mcp-server"],
       "env": {
         "GITHUB_PERSONAL_ACCESS_TOKEN": "${GITHUB_TOKEN}"
       }

--- a/.mcp.json
+++ b/.mcp.json
@@ -12,7 +12,14 @@
     },
     "github": {
       "command": "docker",
-      "args": ["run", "--rm", "-i", "-e", "GITHUB_PERSONAL_ACCESS_TOKEN", "ghcr.io/github/github-mcp-server"],
+      "args": [
+        "run",
+        "-i",
+        "--rm",
+        "-e",
+        "GITHUB_PERSONAL_ACCESS_TOKEN",
+        "ghcr.io/github/github-mcp-server"
+      ],
       "env": {
         "GITHUB_PERSONAL_ACCESS_TOKEN": "${GITHUB_TOKEN}"
       }

--- a/.mcp.json
+++ b/.mcp.json
@@ -11,21 +11,14 @@
       "args": [".claude/start-hoist-core-mcp.sh"]
     },
     "github": {
-      "command": "docker",
-      "args": [
-        "run",
-        "-i",
-        "--rm",
-        "-e",
-        "GITHUB_PERSONAL_ACCESS_TOKEN",
-        "ghcr.io/github/github-mcp-server"
-      ],
+      "command": "npx",
+      "args": ["-y", "@modelcontextprotocol/server-github"],
       "env": {
         "GITHUB_PERSONAL_ACCESS_TOKEN": "${GITHUB_TOKEN}"
       }
     },
     "jetbrains": {
-      "url": "http://localhost:64342/sse",
+      "url": "http://localhost:${JETBRAINS_MCP_PORT:-64342}/sse",
       "type": "sse"
     }
   }

--- a/.mcp.json
+++ b/.mcp.json
@@ -11,7 +11,7 @@
     "hoist-core": {
       "type": "stdio",
       "command": "bash",
-      "args": ["../hoist-core/mcp/bootstrap.sh"]
+      "args": [".claude/start-hoist-core-mcp.sh"]
     },
     "github": {
       "command": "docker",

--- a/.mcp.json
+++ b/.mcp.json
@@ -2,11 +2,8 @@
   "mcpServers": {
     "hoist-react": {
       "type": "stdio",
-      "command": "node",
-      "args": [
-        "client-app/node_modules/@xh/hoist/bin/hoist-mcp.mjs"
-      ],
-      "env": {}
+      "command": "bash",
+      "args": [".claude/start-hoist-react-mcp.sh"]
     },
     "hoist-core": {
       "type": "stdio",

--- a/.mcp.json
+++ b/.mcp.json
@@ -8,6 +8,11 @@
       ],
       "env": {}
     },
+    "hoist-core": {
+      "type": "stdio",
+      "command": "bash",
+      "args": ["../hoist-core/mcp/bootstrap.sh"]
+    },
     "github": {
       "command": "docker",
       "args": [


### PR DESCRIPTION
## Summary
- Adds a smart bootstrap wrapper (`.claude/start-hoist-core-mcp.sh`) that reads `gradle.properties` to automatically start the hoist-core MCP server in local (`runHoistInline=true`) or versioned mode
- Updates `.mcp.json` to use the new wrapper instead of directly calling `../hoist-core/mcp/bootstrap.sh`

## Test plan
- [ ] Verify MCP server starts correctly with `runHoistInline=true`
- [ ] Verify MCP server starts correctly with a pinned `hoistCoreVersion`
- [ ] Confirm hoist-core MCP tools (search-docs, search-symbols, etc.) work in Claude Code

🤖 Generated with [Claude Code](https://claude.com/claude-code)