### PR TITLE
Add dynamic routable tabs spike example app

### DIFF
--- a/client-app/src/apps/dynamicTabs.ts
+++ b/client-app/src/apps/dynamicTabs.ts
@@ -1,0 +1,19 @@
+import '../Bootstrap';
+
+import {XH} from '@xh/hoist/core';
+import {AppContainer} from '@xh/hoist/desktop/appcontainer';
+import {AppComponent} from '../examples/dynamicTabs/AppComponent';
+import {AppModel} from '../examples/dynamicTabs/AppModel';
+import {AuthModel} from '../core/AuthModel';
+
+XH.renderApp({
+    clientAppCode: 'dynamicTabs',
+    clientAppName: 'Dynamic Routable Tabs',
+    componentClass: AppComponent,
+    modelClass: AppModel,
+    containerClass: AppContainer,
+    authModelClass: AuthModel,
+    isMobileApp: false,
+    enableLogout: true,
+    checkAccess: () => true
+});

--- a/client-app/src/examples/dynamicTabs/AppComponent.ts
+++ b/client-app/src/examples/dynamicTabs/AppComponent.ts
@@ -1,0 +1,22 @@
+import {hoistCmp, uses} from '@xh/hoist/core';
+import {appBar} from '@xh/hoist/desktop/cmp/appbar';
+import {panel} from '@xh/hoist/desktop/cmp/panel';
+import {Icon} from '@xh/hoist/icon';
+import {AppModel} from './AppModel';
+import {dynamicRoutableTabsPanel} from './DynamicRoutableTabsPanel';
+import '../../core/Toolbox.scss';
+
+export const AppComponent = hoistCmp({
+    displayName: 'App',
+    model: uses(AppModel),
+
+    render() {
+        return panel({
+            tbar: appBar({
+                icon: Icon.tab({size: '2x', prefix: 'fal'}),
+                appMenuButtonProps: {hideLogoutItem: false}
+            }),
+            item: dynamicRoutableTabsPanel()
+        });
+    }
+});

--- a/client-app/src/examples/dynamicTabs/AppModel.ts
+++ b/client-app/src/examples/dynamicTabs/AppModel.ts
@@ -1,0 +1,20 @@
+import {BaseAppModel} from '../../BaseAppModel';
+
+export class AppModel extends BaseAppModel {
+    static instance: AppModel;
+
+    override getRoutes() {
+        return [
+            {
+                name: 'default',
+                path: '/dynamicTabs',
+                children: [
+                    {name: 'home', path: '/home'},
+                    {name: 'settings', path: '/settings'},
+                    {name: 'about', path: '/about'},
+                    {name: 'item', path: '/item/:id'}
+                ]
+            }
+        ];
+    }
+}

