### PR TITLE
Adopt hoist-react telemetry API changes

### DIFF
--- a/client-app/src/admin/AppModel.ts
+++ b/client-app/src/admin/AppModel.ts
@@ -2,6 +2,7 @@ import {AppModel as HoistAdminAppModel} from '@xh/hoist/admin/AppModel';
 import {TabConfig} from '@xh/hoist/cmp/tab';
 import {XH} from '@xh/hoist/core';
 import {Icon} from '@xh/hoist/icon';
+import {Span} from '@xh/hoist/utils/telemetry';
 import {PortfolioService} from '../core/svc/PortfolioService';
 import {phaseRestPanel, projectRestPanel} from './roadmap';
 import {
@@ -23,9 +24,9 @@ import {
 export class AppModel extends HoistAdminAppModel {
     static instance: AppModel;
 
-    override async initAsync() {
-        await super.initAsync();
-        await XH.installServicesAsync(PortfolioService);
+    override async initAsync(span: Span) {
+        await super.initAsync(span);
+        await XH.installServicesAsync([PortfolioService], span);
     }
 
     //------------------------

--- a/client-app/src/admin/AppModel.ts
+++ b/client-app/src/admin/AppModel.ts
@@ -1,8 +1,7 @@
 import {AppModel as HoistAdminAppModel} from '@xh/hoist/admin/AppModel';
 import {TabConfig} from '@xh/hoist/cmp/tab';
-import {XH} from '@xh/hoist/core';
+import {InitContext, XH} from '@xh/hoist/core';
 import {Icon} from '@xh/hoist/icon';
-import {Span} from '@xh/hoist/utils/telemetry';
 import {PortfolioService} from '../core/svc/PortfolioService';
 import {phaseRestPanel, projectRestPanel} from './roadmap';
 import {
@@ -24,9 +23,9 @@ import {
 export class AppModel extends HoistAdminAppModel {
     static instance: AppModel;
 
-    override async initAsync(span: Span) {
-        await super.initAsync(span);
-        await XH.installServicesAsync([PortfolioService], span);
+    override async initAsync(ctx: InitContext) {
+        await super.initAsync(ctx);
+        await XH.installServicesAsync([PortfolioService], ctx);
     }
 
     //------------------------

--- a/client-app/src/core/svc/DocService.ts
+++ b/client-app/src/core/svc/DocService.ts
@@ -1,5 +1,6 @@
 import {HoistService, XH} from '@xh/hoist/core';
 import {makeObservable, observable, runInAction} from '@xh/hoist/mobx';
+import {Span} from '@xh/hoist/utils/telemetry';
 import MiniSearch from 'minisearch';
 import {DocCategory, DocEntry, DocSourceInfo} from '../../desktop/tabs/docs/docRegistry';
 
@@ -66,7 +67,7 @@ export class DocService extends HoistService {
         return this.registry.filter(it => it.source === source && it.category === categoryId);
     }
 
-    override async initAsync() {
+    override async initAsync(span: Span) {
         await this.loadRegistryAsync();
     }
 

--- a/client-app/src/core/svc/DocService.ts
+++ b/client-app/src/core/svc/DocService.ts
@@ -1,6 +1,5 @@
-import {HoistService, XH} from '@xh/hoist/core';
+import {HoistService, InitContext, XH} from '@xh/hoist/core';
 import {makeObservable, observable, runInAction} from '@xh/hoist/mobx';
-import {Span} from '@xh/hoist/utils/telemetry';
 import MiniSearch from 'minisearch';
 import {DocCategory, DocEntry, DocSourceInfo} from '../../desktop/tabs/docs/docRegistry';
 
@@ -67,7 +66,7 @@ export class DocService extends HoistService {
         return this.registry.filter(it => it.source === source && it.category === categoryId);
     }
 
-    override async initAsync(span: Span) {
+    override async initAsync(ctx: InitContext) {
         await this.loadRegistryAsync();
     }
 

--- a/client-app/src/core/svc/GitHubService.ts
+++ b/client-app/src/core/svc/GitHubService.ts
@@ -1,8 +1,7 @@
-import {HoistService, LoadSpec, XH} from '@xh/hoist/core';
+import {HoistService, InitContext, LoadSpec, XH} from '@xh/hoist/core';
 import {Icon} from '@xh/hoist/icon';
 import {computed, makeObservable, observable, runInAction} from '@xh/hoist/mobx';
 import {LocalDate} from '@xh/hoist/utils/datetime';
-import {Span} from '@xh/hoist/utils/telemetry';
 import {forOwn, sortBy} from 'lodash';
 
 export interface RepoCommitHistory {
@@ -50,7 +49,7 @@ export class GitHubService extends HoistService {
         makeObservable(this);
     }
 
-    override async initAsync(span: Span) {
+    override async initAsync(ctx: InitContext) {
         // Subscribe to websocket based updates so we refresh and pick up new commits immediately.
         XH.webSocketService.subscribe('gitHubUpdate', () => this.autoRefreshAsync());
 

--- a/client-app/src/core/svc/GitHubService.ts
+++ b/client-app/src/core/svc/GitHubService.ts
@@ -2,6 +2,7 @@ import {HoistService, LoadSpec, XH} from '@xh/hoist/core';
 import {Icon} from '@xh/hoist/icon';
 import {computed, makeObservable, observable, runInAction} from '@xh/hoist/mobx';
 import {LocalDate} from '@xh/hoist/utils/datetime';
+import {Span} from '@xh/hoist/utils/telemetry';
 import {forOwn, sortBy} from 'lodash';
 
 export interface RepoCommitHistory {
@@ -49,7 +50,7 @@ export class GitHubService extends HoistService {
         makeObservable(this);
     }
 
-    override async initAsync() {
+    override async initAsync(span: Span) {
         // Subscribe to websocket based updates so we refresh and pick up new commits immediately.
         XH.webSocketService.subscribe('gitHubUpdate', () => this.autoRefreshAsync());
 

--- a/client-app/src/core/svc/PortfolioService.ts
+++ b/client-app/src/core/svc/PortfolioService.ts
@@ -1,6 +1,5 @@
-import {HoistService, PlainObject, XH} from '@xh/hoist/core';
+import {HoistService, InitContext, PlainObject, XH} from '@xh/hoist/core';
 import {LocalDate} from '@xh/hoist/utils/datetime';
-import {Span} from '@xh/hoist/utils/telemetry';
 import {PositionSession} from '../positions/PositionSession';
 import {mapValues} from 'lodash';
 
@@ -10,8 +9,8 @@ export class PortfolioService extends HoistService {
     MAX_POSITIONS = 950;
     lookups: PlainObject;
 
-    override async initAsync(span: Span) {
-        this.lookups = await XH.fetchJson({url: 'portfolio/lookups', span});
+    override async initAsync(ctx: InitContext) {
+        this.lookups = await XH.fetchJson({url: 'portfolio/lookups', span: ctx.span});
     }
 
     async getSymbolsAsync({loadSpec}: any = {}) {

--- a/client-app/src/core/svc/PortfolioService.ts
+++ b/client-app/src/core/svc/PortfolioService.ts
@@ -1,5 +1,6 @@
 import {HoistService, PlainObject, XH} from '@xh/hoist/core';
 import {LocalDate} from '@xh/hoist/utils/datetime';
+import {Span} from '@xh/hoist/utils/telemetry';
 import {PositionSession} from '../positions/PositionSession';
 import {mapValues} from 'lodash';
 
@@ -9,8 +10,8 @@ export class PortfolioService extends HoistService {
     MAX_POSITIONS = 950;
     lookups: PlainObject;
 
-    override async initAsync() {
-        this.lookups = await XH.fetchJson({url: 'portfolio/lookups'});
+    override async initAsync(span: Span) {
+        this.lookups = await XH.fetchJson({url: 'portfolio/lookups', span});
     }
 
     async getSymbolsAsync({loadSpec}: any = {}) {

--- a/client-app/src/desktop/AppModel.ts
+++ b/client-app/src/desktop/AppModel.ts
@@ -1,7 +1,6 @@
 import {span} from '@xh/hoist/cmp/layout';
 import {TabConfig, TabContainerModel, TabSwitcherConfig} from '@xh/hoist/cmp/tab';
-import {LoadSpec, managed, XH} from '@xh/hoist/core';
-import {Span} from '@xh/hoist/utils/telemetry';
+import {InitContext, LoadSpec, managed, XH} from '@xh/hoist/core';
 import {
     autoRefreshAppOption,
     sizingModeAppOption,
@@ -87,9 +86,9 @@ export class AppModel extends BaseAppModel {
     @managed
     tabModel: TabContainerModel = this.createTabContainerModel();
 
-    override async initAsync(initSpan: Span) {
-        await super.initAsync(initSpan);
-        await XH.installServicesAsync([DocService, GitHubService, PortfolioService], initSpan);
+    override async initAsync(ctx: InitContext) {
+        await super.initAsync(ctx);
+        await XH.installServicesAsync([DocService, GitHubService, PortfolioService], ctx);
 
         // Demo app-specific handling of EnvironmentService.serverVersion observable.
         this.addReaction({

--- a/client-app/src/desktop/AppModel.ts
+++ b/client-app/src/desktop/AppModel.ts
@@ -1,6 +1,7 @@
 import {span} from '@xh/hoist/cmp/layout';
 import {TabConfig, TabContainerModel, TabSwitcherConfig} from '@xh/hoist/cmp/tab';
 import {LoadSpec, managed, XH} from '@xh/hoist/core';
+import {Span} from '@xh/hoist/utils/telemetry';
 import {
     autoRefreshAppOption,
     sizingModeAppOption,
@@ -86,9 +87,9 @@ export class AppModel extends BaseAppModel {
     @managed
     tabModel: TabContainerModel = this.createTabContainerModel();
 
-    override async initAsync() {
-        await super.initAsync();
-        await XH.installServicesAsync(DocService, GitHubService, PortfolioService);
+    override async initAsync(initSpan: Span) {
+        await super.initAsync(initSpan);
+        await XH.installServicesAsync([DocService, GitHubService, PortfolioService], initSpan);
 
         // Demo app-specific handling of EnvironmentService.serverVersion observable.
         this.addReaction({

--- a/client-app/src/examples/contact/AppModel.ts
+++ b/client-app/src/examples/contact/AppModel.ts
@@ -1,4 +1,5 @@
 import {XH} from '@xh/hoist/core';
+import {Span} from '@xh/hoist/utils/telemetry';
 import {ContactService} from './svc/ContactService';
 import {BaseAppModel} from '../../BaseAppModel';
 
@@ -7,8 +8,8 @@ export const PERSIST_APP = {prefKey: 'contactAppState'};
 export class AppModel extends BaseAppModel {
     static instance: AppModel;
 
-    override async initAsync() {
-        await super.initAsync();
-        await XH.installServicesAsync(ContactService);
+    override async initAsync(span: Span) {
+        await super.initAsync(span);
+        await XH.installServicesAsync([ContactService], span);
     }
 }

--- a/client-app/src/examples/contact/AppModel.ts
+++ b/client-app/src/examples/contact/AppModel.ts
@@ -1,5 +1,4 @@
-import {XH} from '@xh/hoist/core';
-import {Span} from '@xh/hoist/utils/telemetry';
+import {InitContext, XH} from '@xh/hoist/core';
 import {ContactService} from './svc/ContactService';
 import {BaseAppModel} from '../../BaseAppModel';
 
@@ -8,8 +7,8 @@ export const PERSIST_APP = {prefKey: 'contactAppState'};
 export class AppModel extends BaseAppModel {
     static instance: AppModel;
 
-    override async initAsync(span: Span) {
-        await super.initAsync(span);
-        await XH.installServicesAsync([ContactService], span);
+    override async initAsync(ctx: InitContext) {
+        await super.initAsync(ctx);
+        await XH.installServicesAsync([ContactService], ctx);
     }
 }

--- a/client-app/src/examples/news/AppModel.ts
+++ b/client-app/src/examples/news/AppModel.ts
@@ -1,4 +1,5 @@
 import {managed} from '@xh/hoist/core';
+import {Span} from '@xh/hoist/utils/telemetry';
 import {NewsPanelModel} from './NewsPanelModel';
 import {BaseAppModel} from '../../BaseAppModel';
 
@@ -6,8 +7,8 @@ export class AppModel extends BaseAppModel {
     static instance: AppModel;
     @managed newsPanelModel: NewsPanelModel;
 
-    override async initAsync() {
-        await super.initAsync();
+    override async initAsync(span: Span) {
+        await super.initAsync(span);
         this.newsPanelModel = new NewsPanelModel();
         this.loadAsync();
     }

--- a/client-app/src/examples/news/AppModel.ts
+++ b/client-app/src/examples/news/AppModel.ts
@@ -1,5 +1,4 @@
-import {managed} from '@xh/hoist/core';
-import {Span} from '@xh/hoist/utils/telemetry';
+import {InitContext, managed} from '@xh/hoist/core';
 import {NewsPanelModel} from './NewsPanelModel';
 import {BaseAppModel} from '../../BaseAppModel';
 
@@ -7,8 +6,8 @@ export class AppModel extends BaseAppModel {
     static instance: AppModel;
     @managed newsPanelModel: NewsPanelModel;
 
-    override async initAsync(span: Span) {
-        await super.initAsync(span);
+    override async initAsync(ctx: InitContext) {
+        await super.initAsync(ctx);
         this.newsPanelModel = new NewsPanelModel();
         this.loadAsync();
     }

--- a/client-app/src/examples/portfolio/AppModel.ts
+++ b/client-app/src/examples/portfolio/AppModel.ts
@@ -1,8 +1,7 @@
-import {XH} from '@xh/hoist/core';
+import {InitContext, XH} from '@xh/hoist/core';
 import {ViewManagerModel} from '@xh/hoist/cmp/viewmanager';
 import {sizingModeAppOption, themeAppOption} from '@xh/hoist/desktop/cmp/appOption';
 import {Icon} from '@xh/hoist/icon';
-import {Span} from '@xh/hoist/utils/telemetry';
 import {BaseAppModel} from '../../BaseAppModel';
 import {PortfolioService} from '../../core/svc/PortfolioService';
 
@@ -11,9 +10,9 @@ export class AppModel extends BaseAppModel {
 
     portfolioViewManager: ViewManagerModel;
 
-    override async initAsync(span: Span) {
-        await super.initAsync(span);
-        await XH.installServicesAsync([PortfolioService], span);
+    override async initAsync(ctx: InitContext) {
+        await super.initAsync(ctx);
+        await XH.installServicesAsync([PortfolioService], ctx);
 
         // Constructed here, in initAsync, so we can await the async factory and ensure that all
         // saved views are loaded and the desired option has been preselected before the model

--- a/client-app/src/examples/portfolio/AppModel.ts
+++ b/client-app/src/examples/portfolio/AppModel.ts
@@ -2,6 +2,7 @@ import {XH} from '@xh/hoist/core';
 import {ViewManagerModel} from '@xh/hoist/cmp/viewmanager';
 import {sizingModeAppOption, themeAppOption} from '@xh/hoist/desktop/cmp/appOption';
 import {Icon} from '@xh/hoist/icon';
+import {Span} from '@xh/hoist/utils/telemetry';
 import {BaseAppModel} from '../../BaseAppModel';
 import {PortfolioService} from '../../core/svc/PortfolioService';
 
@@ -10,9 +11,9 @@ export class AppModel extends BaseAppModel {
 
     portfolioViewManager: ViewManagerModel;
 
-    override async initAsync() {
-        await super.initAsync();
-        await XH.installServicesAsync(PortfolioService);
+    override async initAsync(span: Span) {
+        await super.initAsync(span);
+        await XH.installServicesAsync([PortfolioService], span);
 
         // Constructed here, in initAsync, so we can await the async factory and ensure that all
         // saved views are loaded and the desired option has been preselected before the model

--- a/client-app/src/examples/todo/AppModel.ts
+++ b/client-app/src/examples/todo/AppModel.ts
@@ -1,4 +1,5 @@
 import {XH} from '@xh/hoist/core';
+import {Span} from '@xh/hoist/utils/telemetry';
 import {TaskService} from './TaskService';
 import {BaseAppModel} from '../../BaseAppModel';
 
@@ -7,8 +8,8 @@ export const PERSIST_APP = {localStorageKey: 'todoAppState'};
 export class AppModel extends BaseAppModel {
     static instance: AppModel;
 
-    override async initAsync() {
-        await super.initAsync();
-        await XH.installServicesAsync(TaskService);
+    override async initAsync(span: Span) {
+        await super.initAsync(span);
+        await XH.installServicesAsync([TaskService], span);
     }
 }

--- a/client-app/src/examples/todo/AppModel.ts
+++ b/client-app/src/examples/todo/AppModel.ts
@@ -1,5 +1,4 @@
-import {XH} from '@xh/hoist/core';
-import {Span} from '@xh/hoist/utils/telemetry';
+import {InitContext, XH} from '@xh/hoist/core';
 import {TaskService} from './TaskService';
 import {BaseAppModel} from '../../BaseAppModel';
 
@@ -8,8 +7,8 @@ export const PERSIST_APP = {localStorageKey: 'todoAppState'};
 export class AppModel extends BaseAppModel {
     static instance: AppModel;
 
-    override async initAsync(span: Span) {
-        await super.initAsync(span);
-        await XH.installServicesAsync([TaskService], span);
+    override async initAsync(ctx: InitContext) {
+        await super.initAsync(ctx);
+        await XH.installServicesAsync([TaskService], ctx);
     }
 }

--- a/client-app/src/examples/weather/AppModel.ts
+++ b/client-app/src/examples/weather/AppModel.ts
@@ -1,6 +1,5 @@
-import {managed, XH} from '@xh/hoist/core';
+import {InitContext, managed, XH} from '@xh/hoist/core';
 import {ViewManagerModel} from '@xh/hoist/cmp/viewmanager';
-import {Span} from '@xh/hoist/utils/telemetry';
 import {
     autoRefreshAppOption,
     themeAppOption,
@@ -14,8 +13,8 @@ export class AppModel extends BaseAppModel {
     @managed weatherDashModel: WeatherDashModel;
     @managed weatherViewManager: ViewManagerModel;
 
-    override async initAsync(span: Span) {
-        await super.initAsync(span);
+    override async initAsync(ctx: InitContext) {
+        await super.initAsync(ctx);
 
         this.weatherViewManager = await ViewManagerModel.createAsync({
             type: 'weatherDashboard',

--- a/client-app/src/examples/weather/AppModel.ts
+++ b/client-app/src/examples/weather/AppModel.ts
@@ -1,5 +1,6 @@
 import {managed, XH} from '@xh/hoist/core';
 import {ViewManagerModel} from '@xh/hoist/cmp/viewmanager';
+import {Span} from '@xh/hoist/utils/telemetry';
 import {
     autoRefreshAppOption,
     themeAppOption,
@@ -13,8 +14,8 @@ export class AppModel extends BaseAppModel {
     @managed weatherDashModel: WeatherDashModel;
     @managed weatherViewManager: ViewManagerModel;
 
-    override async initAsync() {
-        await super.initAsync();
+    override async initAsync(span: Span) {
+        await super.initAsync(span);
 
         this.weatherViewManager = await ViewManagerModel.createAsync({
             type: 'weatherDashboard',

--- a/client-app/src/mobile/AppModel.ts
+++ b/client-app/src/mobile/AppModel.ts
@@ -1,4 +1,5 @@
 import {loadAllAsync, managed, XH} from '@xh/hoist/core';
+import {Span} from '@xh/hoist/utils/telemetry';
 import {
     autoRefreshAppOption,
     sizingModeAppOption,
@@ -160,9 +161,9 @@ export class AppModel extends BaseAppModel {
         ];
     }
 
-    override async initAsync() {
-        await super.initAsync();
-        await XH.installServicesAsync(PortfolioService);
+    override async initAsync(span: Span) {
+        await super.initAsync(span);
+        await XH.installServicesAsync([PortfolioService], span);
     }
 
     override async doLoadAsync(loadSpec) {

--- a/client-app/src/mobile/AppModel.ts
+++ b/client-app/src/mobile/AppModel.ts
@@ -1,5 +1,4 @@
-import {loadAllAsync, managed, XH} from '@xh/hoist/core';
-import {Span} from '@xh/hoist/utils/telemetry';
+import {InitContext, loadAllAsync, managed, XH} from '@xh/hoist/core';
 import {
     autoRefreshAppOption,
     sizingModeAppOption,
@@ -161,9 +160,9 @@ export class AppModel extends BaseAppModel {
         ];
     }
 
-    override async initAsync(span: Span) {
-        await super.initAsync(span);
-        await XH.installServicesAsync([PortfolioService], span);
+    override async initAsync(ctx: InitContext) {
+        await super.initAsync(ctx);
+        await XH.installServicesAsync([PortfolioService], ctx);
     }
 
     override async doLoadAsync(loadSpec) {

--- a/grails-app/init/io/xh/toolbox/BootStrap.groovy
+++ b/grails-app/init/io/xh/toolbox/BootStrap.groovy
@@ -4,6 +4,7 @@ import grails.gorm.transactions.Transactional
 import io.xh.hoist.config.ConfigService
 import io.xh.hoist.log.LogSupport
 import io.xh.hoist.pref.PrefService
+import io.xh.hoist.telemetry.trace.TraceService
 import io.xh.toolbox.user.User
 
 import java.time.LocalDate
@@ -16,20 +17,23 @@ class BootStrap implements LogSupport {
 
     ConfigService configService
     PrefService prefService
+    TraceService traceService
 
     def init = {servletContext ->
         logStartupMsg()
 
-        ensureRequiredConfigsCreated()
-        ensureRequiredPrefsCreated()
-        createLocalAdminUserIfNeeded()
+        traceService.withSpan(name: 'toolbox.server.appLoad', caller: this) {
+            ensureRequiredConfigsCreated()
+            ensureRequiredPrefsCreated()
+            createLocalAdminUserIfNeeded()
 
-        def services = xhServices.findAll {
-            it.class.canonicalName.startsWith(this.class.package.name)
+            def services = xhServices.findAll {
+                it.class.canonicalName.startsWith(this.class.package.name)
+            }
+            parallelInit(services)
+
+            JavaTest.helloWorld()
         }
-        parallelInit(services)
-
-        JavaTest.helloWorld()
     }
 
     def destroy = {}

--- a/grails-app/services/io/xh/toolbox/portfolio/PortfolioService.groovy
+++ b/grails-app/services/io/xh/toolbox/portfolio/PortfolioService.groovy
@@ -6,7 +6,7 @@ import io.micrometer.core.instrument.Timer
 import io.xh.hoist.BaseService
 import io.xh.hoist.cachedvalue.CachedValue
 import io.xh.hoist.exception.DataNotAvailableException
-import io.xh.hoist.telemetry.MetricsService
+import io.xh.hoist.telemetry.metric.MetricsService
 
 import java.time.*
 


### PR DESCRIPTION
## Summary

Downstream updates for the hoist-react telemetry changes in xh/hoist-react#4345:

- `AppModel.initAsync()` overrides now accept a `span: Span` and forward it to `super.initAsync(span)`
- `XH.installServicesAsync()` calls updated to `([ServiceA, ServiceB], span)` array form
- Service `initAsync()` overrides accept the new `span: Span` parameter

## Test plan

- [ ] Smoke-test Toolbox boots against hoist-react SNAPSHOT from #4345
- [ ] Confirm service-init spans nest under `app-init` when tracing enabled