### PR TITLE
Update FileChooser callers for react-dropzone 15 upgrade

### DIFF
--- a/client-app/src/desktop/tabs/other/FileChooserPanel.ts
+++ b/client-app/src/desktop/tabs/other/FileChooserPanel.ts
@@ -45,7 +45,7 @@ export const fileChooserPanel = hoistCmp.factory({
                     enableMulti,
                     enableAddMulti,
                     showFileGrid,
-                    accept: ['.txt', '.png'],
+                    accept: {'text/plain': ['.txt'], 'image/png': ['.png']},
                     targetText: fragment(
                         p('Drag and drop files here, or click to browse.'),
                         p(

--- a/client-app/src/examples/filemanager/FileManager.ts
+++ b/client-app/src/examples/filemanager/FileManager.ts
@@ -5,6 +5,7 @@ import {panel} from '@xh/hoist/desktop/cmp/panel';
 import {toolbarSep} from '@xh/hoist/desktop/cmp/toolbar';
 import {button} from '@xh/hoist/desktop/cmp/button';
 import {fileChooser} from '@xh/hoist/desktop/cmp/filechooser';
+import {Accept} from '@xh/hoist/kit/react-dropzone';
 import {grid} from '@xh/hoist/cmp/grid';
 import {FileManagerModel} from './FileManagerModel';
 import './FileManager.scss';
@@ -61,16 +62,16 @@ export const fileManager = hoistCmp.factory({
 
 // Entire example is limited to admins, but still limit to arbitrary-but-reasonable list of
 // accepted file types for sanity (and to demo the `accepts` prop).
-const acceptedFileTypes: string[] = [
-    '.txt',
-    '.png',
-    '.gif',
-    '.jpg',
-    '.doc',
-    '.docx',
-    '.xls',
-    '.xlsx',
-    '.ppt',
-    '.pptx',
-    '.pdf'
-];
+const acceptedFileTypes: Accept = {
+    'text/plain': ['.txt'],
+    'image/png': ['.png'],
+    'image/gif': ['.gif'],
+    'image/jpeg': ['.jpg'],
+    'application/msword': ['.doc'],
+    'application/vnd.openxmlformats-officedocument.wordprocessingml.document': ['.docx'],
+    'application/vnd.ms-excel': ['.xls'],
+    'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet': ['.xlsx'],
+    'application/vnd.ms-powerpoint': ['.ppt'],
+    'application/vnd.openxmlformats-officedocument.presentationml.presentation': ['.pptx'],
+    'application/pdf': ['.pdf']
+};


### PR DESCRIPTION
Adopts the new `Accept` object form for the `FileChooser.accept` prop, keyed by MIME type with extension arrays as values.