--- a/client-app/src/examples/dynamicTabs/DynamicRoutableTabsModel.ts
+++ b/client-app/src/examples/dynamicTabs/DynamicRoutableTabsModel.ts
@@ -1,0 +1,179 @@
+import {TabContainerModel} from '@xh/hoist/cmp/tab';
+import {HoistModel, managed, XH} from '@xh/hoist/core';
+import {Icon} from '@xh/hoist/icon';
+import {action, bindable, makeObservable} from '@xh/hoist/mobx';
+import {wait} from '@xh/hoist/promise';
+import {homePanel} from './tabs/HomePanel';
+import {settingsPanel} from './tabs/SettingsPanel';
+import {aboutPanel} from './tabs/AboutPanel';
+import {itemDetailPanel} from './tabs/ItemDetailPanel';
+
+/**
+ * Model demonstrating dynamic, routable tabs.
+ *
+ * Cannot use TabContainerModel's built-in `route` config because it prohibits all dynamic
+ * tab mutations (addTab/removeTab both call setTabs, which throws when routing is enabled).
+ * Instead, we manage routing manually with bidirectional reactions.
+ */
+export class DynamicRoutableTabsModel extends HoistModel {
+    @managed
+    tabContainerModel: TabContainerModel = new TabContainerModel({
+        // No `route` config — we manage routing manually.
+        switcher: {mode: 'dynamic', initialFavorites: ['home', 'settings', 'about']},
+        tabs: [
+            {id: 'home', title: 'Home', icon: Icon.home(), content: homePanel},
+            {id: 'settings', title: 'Settings', icon: Icon.gear(), content: settingsPanel},
+            {id: 'about', title: 'About', icon: Icon.info(), content: aboutPanel}
+        ]
+    });
+
+    /** ID typed into the "open item" input. */
+    @bindable itemIdInput: string = '';
+
+    // Guard to prevent reaction loops during sync.
+    private _syncing = false;
+    private _routerUnsub = null;
+
+    constructor() {
+        super();
+        makeObservable(this);
+    }
+
+    override onLinked() {
+        super.onLinked();
+
+        // Router → Tabs: subscribe directly to Router 5 for reliable change detection,
+        // including param-only changes on the same route name. MobX reactions on
+        // XH.routerState don't reliably detect these.
+        this._routerUnsub = XH.router.subscribe(() => this.syncRouterToTabs());
+        // Initial sync on mount.
+        this.syncRouterToTabs();
+
+        // Tabs → Router: when the active tab changes, update the URL.
+        this.addReaction({
+            track: () => this.tabContainerModel.activeTabId,
+            run: () => this.syncTabsToRouter(),
+            fireImmediately: true
+        });
+
+        // Cleanup: when the DynamicTabSwitcher hides an item tab (user clicks X), defer
+        // removal to the next tick so that MobX reactions from tab creation have settled.
+        this.addReaction({
+            track: () =>
+                this.tabContainerModel.dynamicTabSwitcherModel?.visibleTabs?.map(t => t.id),
+            run: visibleIds => this.deferredCleanupHiddenItemTabs(visibleIds)
+        });
+    }
+
+    /** Open (or activate) the item tab for the given ID. */
+    @action
+    openItemTab(id: string | number) {
+        const itemId = String(id),
+            tabId = `item-${itemId}`,
+            {tabContainerModel} = this;
+
+        if (!tabContainerModel.findTab(tabId)) {
+            tabContainerModel.addTab({
+                id: tabId,
+                title: `Item ${itemId}`,
+                icon: Icon.detail(),
+                content: () => itemDetailPanel({itemId})
+            });
+        }
+
+        tabContainerModel.activateTab(tabId);
+    }
+
+    /** Handle "Open Tab" button click. */
+    @action
+    onOpenItemClick() {
+        const id = this.itemIdInput?.trim();
+        if (id) {
+            this.openItemTab(id);
+            this.itemIdInput = '';
+        }
+    }
+
+    override destroy() {
+        if (typeof this._routerUnsub === 'function') this._routerUnsub();
+        super.destroy();
+    }
+
+    //------------------------------------------------------------------
+    // Routing sync
+    //------------------------------------------------------------------
+    private syncRouterToTabs() {
+        if (this._syncing) return;
+        this._syncing = true;
+        try {
+            const state = XH.routerState;
+            if (!state) return;
+
+            const {name, params} = state;
+
+            // Match parameterized item route.
+            // Note: cannot use router.isActive('default.item') without params — Router 5
+            // requires params to match for parameterized routes. Check route name directly.
+            if (name === 'default.item' && params?.id) {
+                this.openItemTab(params.id);
+                return;
+            }
+
+            // Match static tab routes by name.
+            const staticIds = ['home', 'settings', 'about'];
+            for (const tabId of staticIds) {
+                if (name === 'default.' + tabId) {
+                    this.tabContainerModel.activateTab(tabId);
+                    return;
+                }
+            }
+
+            // Fallback: if we're on the base route with no child, go to home.
+            if (name === 'default') {
+                this.tabContainerModel.activateTab('home');
+            }
+        } finally {
+            this._syncing = false;
+        }
+    }
+
+    private syncTabsToRouter() {
+        if (this._syncing) return;
+        this._syncing = true;
+        try {
+            const tabId = this.tabContainerModel.activeTabId;
+            if (!tabId) return;
+
+            if (tabId.startsWith('item-')) {
+                const itemId = tabId.replace('item-', '');
+                XH.navigate('default.item', {id: itemId});
+            } else {
+                XH.navigate('default.' + tabId);
+            }
+        } finally {
+            this._syncing = false;
+        }
+    }
+
+    /**
+     * When the DynamicTabSwitcher "hides" a tab (user clicks X), the tab is removed from the
+     * switcher's visible list but still exists in the container. For dynamic item tabs, we want
+     * to fully remove them. Deferred to next tick to avoid racing with tab creation — the
+     * DynamicTabSwitcherModel's activeTabReaction needs time to add newly activated tabs to
+     * its visibleTabs before we check for orphans.
+     */
+    private deferredCleanupHiddenItemTabs(visibleIds: string[]) {
+        if (!visibleIds) return;
+        wait().then(() => {
+            if (this.isDestroyed) return;
+            const switcherVisibleIds =
+                this.tabContainerModel.dynamicTabSwitcherModel?.visibleTabs?.map(t => t.id) ?? [];
+            const allTabs = [...this.tabContainerModel.tabs];
+            for (const tab of allTabs) {
+                if (tab.id.startsWith('item-') && !switcherVisibleIds.includes(tab.id)) {
+                    this.tabContainerModel.removeTab(tab);
+                }
+            }
+        });
+    }
+}

