### PR TITLE
Adopt LoadSpec spanning API

### DIFF
--- a/client-app/src/examples/news/AppModel.ts
+++ b/client-app/src/examples/news/AppModel.ts
@@ -9,7 +9,7 @@ export class AppModel extends BaseAppModel {
     override async initAsync(ctx: InitContext) {
         await super.initAsync(ctx);
         this.newsPanelModel = new NewsPanelModel();
-        this.loadAsync({parentSpan: ctx.span});
+        this.loadAsync({span: ctx.span});
     }
 
     override async doLoadAsync(loadSpec) {

--- a/client-app/src/examples/news/AppModel.ts
+++ b/client-app/src/examples/news/AppModel.ts
@@ -9,7 +9,7 @@ export class AppModel extends BaseAppModel {
     override async initAsync(ctx: InitContext) {
         await super.initAsync(ctx);
         this.newsPanelModel = new NewsPanelModel();
-        this.loadAsync();
+        this.loadAsync({parentSpan: ctx.span});
     }
 
     override async doLoadAsync(loadSpec) {

--- a/client-app/src/examples/news/NewsPanelModel.ts
+++ b/client-app/src/examples/news/NewsPanelModel.ts
@@ -10,6 +10,7 @@ import {p, vbox} from '@xh/hoist/cmp/layout';
 export class NewsPanelModel extends HoistModel {
     SEARCH_FIELDS = ['title', 'text'];
 
+    loadSpan = 'toolbox.client.news.load';
     @managed
     viewModel = new DataViewModel({
         emptyText: vbox([

--- a/client-app/src/examples/news/NewsPanelModel.ts
+++ b/client-app/src/examples/news/NewsPanelModel.ts
@@ -1,4 +1,4 @@
-import {HoistModel, managed, XH} from '@xh/hoist/core';
+import {HoistModel, LoadSpec, managed, XH} from '@xh/hoist/core';
 import {action, bindable, observable, makeObservable} from '@xh/hoist/mobx';
 import {DataViewModel} from '@xh/hoist/cmp/dataview';
 import {appendFilter, FilterLike} from '@xh/hoist/data';
@@ -10,7 +10,6 @@ import {p, vbox} from '@xh/hoist/cmp/layout';
 export class NewsPanelModel extends HoistModel {
     SEARCH_FIELDS = ['title', 'text'];
 
-    loadSpan = 'toolbox.client.news.load';
     @managed
     viewModel = new DataViewModel({
         emptyText: vbox([
@@ -52,7 +51,11 @@ export class NewsPanelModel extends HoistModel {
         });
     }
 
-    override async doLoadAsync(loadSpec) {
+    override getLoadSpan() {
+        return 'toolbox.client.news.load';
+    }
+
+    override async doLoadAsync(loadSpec: LoadSpec) {
         const stories = await XH.fetchJson({url: 'news', loadSpec});
         this.completeLoad(stories);
     }

--- a/client-app/src/examples/news/NewsPanelModel.ts
+++ b/client-app/src/examples/news/NewsPanelModel.ts
@@ -51,10 +51,6 @@ export class NewsPanelModel extends HoistModel {
         });
     }
 
-    override getLoadSpan() {
-        return 'toolbox.client.news.load';
-    }
-
     override async doLoadAsync(loadSpec: LoadSpec) {
         const stories = await XH.fetchJson({url: 'news', loadSpec});
         this.completeLoad(stories);

--- a/client-app/src/examples/recalls/RecallsPanelModel.ts
+++ b/client-app/src/examples/recalls/RecallsPanelModel.ts
@@ -116,10 +116,6 @@ export class RecallsPanelModel extends HoistModel {
     //------------------------
     // Implementation
     //------------------------
-    override getLoadSpan() {
-        return 'toolbox.client.recalls.load';
-    }
-
     override async doLoadAsync(loadSpec) {
         const {gridModel} = this;
 

--- a/client-app/src/examples/recalls/RecallsPanelModel.ts
+++ b/client-app/src/examples/recalls/RecallsPanelModel.ts
@@ -11,8 +11,6 @@ import {DetailsPanelModel} from './detail/DetailsPanelModel';
 export class RecallsPanelModel extends HoistModel {
     override persistWith = PERSIST_APP;
 
-    loadSpan = 'toolbox.client.recalls.load';
-
     @bindable
     searchQuery: string = '';
 
@@ -118,6 +116,10 @@ export class RecallsPanelModel extends HoistModel {
     //------------------------
     // Implementation
     //------------------------
+    override getLoadSpan() {
+        return 'toolbox.client.recalls.load';
+    }
+
     override async doLoadAsync(loadSpec) {
         const {gridModel} = this;
 

--- a/client-app/src/examples/recalls/RecallsPanelModel.ts
+++ b/client-app/src/examples/recalls/RecallsPanelModel.ts
@@ -11,6 +11,8 @@ import {DetailsPanelModel} from './detail/DetailsPanelModel';
 export class RecallsPanelModel extends HoistModel {
     override persistWith = PERSIST_APP;
 
+    loadSpan = 'toolbox.client.recalls.load';
+
     @bindable
     searchQuery: string = '';
 

--- a/client-app/src/examples/weather/AppModel.ts
+++ b/client-app/src/examples/weather/AppModel.ts
@@ -24,7 +24,7 @@ export class AppModel extends BaseAppModel {
         });
 
         this.weatherDashModel = new WeatherDashModel(this.weatherViewManager);
-        this.loadAsync({parentSpan: ctx.span});
+        this.loadAsync({span: ctx.span});
     }
 
     override async doLoadAsync(loadSpec) {

--- a/client-app/src/examples/weather/AppModel.ts
+++ b/client-app/src/examples/weather/AppModel.ts
@@ -24,7 +24,7 @@ export class AppModel extends BaseAppModel {
         });
 
         this.weatherDashModel = new WeatherDashModel(this.weatherViewManager);
-        this.loadAsync();
+        this.loadAsync({parentSpan: ctx.span});
     }
 
     override async doLoadAsync(loadSpec) {

--- a/client-app/src/examples/weather/WeatherDashModel.ts
+++ b/client-app/src/examples/weather/WeatherDashModel.ts
@@ -133,10 +133,6 @@ export class WeatherDashModel extends HoistModel {
         });
     }
 
-    override getLoadSpan() {
-        return 'toolbox.client.weather.load';
-    }
-
     override async doLoadAsync(loadSpec: LoadSpec) {
         const {selectedCity} = this;
         if (!selectedCity) return;

--- a/client-app/src/examples/weather/WeatherDashModel.ts
+++ b/client-app/src/examples/weather/WeatherDashModel.ts
@@ -137,7 +137,6 @@ export class WeatherDashModel extends HoistModel {
         const {selectedCity} = this;
         if (!selectedCity) return;
 
-        loadSpec.span.setTags({city: selectedCity});
         try {
             const [currentWeather, forecast] = await Promise.all([
                 XH.fetchJson({

--- a/client-app/src/examples/weather/WeatherDashModel.ts
+++ b/client-app/src/examples/weather/WeatherDashModel.ts
@@ -57,8 +57,6 @@ export class WeatherDashModel extends HoistModel {
     viewManagerModel: ViewManagerModel;
     @managed dashCanvasModel: DashCanvasModel;
 
-    loadSpan = 'toolbox.client.weather.load';
-
     constructor(viewManagerModel: ViewManagerModel) {
         super();
         makeObservable(this);
@@ -135,11 +133,15 @@ export class WeatherDashModel extends HoistModel {
         });
     }
 
+    override getLoadSpan() {
+        return 'toolbox.client.weather.load';
+    }
+
     override async doLoadAsync(loadSpec: LoadSpec) {
         const {selectedCity} = this;
         if (!selectedCity) return;
 
-        loadSpec.span?.setTags({city: selectedCity});
+        loadSpec.span.setTags({city: selectedCity});
         try {
             const [currentWeather, forecast] = await Promise.all([
                 XH.fetchJson({

--- a/client-app/src/examples/weather/WeatherDashModel.ts
+++ b/client-app/src/examples/weather/WeatherDashModel.ts
@@ -57,6 +57,8 @@ export class WeatherDashModel extends HoistModel {
     viewManagerModel: ViewManagerModel;
     @managed dashCanvasModel: DashCanvasModel;
 
+    loadSpan = 'toolbox.client.weather.load';
+
     constructor(viewManagerModel: ViewManagerModel) {
         super();
         makeObservable(this);
@@ -137,29 +139,25 @@ export class WeatherDashModel extends HoistModel {
         const {selectedCity} = this;
         if (!selectedCity) return;
 
+        loadSpec.span?.setTags({city: selectedCity});
         try {
-            await this.span('toolbox.client.weather.loadDash').run(async span => {
-                const [currentWeather, forecast] = await Promise.all([
-                    XH.fetchJson({
-                        url: 'weather/current',
-                        params: {city: selectedCity},
-                        loadSpec,
-                        span
-                    }),
-                    XH.fetchJson({
-                        url: 'weather/forecast',
-                        params: {city: selectedCity},
-                        loadSpec,
-                        span
-                    })
-                ]);
+            const [currentWeather, forecast] = await Promise.all([
+                XH.fetchJson({
+                    url: 'weather/current',
+                    params: {city: selectedCity},
+                    loadSpec
+                }),
+                XH.fetchJson({
+                    url: 'weather/forecast',
+                    params: {city: selectedCity},
+                    loadSpec
+                })
+            ]);
+            if (loadSpec.isStale) return;
 
-                if (loadSpec.isStale) return;
-
-                runInAction(() => {
-                    this.currentWeather = currentWeather;
-                    this.forecast = forecast;
-                });
+            runInAction(() => {
+                this.currentWeather = currentWeather;
+                this.forecast = forecast;
             });
         } catch (e) {
             if (loadSpec.isAutoRefresh || loadSpec.isStale) return;


### PR DESCRIPTION
## Summary

Adopts the new hoist-react `loadSpec` opt-in (xh/hoist-react#4353) in three example models.

Pairs with hoist-react PR xh/hoist-react#4353.
