### PR TITLE
build.gradle: skip JDK-install props when forwarding to bootRun JVM

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -140,10 +140,27 @@ Map hoistMetaData = [
 //-------------------------
 // Trampoline  jvmArgs
 //-------------------------
+// Properties that describe the daemon's own JDK install. Forwarding them to a forked toolchain
+// JVM that runs a different JDK corrupts it - e.g. `java.home` makes the forked JVM resolve its
+// internal modules against the wrong install, surfacing as `NoClassDefFoundError` on any code
+// path that touches ICU (regex normalization, JCE init, java.text.Normalizer).
+def jdkInstallProps = [
+    'java.class.path', 'java.class.version', 'java.home', 'java.library.path',
+    'java.runtime.name', 'java.runtime.version', 'java.specification.name',
+    'java.specification.vendor', 'java.specification.version',
+    'java.vendor', 'java.vendor.url', 'java.vendor.url.bug', 'java.vendor.version',
+    'java.version', 'java.version.date',
+    'java.vm.compressedOopsMode', 'java.vm.info', 'java.vm.name',
+    'java.vm.specification.name', 'java.vm.specification.vendor', 'java.vm.specification.version',
+    'java.vm.vendor', 'java.vm.version', 'jdk.debug'
+] as Set
+
 def execTasks = tasks.matching {it.name == 'bootRun' || it.name == 'console'}
 execTasks.configureEach {
     ignoreExitValue = true
-    systemProperties System.properties
+    // Forward daemon `-D` properties (e.g. `bootRun -Dserver.port=8081`) but skip the
+    // JDK-install descriptors above.
+    systemProperties System.properties.findAll { k, _ -> !jdkInstallProps.contains(k) }
     jvmArgs(allJvmArgs)
     systemProperties hoistMetaData
     // Bring .env sourced environment variables into bootRun JVM process.


### PR DESCRIPTION
## Summary

The `execTasks` block in `build.gradle` (shared verbatim across XH apps) wholesale-forwards the Gradle daemon's `System.properties` to the forked `bootRun`/`console` JVM via `systemProperties System.properties`. When the daemon JDK differs from the toolchain JDK — common with sdkman-managed daemons + a toolchain pin — that forward overrides the forked JVM's own `java.home` (and a handful of related JDK-install descriptors) with the daemon's. The forked JVM then resolves its internal modules against the wrong install, breaking `Class.getResourceAsStream` for any non-exported JDK package (notably `sun/text/resources/icu/unicode/Norm.icu`).

Concrete symptom on this branch's reproducer: any call into `java.text.Normalizer`, `java.util.regex.Pattern` with canonical equivalence, or `javax.crypto.Cipher.getInstance(...)` (via `JceSecurity.<clinit>` → policy-file glob compilation → ICU normalize) throws `NoClassDefFoundError: jdk.internal.icu.text.NormalizerBase$NFCModeImpl` and poisons that JVM permanently. The failure is fully reproducible standalone:

```
$ /path/to/jdk-21/bin/java -Djava.home=/path/to/jdk-17 -cp ... JceTest
Normalizer.normalize: FAIL ExceptionInInitializerError
Cipher.getInstance:   FAIL NoClassDefFoundError
```

This change narrows the forward to skip the descriptors that name the JDK install (`java.home`, `java.version`, `java.vendor`, `java.vm.*`, `java.runtime.*`, `java.specification.*`, `java.class.path`, `java.library.path`, `jdk.debug`) while continuing to pass everything else through. Documented developer flags (`-Dserver.port=8081`, `-Duser.timezone=Etc/UTC`, `-Dserver.ssl.*` — all referenced in `README.md`) keep working unchanged.

## Why the narrow denylist over alternatives

- **Remove the forward entirely** — tempting, but breaks the `README.md`-documented dev workflow (port override, timezone override, the HTTPS-on-xh.io flow), and `user.timezone` in particular has no `--args=` or env-var equivalent.
- **Targeted allowlist** (e.g. only forward `http.*`, `https.*`, `server.*`) — same downside as removal, plus inevitable churn as new well-known prefixes emerge.
- **Skip just the JDK-install descriptors** (this PR) — preserves all documented patterns, fixes the actual failure mode, and the blocked set is small and stable.

## How it was found

Surfaced while bringing up a Playwright E2E suite against a JDK 21 toolchain on top of a sdkman-default JDK 17 daemon. The initial symptom was Toolbox bootstrap blowing up inside `jasypt` — which led down a path of investigating jasypt and its successor in hoist-core. End-to-end verification ultimately traced the root cause to this `build.gradle` line. Diagnosis + repro detail in `docs/playwright-port/PR568_VERIFICATION_FINDING.md` (on the playwright-setup branch).

## Test plan

- [x] `./gradlew :bootRun` boots cleanly with daemon JDK ≠ toolchain JDK (the original failure scenario).
- [x] `./gradlew :bootRun -Dserver.port=8081` propagates correctly — Spring Boot binds 8081.
- [x] `./gradlew :bootRun -Duser.timezone=Etc/UTC` propagates correctly — boot log timestamps in UTC.
- [x] Hot-swap mode (`enableHotSwap=true`) still functional.
- [ ] Reviewer to confirm production deploy (`java -jar`) is unaffected — this block only configures the Gradle `bootRun`/`console` tasks.

## Sibling apps

The same `execTasks` block appears verbatim in several other XH Hoist apps that came from the same Grails 5 upgrade in 2022. A corresponding small PR per app is warranted; longer-term, this configuration is a candidate for extraction into a shared Gradle convention plugin under `hoist-dev-utils` (or similar) so the fix lands once, not N times.

🤖 Generated with [Claude Code](https://claude.com/claude-code)