--- a/client-app/src/examples/dynamicTabs/DynamicRoutableTabsPanel.ts
+++ b/client-app/src/examples/dynamicTabs/DynamicRoutableTabsPanel.ts
@@ -1,0 +1,41 @@
+import {tabContainer} from '@xh/hoist/cmp/tab';
+import {creates, hoistCmp} from '@xh/hoist/core';
+import {button} from '@xh/hoist/desktop/cmp/button';
+import {textInput} from '@xh/hoist/desktop/cmp/input';
+import {panel} from '@xh/hoist/desktop/cmp/panel';
+import {dynamicTabSwitcher} from '@xh/hoist/desktop/cmp/tab';
+import {toolbar} from '@xh/hoist/desktop/cmp/toolbar';
+import {filler, span} from '@xh/hoist/cmp/layout';
+import {Icon} from '@xh/hoist/icon';
+import {DynamicRoutableTabsModel} from './DynamicRoutableTabsModel';
+
+export const dynamicRoutableTabsPanel = hoistCmp.factory({
+    model: creates(DynamicRoutableTabsModel),
+
+    render({model}) {
+        const {tabContainerModel} = model;
+        return panel({
+            tbar: toolbar(
+                dynamicTabSwitcher({model: tabContainerModel, flex: 1}),
+                filler(),
+                span('Open Item:'),
+                textInput({
+                    bind: 'itemIdInput',
+                    model,
+                    width: 80,
+                    placeholder: 'ID...',
+                    commitOnChange: true,
+                    onKeyDown: e => {
+                        if (e.key === 'Enter') model.onOpenItemClick();
+                    }
+                }),
+                button({
+                    text: 'Open Tab',
+                    icon: Icon.add(),
+                    onClick: () => model.onOpenItemClick()
+                })
+            ),
+            item: tabContainer({model: tabContainerModel, switcher: false})
+        });
+    }
+});

--- a/client-app/src/examples/dynamicTabs/FINDINGS.md
+++ b/client-app/src/examples/dynamicTabs/FINDINGS.md
@@ -1,0 +1,132 @@
+# Dynamic Routable Tabs — Spike Findings
+
+## Summary
+
+All 7 routing scenarios work with a viable workaround pattern. The approach requires
+**bypassing TabContainerModel's built-in routing** entirely and managing the Router 5 ↔ tab
+sync manually. This works well but exposes several framework-level friction points that could be
+smoothed out in hoist-react.
+
+## What Works Out of the Box
+
+- **TabContainerModel + DynamicTabSwitcher** — the tab container's dynamic switcher mode
+  (`switcher: {mode: 'dynamic'}`) works well for adding, removing, reordering, and
+  favoriting tabs at runtime. No issues with the core tab lifecycle.
+- **addTab / removeTab** — these work correctly on a non-routed TabContainerModel. Tabs are
+  created, rendered, and destroyed as expected.
+- **Router 5 parameterized routes** — defining routes like `/item/:id` works. The router
+  resolves params correctly and fires subscribers on navigation.
+- **tabContainer switcher: false prop** — the `tabContainer()` component accepts
+  `switcher: false` (or `null`) to suppress the built-in switcher, allowing a separately
+  placed `dynamicTabSwitcher()` in a toolbar. This is essential for custom layouts.
+
+## Workarounds Required
+
+### 1. Cannot use TabContainerModel's `route` config with dynamic tabs
+
+**The issue:** `TabContainerModel.setTabs()` throws `"Dynamic tabs not available on TabContainer
+with routing"` when `route` is set. Since `addTab()` and `removeTab()` both call `setTabs()`
+internally, ALL dynamic tab mutations are blocked on routed containers.
+
+**Workaround:** Omit the `route` config and manage routing manually:
+- Subscribe to Router 5 directly (`XH.router.subscribe()`) for router→tab sync.
+- Use a MobX reaction on `activeTabId` for tab→router sync.
+- Use a `_syncing` guard flag to prevent reaction loops.
+
+**This is the central finding of the spike.** The workaround is viable but non-trivial — it
+requires ~80 lines of manual routing logic that mirrors what `TabContainerModel` does
+internally but adds support for parameterized routes and dynamic tab creation.
+
+### 2. Must subscribe to Router 5 directly, not via MobX reaction on `XH.routerState`
+
+**The issue:** A MobX `reaction` tracking `() => XH.routerState` does not reliably fire when
+navigating between routes that share the same name but differ only in params (e.g.,
+`/item/5` → `/item/7`). The `routerState` property is `@observable.ref` and the reference
+does change, but MobX reactions scheduled from within a Router 5 subscriber callback
+interact poorly with MobX's batching — the reaction fires but observable changes made inside
+it (via `@action` methods) can be rolled back by other pending reactions.
+
+**Workaround:** Use `XH.router.subscribe()` directly (a native Router 5 subscription) instead
+of a MobX reaction. Store the unsubscribe function and call it in `destroy()`.
+
+### 3. Router 5's `isActive()` requires params for parameterized routes
+
+**The issue:** `XH.router.isActive('default.item')` returns `false` when the current route IS
+`default.item` with params `{id: '5'}`. Router 5 requires params to be passed for the check
+to succeed: `isActive('default.item', {id: '5'})` returns `true`.
+
+**Workaround:** Match routes by checking `XH.routerState.name` directly instead of using
+`router.isActive()`.
+
+### 4. DynamicTabSwitcher cleanup races with tab creation
+
+**The issue:** When watching `DynamicTabSwitcherModel.visibleTabs` to detect tab closures and
+remove orphaned dynamic tabs from the container, the cleanup reaction fires in the same MobX
+batch as a new tab being added. The `DynamicTabSwitcherModel`'s `activeTabReaction` hasn't
+yet added the new tab to `visibleTabs`, so the cleanup sees the new tab as "not visible" and
+removes it immediately.
+
+**Workaround:** Defer the cleanup to the next microtask using `wait().then(...)`. This allows
+`DynamicTabSwitcherModel`'s `activeTabReaction` to settle before checking for orphans.
+
+### 5. DynamicTabSwitcher's close button calls `hide()`, not `removeTab()`
+
+**The issue:** Clicking X on a tab in `DynamicTabSwitcher` calls
+`DynamicTabSwitcherModel.hide(tabId)`, which removes the tab from the switcher's visible list
+but does NOT remove it from the `TabContainerModel`. The tab's model and rendered content
+persist in the DOM (with `display: none`). For dynamic detail tabs, we want actual removal.
+
+**Workaround:** Watch `visibleTabs` for changes and call `removeTab()` on dynamic tabs that
+are no longer visible (with the deferral from workaround #4).
+
+## Recommended Framework Changes
+
+In priority order:
+
+### P1: Allow `addTab` / `removeTab` on routed containers
+
+The guard in `setTabs()` that blocks mutations when `route` is set is too broad. Individual
+`addTab`/`removeTab` operations should be allowed — the restriction was likely intended for
+`setTabs()` (wholesale replacement) where route consistency is harder to guarantee. If
+`addTab`/`removeTab` worked with routing, the entire manual routing approach would be
+unnecessary for the common case.
+
+**Implementation sketch:** When adding a tab to a routed container, also register the new
+tab's route with Router 5 via `XH.router.add()`. When removing a tab, the route can remain
+(navigating to it would show no content, or could trigger a fallback). The `syncWithRouter()`
+method already iterates over `tabs` and matches by ID, so dynamically added tabs would
+naturally participate.
+
+The open question is parameterized routes (`/item/:id`). A single route definition can serve
+all dynamic items, but `TabContainerModel.syncWithRouter()` matches tabs by
+`route + '.' + tab.id`, which doesn't support params. Supporting a parameterized route pattern
+where multiple tabs map to the same route name (differentiated by params) would require
+changes to how `syncWithRouter` matches tabs.
+
+### P2: Support `onTabRemoved` callback or actual removal in DynamicTabSwitcher
+
+Currently, `DynamicTabSwitcher.hide()` only affects visibility, not the underlying
+`TabContainerModel`. For use cases where dynamic tabs should be fully removed (not just
+hidden), the framework should either:
+- Provide an `onTabRemoved` callback on the switcher config, or
+- Add a `removeOnHide` flag to `TabConfig` / `DynamicTabSwitcherModel`.
+
+### P3: Consider a `TabContainerModel` option for parameterized tab routes
+
+The current routing model assumes a 1:1 mapping between tab IDs and route segments. For
+dynamic item detail tabs, a more flexible model would allow a single parameterized route
+(e.g., `/item/:id`) to map to multiple tabs, with the model managing the ID↔tab lookup.
+
+## File Inventory
+
+| File | Purpose |
+|------|---------|
+| `apps/dynamicTabs.ts` | Entry point |
+| `examples/dynamicTabs/AppModel.ts` | Route definitions (incl. `/item/:id`) |
+| `examples/dynamicTabs/AppComponent.ts` | App shell with app bar |
+| `examples/dynamicTabs/DynamicRoutableTabsModel.ts` | Core model: manual routing sync |
+| `examples/dynamicTabs/DynamicRoutableTabsPanel.ts` | Panel: tab container + toolbar |
+| `examples/dynamicTabs/tabs/HomePanel.ts` | Static tab content |
+| `examples/dynamicTabs/tabs/SettingsPanel.ts` | Static tab content |
+| `examples/dynamicTabs/tabs/AboutPanel.ts` | Static tab content |
+| `examples/dynamicTabs/tabs/ItemDetailPanel.ts` | Dynamic tab content |

--- a/client-app/src/examples/dynamicTabs/tabs/AboutPanel.ts
+++ b/client-app/src/examples/dynamicTabs/tabs/AboutPanel.ts
@@ -1,0 +1,21 @@
+import {div} from '@xh/hoist/cmp/layout';
+import {hoistCmp} from '@xh/hoist/core';
+import {panel} from '@xh/hoist/desktop/cmp/panel';
+
+export const aboutPanel = hoistCmp.factory({
+    render() {
+        return panel({
+            className: 'dynamic-tabs-content',
+            item: div({
+                style: {padding: 20},
+                items: [
+                    div({
+                        style: {fontSize: 24, fontWeight: 'bold', marginBottom: 10},
+                        item: 'About'
+                    }),
+                    div('This is the About tab. Placeholder content.')
+                ]
+            })
+        });
+    }
+});

--- a/client-app/src/examples/dynamicTabs/tabs/HomePanel.ts
+++ b/client-app/src/examples/dynamicTabs/tabs/HomePanel.ts
@@ -1,0 +1,23 @@
+import {div} from '@xh/hoist/cmp/layout';
+import {hoistCmp} from '@xh/hoist/core';
+import {panel} from '@xh/hoist/desktop/cmp/panel';
+
+export const homePanel = hoistCmp.factory({
+    render() {
+        return panel({
+            className: 'dynamic-tabs-content',
+            item: div({
+                style: {padding: 20},
+                items: [
+                    div({
+                        style: {fontSize: 24, fontWeight: 'bold', marginBottom: 10},
+                        item: 'Home'
+                    }),
+                    div(
+                        'This is the Home tab. Use the toolbar above to open dynamic Item tabs by ID.'
+                    )
+                ]
+            })
+        });
+    }
+});

--- a/client-app/src/examples/dynamicTabs/tabs/ItemDetailPanel.ts
+++ b/client-app/src/examples/dynamicTabs/tabs/ItemDetailPanel.ts
@@ -1,0 +1,21 @@
+import {div} from '@xh/hoist/cmp/layout';
+import {hoistCmp} from '@xh/hoist/core';
+import {panel} from '@xh/hoist/desktop/cmp/panel';
+
+export const itemDetailPanel = hoistCmp.factory({
+    render({itemId}) {
+        return panel({
+            className: 'dynamic-tabs-content',
+            item: div({
+                style: {padding: 20},
+                items: [
+                    div({
+                        style: {fontSize: 32, fontWeight: 'bold', marginBottom: 10},
+                        item: `Detail for Item ${itemId}`
+                    }),
+                    div(`This is a dynamically created tab for item ${itemId}.`)
+                ]
+            })
+        });
+    }
+});

--- a/client-app/src/examples/dynamicTabs/tabs/SettingsPanel.ts
+++ b/client-app/src/examples/dynamicTabs/tabs/SettingsPanel.ts
@@ -1,0 +1,21 @@
+import {div} from '@xh/hoist/cmp/layout';
+import {hoistCmp} from '@xh/hoist/core';
+import {panel} from '@xh/hoist/desktop/cmp/panel';
+
+export const settingsPanel = hoistCmp.factory({
+    render() {
+        return panel({
+            className: 'dynamic-tabs-content',
+            item: div({
+                style: {padding: 20},
+                items: [
+                    div({
+                        style: {fontSize: 24, fontWeight: 'bold', marginBottom: 10},
+                        item: 'Settings'
+                    }),
+                    div('This is the Settings tab. Placeholder content.')
+                ]
+            })
+        });
+    }
+});


### PR DESCRIPTION
Exploratory spike demonstrating dynamic, routable tabs using TabContainerModel with DynamicTabSwitcher and Router 5 integration. All 7 target routing scenarios work via a manual routing workaround.

Key finding: TabContainerModel's built-in `route` config cannot be used with dynamic tabs — addTab/removeTab both call setTabs() which throws when routing is enabled. The workaround manages Router 5 ↔ tab sync manually with a direct router subscription and MobX reactions.

Additional friction points discovered and documented: Router 5's isActive() requires params for parameterized routes, MobX reactions don't reliably detect param-only route changes, DynamicTabSwitcher's hide() doesn't remove tabs from the container, and cleanup reactions race with tab creation due to MobX batching.

See FINDINGS.md for full analysis and recommended framework changes.