### PR TITLE
Mobile: standalone Docs viewer (corpus chooser, drill-down, search)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## 10.0.0-SNAPSHOT - unreleased
 
+### New Features
+
+* Promoted the mobile (phone) documentation viewer to a top-level Docs section: a corpus-chooser landing (hoist-react and hoist-core as cards with live doc counts and recently-viewed shortcuts), iOS-style push drill-down through categories and documents, and a cross-corpus search screen with recent searches and library-grouped, highlighted results - all routing into the existing single-doc reader, now fitted with a within-category prev/next pager.
+
 ## 9.0.0 - 2026-06-22
 
 ### New Features

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### New Features
 
-* Promoted the mobile (phone) documentation viewer to a top-level Docs section: a corpus-chooser landing (hoist-react and hoist-core as cards with live doc counts and recently-viewed shortcuts), iOS-style push drill-down through categories and documents, and a cross-corpus search screen with recent searches and library-grouped, highlighted results - all routing into the existing single-doc reader, now fitted with a within-category prev/next pager.
+* Promoted the mobile documentation viewer to a top-level Docs section: a library-chooser landing (hoist-react and hoist-core as cards plus recently-viewed shortcuts), iOS-style push drill-down through categories and documents, and a search screen with recent searches and library-grouped, highlighted results - all routing into the existing single-doc reader.
 
 ## 9.0.0 - 2026-06-22
 

--- a/client-app/src/core/docs/DocIcons.ts
+++ b/client-app/src/core/docs/DocIcons.ts
@@ -1,0 +1,62 @@
+import {library} from '@fortawesome/fontawesome-svg-core';
+import {faReact} from '@fortawesome/free-brands-svg-icons';
+import {Icon} from '@xh/hoist/icon';
+import {ReactElement} from 'react';
+
+// Register the React brand icon used for the hoist-react source (brand glyphs are opt-in).
+library.add(faReact);
+
+/**
+ * Shared icon helpers for the documentation viewer, used by both the desktop tree-grid nav and the
+ * mobile drill-down screens so a given doc source / category always reads with the same glyph.
+ */
+
+/** Icon for a documentation source (corpus). */
+export function getSourceIcon(source: string): ReactElement {
+    switch (source) {
+        case 'hoist-react':
+            return Icon.icon({iconName: 'react', prefix: 'fab'});
+        case 'hoist-core':
+            return Icon.server();
+        default:
+            return Icon.folder();
+    }
+}
+
+/** Icon for a documentation category, keyed by the category id from the registry. */
+export function getCategoryIcon(categoryId: string): ReactElement {
+    switch (categoryId) {
+        case 'app-development':
+            return Icon.code();
+        case 'components':
+            return Icon.gridPanel();
+        case 'concepts':
+            return Icon.book();
+        case 'core':
+            return Icon.gear();
+        case 'core-features':
+            return Icon.boxFull();
+        case 'core-framework':
+            return Icon.gear();
+        case 'desktop':
+            return Icon.desktop();
+        case 'devops':
+            return Icon.server();
+        case 'grails-platform':
+            return Icon.database();
+        case 'infrastructure':
+            return Icon.server();
+        case 'mobile':
+            return Icon.mobile();
+        case 'overview':
+            return Icon.home();
+        case 'supporting':
+            return Icon.cube();
+        case 'upgrade':
+            return Icon.arrowUp();
+        case 'utilities':
+            return Icon.wrench();
+        default:
+            return Icon.folder();
+    }
+}

--- a/client-app/src/core/docs/DocUtils.ts
+++ b/client-app/src/core/docs/DocUtils.ts
@@ -8,6 +8,24 @@ const DOC_SOURCE_TOKENS: Record<string, string> = {
 };
 
 /**
+ * Encode a doc id (a file path, e.g. `cmp/grid/README.md`) for safe use as a single route param,
+ * swapping `/` for `~` so it does not introduce extra path segments. {@link decodeDocId} reverses it.
+ */
+export function encodeDocId(id: string): string {
+    return id.replaceAll('/', '~');
+}
+
+/** Decode a `~`-encoded route docId back to its file-path form. */
+export function decodeDocId(routeId: string): string {
+    return routeId.replaceAll('~', '/');
+}
+
+/** True if two entries reference the same doc (same source + id). */
+export function sameDoc(a: DocEntry, b: DocEntry): boolean {
+    return a.source === b.source && a.id === b.id;
+}
+
+/**
  * Parse a Markdown doc url (e.g. `$HR/cmp/grid/README.md#tree-grids`) into the params needed to
  * route into the document viewer: the `source` repo, the `docId` (file path, with `/` encoded as
  * `~` for the route), and an optional `section` (an H2 slug). Returns null for any url that is not
@@ -23,7 +41,7 @@ export function docRouteParams(
     const [path, section] = rest.join('/').split('#');
     if (!path.endsWith('.md')) return null;
 
-    return {source, docId: path.replaceAll('/', '~'), section: section ?? null};
+    return {source, docId: encodeDocId(path), section: section ?? null};
 }
 
 /**

--- a/client-app/src/core/docs/DocViewModel.ts
+++ b/client-app/src/core/docs/DocViewModel.ts
@@ -2,7 +2,7 @@ import {HoistModel, LoadSpec, XH} from '@xh/hoist/core';
 import {action, computed, makeObservable, observable, runInAction} from '@xh/hoist/mobx';
 import {DocService} from '../svc/DocService';
 import {DocCategory, DocEntry, DocSection} from './types';
-import {extractSections, resolveDocLink} from './DocUtils';
+import {decodeDocId, encodeDocId, extractSections, resolveDocLink} from './DocUtils';
 
 /**
  * Shared, platform-neutral base for the documentation viewer. Owns the active doc, its loaded
@@ -115,6 +115,7 @@ export abstract class DocViewModel extends HoistModel {
         this.activeSection = null;
         this.pendingScrollSection = section ?? null;
         this.content = null;
+        this.docService.noteRecentlyViewed(entry);
         this.onDocActivated(entry);
         this.loadAsync();
         this.updateRouteFromDoc();
@@ -186,18 +187,19 @@ export abstract class DocViewModel extends HoistModel {
         if (!this.isDocsRoute(name)) return;
 
         if (activeDoc) {
-            XH.navigate(
-                docRouteName,
-                {source: activeDoc.source, docId: this.docIdToRoute(activeDoc.id)},
-                {replace: true}
-            );
+            XH.navigate(docRouteName, this.routeParamsForDoc(activeDoc), {replace: true});
         } else {
             XH.navigate(BASE_ROUTE, {replace: true});
         }
     }
 
-    private docIdToRoute(docId: string): string {
-        return docId.replaceAll('/', '~');
+    /**
+     * Build the route params written back when a doc is activated. Base form is `{source, docId}`;
+     * subclasses whose active route needs additional segment params (e.g. the mobile browse reader's
+     * `categoryId`) override this to add them.
+     */
+    protected routeParamsForDoc(entry: DocEntry): Record<string, string> {
+        return {source: entry.source, docId: encodeDocId(entry.id)};
     }
 
     protected docRefFromRoute(params: Record<string, string>): {
@@ -207,7 +209,7 @@ export abstract class DocViewModel extends HoistModel {
     } {
         const {source, docId, section} = params;
         if (!source || !docId) return null;
-        return {source, docId: docId.replaceAll('~', '/'), section: section ?? null};
+        return {source, docId: decodeDocId(docId), section: section ?? null};
     }
 
     /**

--- a/client-app/src/core/docs/index.ts
+++ b/client-app/src/core/docs/index.ts
@@ -1,4 +1,5 @@
 export {docContent} from './DocContent';
 export {DocViewModel} from './DocViewModel';
+export {getCategoryIcon, getSourceIcon} from './DocIcons';
 export * from './types';
 export * from './DocUtils';

--- a/client-app/src/core/svc/DocService.ts
+++ b/client-app/src/core/svc/DocService.ts
@@ -1,12 +1,22 @@
 import {HoistService, InitContext, XH} from '@xh/hoist/core';
-import {makeObservable, observable, runInAction} from '@xh/hoist/mobx';
+import {action, makeObservable, observable, runInAction} from '@xh/hoist/mobx';
+import {isEmpty} from 'lodash';
 import MiniSearch from 'minisearch';
+import {sameDoc} from '../docs/DocUtils';
 import {DocCategory, DocEntry, DocSourceInfo} from '../docs/types';
 
 export interface DocSearchResult {
     entry: DocEntry;
     score: number;
+    /** A short content excerpt around the first matched term (mobile search results). */
+    snippet?: string;
+    /** The query terms used, for client-side highlighting. */
+    matchedTerms?: string[];
 }
+
+/** localStorage key + cap for the mobile "recently viewed" docs list. */
+const RECENT_DOCS_KEY = 'docs.recentDocs',
+    RECENT_DOCS_MAX = 8;
 
 /**
  * Service providing access to hoist-react and hoist-core documentation content.
@@ -22,6 +32,9 @@ export class DocService extends HoistService {
     @observable indexReady: boolean = false;
     @observable.ref registry: DocEntry[] = [];
     @observable.ref sourceInfo: Record<string, DocSourceInfo> = {};
+
+    /** Most-recently-viewed docs (most recent first), persisted locally - drives the mobile landing. */
+    @observable.ref recentDocs: DocEntry[] = [];
 
     private cache: Map<string, string> = new Map();
     private index: MiniSearch;
@@ -68,8 +81,86 @@ export class DocService extends HoistService {
         return this.registry.filter(it => it.source === source && it.category === categoryId);
     }
 
+    /** Total number of docs available for a given source. */
+    getDocCount(source: string): number {
+        return this.registry.filter(it => it.source === source).length;
+    }
+
+    /** Categories for a source that contain at least one doc (in registry order). */
+    getPopulatedCategories(source: string): DocCategory[] {
+        return this.getCategories(source).filter(
+            c => this.getDocsByCategory(source, c.id).length > 0
+        );
+    }
+
+    /** Number of populated categories for a source. */
+    getCategoryCount(source: string): number {
+        return this.getPopulatedCategories(source).length;
+    }
+
+    /**
+     * Record a doc as recently viewed (most recent first, de-duped, capped). Persisted to
+     * localStorage so the mobile landing's "Jump back in" row survives reloads. Called from the
+     * shared `DocViewModel.navigateToDoc`, so any in-app doc view feeds it.
+     */
+    @action
+    noteRecentlyViewed(entry: DocEntry) {
+        const next = [entry, ...this.recentDocs.filter(d => !sameDoc(d, entry))].slice(
+            0,
+            RECENT_DOCS_MAX
+        );
+        this.recentDocs = next;
+        XH.localStorageService.set(
+            RECENT_DOCS_KEY,
+            next.map(d => `${d.source}:${d.id}`)
+        );
+    }
+
+    /**
+     * First content line containing any of the given terms, markdown-stripped and clipped - used as
+     * the matched-line excerpt on mobile search hits. Reads cached content only (populated once the
+     * full-text index has been built); returns null when no content is cached or no line matches.
+     */
+    getContentSnippet(source: string, docId: string, terms: string[]): string | null {
+        const content = this.cache.get(`${source}:${docId}`);
+        if (!content || isEmpty(terms)) return null;
+
+        const lowered = terms.map(t => t.toLowerCase()),
+            lines = this.stripMarkdown(content).split('\n');
+        const hit = lines.find(line => {
+            const lc = line.toLowerCase();
+            return lowered.some(t => lc.includes(t));
+        });
+        if (!hit) return null;
+
+        const trimmed = hit.trim();
+        if (trimmed.length <= 140) return trimmed;
+
+        // Clip a ~140-char window centered on the first match.
+        const idx = lowered.reduce((min, t) => {
+            const i = trimmed.toLowerCase().indexOf(t);
+            return i >= 0 && (min < 0 || i < min) ? i : min;
+        }, -1);
+        const start = Math.max(0, idx - 50),
+            excerpt = trimmed.slice(start, start + 140).trim();
+        return (start > 0 ? '...' : '') + excerpt + '...';
+    }
+
     override async initAsync(ctx: InitContext) {
         await this.loadRegistryAsync();
+        this.hydrateRecentDocs();
+    }
+
+    /** Restore recently-viewed docs from localStorage, mapping stored ids to live registry entries. */
+    @action
+    private hydrateRecentDocs() {
+        const stored: string[] = XH.localStorageService.get(RECENT_DOCS_KEY, []);
+        this.recentDocs = stored
+            .map(key => {
+                const [source, ...idParts] = key.split(':');
+                return this.getDocEntry(idParts.join(':'), source);
+            })
+            .filter(Boolean);
     }
 
     /** Kick off full-text index build. Called lazily on first search request. */

--- a/client-app/src/desktop/tabs/docs/DocsPanelModel.ts
+++ b/client-app/src/desktop/tabs/docs/DocsPanelModel.ts
@@ -5,6 +5,7 @@ import {PanelModel} from '@xh/hoist/desktop/cmp/panel';
 import {Icon} from '@xh/hoist/icon';
 import {action, bindable, computed, makeObservable, observable, runInAction} from '@xh/hoist/mobx';
 import {DocViewModel} from '../../../core/docs/DocViewModel';
+import {getCategoryIcon, getSourceIcon} from '../../../core/docs/DocIcons';
 import {DocEntry, DocExampleLink, getDocExamples} from './docRegistry';
 import {DocSearchResult} from '../../../core/svc/DocService';
 
@@ -346,51 +347,12 @@ export class DocsPanelModel extends DocViewModel {
         this.navigateToDoc(docId, source);
     }
 
+    /** Delegate to the shared doc-icon helpers (kept as instance methods for view call-sites). */
     getCategoryIcon(categoryId: string) {
-        switch (categoryId) {
-            case 'app-development':
-                return Icon.code();
-            case 'components':
-                return Icon.gridPanel();
-            case 'concepts':
-                return Icon.book();
-            case 'core':
-                return Icon.gear();
-            case 'core-features':
-                return Icon.boxFull();
-            case 'core-framework':
-                return Icon.gear();
-            case 'desktop':
-                return Icon.desktop();
-            case 'devops':
-                return Icon.server();
-            case 'grails-platform':
-                return Icon.database();
-            case 'infrastructure':
-                return Icon.server();
-            case 'mobile':
-                return Icon.mobile();
-            case 'overview':
-                return Icon.home();
-            case 'supporting':
-                return Icon.cube();
-            case 'upgrade':
-                return Icon.arrowUp();
-            case 'utilities':
-                return Icon.wrench();
-            default:
-                return Icon.folder();
-        }
+        return getCategoryIcon(categoryId);
     }
 
     getSourceIcon(sourceName: string) {
-        switch (sourceName) {
-            case 'hoist-react':
-                return Icon.icon({iconName: 'react', prefix: 'fab'});
-            case 'hoist-core':
-                return Icon.server();
-            default:
-                return Icon.folder();
-        }
+        return getSourceIcon(sourceName);
     }
 }

--- a/client-app/src/mobile/AppComponent.ts
+++ b/client-app/src/mobile/AppComponent.ts
@@ -30,6 +30,9 @@ export const AppComponent = hoistCmp({
                 hideRefreshButton: false,
                 // The back affordance is for drilldowns only; top-level pages keep the hamburger.
                 hideBackButton: model.navBladeModel.isTopLevelRoute,
+                // On the docs drill-down the chevron carries the parent screen's name (iOS Settings
+                // style); elsewhere `backLabel` is null and the button stays icon-only.
+                backButtonProps: {text: model.navBladeModel.backLabel},
                 // The hamburger glyph and the XH logo together form a single, generously sized button
                 // that opens the navigation blade. Shown on every blade-navigable page (Home and the
                 // top-level examples) so the menu is always one tap away - drilldown pages drop it and

--- a/client-app/src/mobile/AppModel.ts
+++ b/client-app/src/mobile/AppModel.ts
@@ -12,6 +12,10 @@ import {DocService} from '../core/svc/DocService';
 import {GitHubService} from '../core/svc/GitHubService';
 import {PortfolioService} from '../core/svc/PortfolioService';
 import {docsPage} from './docs/DocsPage';
+import {docsLandingPage} from './docs/landing/DocsLandingPage';
+import {docsCorpusPage} from './docs/corpus/DocsCorpusPage';
+import {docsCategoryPage} from './docs/category/DocsCategoryPage';
+import {docsSearchPage} from './docs/search/DocsSearchPage';
 import {HomeModel} from './home/HomeModel';
 import {NavBladeModel} from './cmp/navBlade/NavBladeModel';
 import {badgePage} from './badge/BadgePage';
@@ -72,17 +76,24 @@ export class AppModel extends BaseAppModel {
             {id: 'icons', content: iconPage},
             {id: 'mask', content: maskPage},
             {id: 'pinPad', content: pinPadPage},
-            {id: 'docs', content: docsPage}
+            // Standalone Docs section: landing (corpus chooser) -> corpus -> category -> reader,
+            // plus a dedicated search screen. The reader (`doc`) is reused at every mount point.
+            {id: 'docs', content: docsLandingPage},
+            {id: 'corpus', content: docsCorpusPage},
+            {id: 'category', content: docsCategoryPage},
+            {id: 'search', content: docsSearchPage},
+            {id: 'doc', content: docsPage}
         ]
     });
 
     override getRoutes() {
-        // The in-app docs reader is registered as a drilldown child of every example, so opening a
-        // doc from an example stacks the reader on top of it - the standard app-bar back button and
-        // the Navigator edge-swipe then both return to the example, exactly like the grid -> detail
-        // drilldown. It is also registered as a standalone child of `default` for cold deep-links and
-        // the home page, where there is no example to return to.
-        const docsRoute = () => ({name: 'docs', path: '/docs/:source/:docId?section'});
+        // The single-doc reader (`doc`) is registered at three nodes, so its back-target always
+        // follows its push origin via the Navigator stack: (1) a drilldown child of every example
+        // (a Resources doc link stacks the reader on the example, back returns there); (2) the deepest
+        // segment of the standalone docs browse stack (back climbs to the category doc list); and
+        // (3) a child of the search screen (back returns to the results). The standalone Docs section
+        // (`docs`) is the corpus-chooser landing - a top-level destination reached from the nav blade.
+        const docReaderRoute = () => ({name: 'doc', path: '/doc/:source/:docId?section'});
 
         const examples = [
             {name: 'grid', path: '/grid', children: [{name: 'gridDetail', path: '/:id<\\d+>'}]},
@@ -119,8 +130,29 @@ export class AppModel extends BaseAppModel {
                 name: 'default',
                 path: '/mobile',
                 children: [
-                    ...examples.map(r => ({...r, children: [...r.children, docsRoute()]})),
-                    docsRoute()
+                    ...examples.map(r => ({...r, children: [...r.children, docReaderRoute()]})),
+                    {
+                        name: 'docs',
+                        path: '/docs',
+                        children: [
+                            {
+                                name: 'corpus',
+                                path: '/browse/:source',
+                                children: [
+                                    {
+                                        name: 'category',
+                                        path: '/:categoryId',
+                                        children: [{name: 'doc', path: '/:docId?section'}]
+                                    }
+                                ]
+                            },
+                            {
+                                name: 'search',
+                                path: '/search',
+                                children: [{name: 'doc', path: '/:source/:docId?section'}]
+                            }
+                        ]
+                    }
                 ]
             }
         ];

--- a/client-app/src/mobile/cmp/example/ExampleScreen.ts
+++ b/client-app/src/mobile/cmp/example/ExampleScreen.ts
@@ -289,7 +289,7 @@ function defaultLinkText(url: string): string {
 
 /**
  * Doc links deep-link into the in-app reader; code/external links open the system browser. The
- * reader is opened as a `docs` drilldown child of the current example route (via `appendRoute`), so
+ * reader is opened as a `doc` drilldown child of the current example route (via `appendRoute`), so
  * it stacks on top of the example and the standard back button / edge-swipe return to it. The doc
  * params (`~`-encoded `docId` + an optional `section`) ride on that route segment.
  */
@@ -298,7 +298,7 @@ function openResource(url: string) {
     if (ref) {
         const params: Record<string, string> = {source: ref.source, docId: ref.docId};
         if (ref.section) params.section = ref.section;
-        XH.appendRoute('docs', params);
+        XH.appendRoute('doc', params);
         return;
     }
     window.open(toolboxUrl(url), '_blank');

--- a/client-app/src/mobile/cmp/navBlade/NavBlade.scss
+++ b/client-app/src/mobile/cmp/navBlade/NavBlade.scss
@@ -93,6 +93,13 @@
     padding-left: 30px;
   }
 
+  // Hairline separating the top-level destinations (Home, Docs) from the example groups.
+  &__rule {
+    height: 0;
+    margin: var(--xh-pad-half-px) var(--xh-pad-px);
+    border-top: var(--xh-border-solid);
+  }
+
   &__row {
     align-items: center;
     gap: var(--xh-pad-px);

--- a/client-app/src/mobile/cmp/navBlade/NavBlade.ts
+++ b/client-app/src/mobile/cmp/navBlade/NavBlade.ts
@@ -66,6 +66,15 @@ const bladeNav = hoistCmp.factory<NavBladeModel>({
                     active: model.isRouteActive(model.homeRoute),
                     onClick: () => model.navigateTo(model.homeRoute)
                 }),
+                // Docs is a top-level destination, not an example - it sits directly under Home,
+                // separated from the example-category groups by a hairline rule.
+                navRow({
+                    icon: Icon.book(),
+                    text: 'Docs',
+                    active: model.isRouteActive(model.docsRoute),
+                    onClick: () => model.navigateTo(model.docsRoute)
+                }),
+                div({className: 'tb-nav-blade__rule'}),
                 ...model.groups.map(group => navGroup({model, group}))
             ]
         });

--- a/client-app/src/mobile/cmp/navBlade/NavBladeModel.ts
+++ b/client-app/src/mobile/cmp/navBlade/NavBladeModel.ts
@@ -2,6 +2,7 @@ import {HoistModel, XH} from '@xh/hoist/core';
 import {Icon} from '@xh/hoist/icon';
 import {action, bindable, makeObservable, observable} from '@xh/hoist/mobx';
 import {ReactElement} from 'react';
+import {DocService} from '../../../core/svc/DocService';
 
 /** A single navigable leaf within the blade - maps to a fully-qualified app route. */
 export interface NavBladeItem {
@@ -21,6 +22,16 @@ export interface NavBladeGroup {
 /** Route name of the standalone Home destination. */
 const HOME_ROUTE = 'default';
 
+/** Route name of the standalone Docs section (the corpus-chooser landing). */
+const DOCS_ROUTE = 'default.docs';
+
+/**
+ * App-bar center title for docs drill-down screens. The shell's `appBar` falls back to the app name
+ * on an empty string, so we use a single space to leave it visually blank - the large in-body title
+ * and the parent-named back chevron carry the context (iOS large-title style).
+ */
+const BLANK_TITLE = ' ';
+
 /**
  * State + behavior for the mobile navigation blade (left drawer).
  *
@@ -37,6 +48,10 @@ export class NavBladeModel extends HoistModel {
 
     get homeRoute(): string {
         return HOME_ROUTE;
+    }
+
+    get docsRoute(): string {
+        return DOCS_ROUTE;
     }
 
     readonly groups: NavBladeGroup[] = [
@@ -150,20 +165,56 @@ export class NavBladeModel extends HoistModel {
      */
     get isTopLevelRoute(): boolean {
         const {name} = XH.routerState;
-        return name === HOME_ROUTE || this.groups.some(g => g.items.some(it => it.route === name));
+        return (
+            name === HOME_ROUTE ||
+            name === DOCS_ROUTE ||
+            this.groups.some(g => g.items.some(it => it.route === name))
+        );
     }
 
     /**
      * Display title for the active section, shown in the app bar in place of the app name. Resolves
      * the current route against the nav catalog, matching the nearest ancestor section - so a
-     * drilldown route (e.g. a grid's single-record detail) keeps its parent section's title.
+     * drilldown route (e.g. a grid's single-record detail) keeps its parent section's title. Docs
+     * drill-down screens (and the example doc reader) render their own large in-body title, so the
+     * bar is left blank there.
      */
     get activeTitle(): string {
-        if (this.isRouteActive(HOME_ROUTE)) return 'Home';
+        const {name} = XH.routerState;
+        if (name === HOME_ROUTE) return 'Home';
+        if (name === DOCS_ROUTE) return 'Docs';
+        if (name.startsWith(DOCS_ROUTE + '.') || name.endsWith('.doc')) return BLANK_TITLE;
         for (const group of this.groups) {
             const item = group.items.find(it => this.isRouteActive(it.route));
             if (item) return item.text;
         }
         return XH.clientAppName;
+    }
+
+    /**
+     * Parent-screen name for the app-bar back chevron on the docs drill-down (iOS Settings style:
+     * "< Docs", "< Hoist React", "< Concepts"). Returns null elsewhere so non-docs back buttons stay
+     * icon-only, matching the rest of the app.
+     */
+    get backLabel(): string {
+        const {name, params} = XH.routerState,
+            docService = DocService.instance;
+        switch (name) {
+            case 'default.docs.corpus':
+            case 'default.docs.search':
+                return 'Docs';
+            case 'default.docs.corpus.category':
+                return docService.getSourceLabel(params.source);
+            case 'default.docs.corpus.category.doc': {
+                const cat = docService
+                    .getCategories(params.source)
+                    .find(c => c.id === params.categoryId);
+                return cat?.title ?? docService.getSourceLabel(params.source);
+            }
+            case 'default.docs.search.doc':
+                return 'Search';
+            default:
+                return null;
+        }
     }
 }

--- a/client-app/src/mobile/docs/DocsPage.scss
+++ b/client-app/src/mobile/docs/DocsPage.scss
@@ -1,13 +1,60 @@
 .tb-docs-page {
+  // Top header line: muted breadcrumb (the hierarchy above the page). Reset the panel header's
+  // default title weight so it reads as a quiet breadcrumb rather than a heading.
+  &__crumb-header {
+    .xh-panel-header__title {
+      font-weight: normal;
+    }
+  }
+
   &__crumb {
     align-items: center;
     gap: var(--xh-pad-half-px);
-    padding: 0 var(--xh-pad-px);
     font-size: var(--xh-font-size-small-px);
     color: var(--xh-text-color-muted);
   }
 
   &__crumb-sep {
     opacity: 0.6;
+  }
+
+  //------------------------
+  // Lower header line: doc title + "On this page"
+  //------------------------
+  &__title-bar {
+    align-items: center;
+    gap: var(--xh-pad-half-px);
+  }
+
+  &__title-text {
+    font-size: var(--xh-font-size-large-px);
+    color: var(--xh-text-color);
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
+
+  //------------------------
+  // Footer pager (prev / next within category)
+  //------------------------
+  &__pager {
+    gap: var(--xh-pad-px);
+  }
+
+  &__pager-btn {
+    // Cap each button so a long neighbor title cannot crowd out the other side.
+    max-width: 48%;
+  }
+
+  &__pager-label {
+    align-items: center;
+    gap: var(--xh-pad-half-px);
+    overflow: hidden;
+  }
+
+  &__pager-title {
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
   }
 }

--- a/client-app/src/mobile/docs/DocsPage.ts
+++ b/client-app/src/mobile/docs/DocsPage.ts
@@ -1,5 +1,6 @@
-import {filler, span} from '@xh/hoist/cmp/layout';
+import {filler, hbox, span} from '@xh/hoist/cmp/layout';
 import {creates, hoistCmp} from '@xh/hoist/core';
+import {button} from '@xh/hoist/mobile/cmp/button';
 import {menuButton} from '@xh/hoist/mobile/cmp/menu';
 import {panel} from '@xh/hoist/mobile/cmp/panel';
 import {toolbar} from '@xh/hoist/mobile/cmp/toolbar';
@@ -11,33 +12,75 @@ import './DocsPage.scss';
 
 /**
  * Mobile Navigator page for the in-app documentation reader. Renders a single doc via the shared
- * `docContent` body component, with a breadcrumb context row and an "On this page" section-jump
- * menu in a top toolbar. Back navigation is provided automatically by the Navigator for pushed pages.
+ * `docContent` body component. Two stacked header rows sit below the app bar: the source > category
+ * breadcrumb on top (the hierarchy "above" the page), then the doc title sharing a bar with the
+ * "On this page" section-jump menu. A footer pager steps through the current category. Back
+ * navigation is provided automatically by the Navigator for pushed pages.
  */
 export const docsPage = hoistCmp.factory({
     displayName: 'DocsPage',
     model: creates(DocsPageModel),
 
     render({model}) {
-        const {activeDoc} = model;
         return panel({
             className: 'tb-docs-page',
-            title: activeDoc?.title ?? 'Docs',
-            icon: Icon.book(),
+            headerClassName: 'tb-docs-page__crumb-header',
+            title: breadcrumb(),
             mask: 'onLoad',
-            tbar: breadcrumbBar(),
-            item: docContent({model})
+            tbar: titleBar(),
+            item: docContent({model}),
+            bbar: pagerBar()
         });
     }
 });
 
-/** Lightweight context row: source name > category, plus an "On this page" section-jump menu. */
-const breadcrumbBar = hoistCmp.factory<DocsPageModel>({
+/** Footer pager - steps prev/next through the active doc's category siblings. */
+const pagerBar = hoistCmp.factory<DocsPageModel>({
     render({model}) {
-        const {activeSource, activeCategory, sections} = model;
+        const {prevDoc, nextDoc} = model;
+        if (!prevDoc && !nextDoc) return null;
+        return toolbar({
+            className: 'tb-docs-page__pager',
+            items: [
+                button({
+                    className: 'tb-docs-page__pager-btn',
+                    minimal: true,
+                    omit: !prevDoc,
+                    onClick: () => model.navigatePrev(),
+                    text: hbox({
+                        className: 'tb-docs-page__pager-label',
+                        items: [
+                            Icon.chevronLeft(),
+                            span({className: 'tb-docs-page__pager-title', item: prevDoc?.title})
+                        ]
+                    })
+                }),
+                filler(),
+                button({
+                    className: 'tb-docs-page__pager-btn tb-docs-page__pager-btn--next',
+                    minimal: true,
+                    omit: !nextDoc,
+                    onClick: () => model.navigateNext(),
+                    text: hbox({
+                        className: 'tb-docs-page__pager-label',
+                        items: [
+                            span({className: 'tb-docs-page__pager-title', item: nextDoc?.title}),
+                            Icon.chevronRight()
+                        ]
+                    })
+                })
+            ]
+        });
+    }
+});
+
+/** Top header line: the source > category breadcrumb (the hierarchy above the current doc). */
+const breadcrumb = hoistCmp.factory<DocsPageModel>({
+    render({model}) {
+        const {activeSource, activeCategory} = model;
         if (!activeSource) return null;
         const sourceLabel = DocService.instance.getSourceLabel(activeSource);
-        return toolbar({
+        return hbox({
             className: 'tb-docs-page__crumb',
             items: [
                 span({className: 'tb-docs-page__crumb-src', item: sourceLabel}),
@@ -46,7 +89,20 @@ const breadcrumbBar = hoistCmp.factory<DocsPageModel>({
                     : null,
                 activeCategory
                     ? span({className: 'tb-docs-page__crumb-cat', item: activeCategory.title})
-                    : null,
+                    : null
+            ]
+        });
+    }
+});
+
+/** Lower header line: the doc title sharing the bar with the "On this page" section-jump menu. */
+const titleBar = hoistCmp.factory<DocsPageModel>({
+    render({model}) {
+        const {activeDoc, sections} = model;
+        return toolbar({
+            className: 'tb-docs-page__title-bar',
+            items: [
+                span({className: 'tb-docs-page__title-text', item: activeDoc?.title ?? 'Docs'}),
                 filler(),
                 onThisPageButton({omit: !sections.length})
             ]

--- a/client-app/src/mobile/docs/DocsPageModel.ts
+++ b/client-app/src/mobile/docs/DocsPageModel.ts
@@ -1,20 +1,68 @@
 import {XH} from '@xh/hoist/core';
+import {computed} from '@xh/hoist/mobx';
+import {DocEntry} from '../../core/docs/types';
 import {DocViewModel} from '../../core/docs/DocViewModel';
 
 /**
- * Mobile Docs reader model. The reader mounts at a `docs` route segment that carries the doc params
- * directly (no `docRef` child as on desktop). That segment lives in two places: a standalone
- * `default.docs` (deep-links / home) and a drilldown child of each example (`default.<example>.docs`)
- * so the reader stacks on top of the example and back returns to it. Both forms end in `.docs`, and
- * route write-backs (e.g. following an in-content doc link) must stay on whichever one is current.
+ * Mobile Docs reader model. The reader mounts at a `doc` route segment that carries the doc params
+ * directly (no `docRef` child as on desktop). That segment lives at three nodes - a browse drilldown
+ * (`default.docs.corpus.category.doc`), a search result (`default.docs.search.doc`), and a deep-link
+ * child of each example (`default.<example>.doc`) - so the reader always stacks on top of its origin
+ * and the standard back / edge-swipe returns there. All three end in `.doc`, and route write-backs
+ * (e.g. following an in-content doc link) must stay on whichever one is current.
  */
 export class DocsPageModel extends DocViewModel {
     protected override isDocsRoute(name: string): boolean {
-        return name.endsWith('.docs');
+        return name.endsWith('.doc');
     }
 
     protected override get docRouteName(): string {
         return XH.routerState.name;
+    }
+
+    /**
+     * Browse readers nest under a `category` segment whose `categoryId` param must be preserved on
+     * write-back; the search/example readers do not carry it. Detect by route name so we never emit a
+     * stray query param on the flatter routes.
+     */
+    protected override routeParamsForDoc(entry: DocEntry): Record<string, string> {
+        const params = super.routeParamsForDoc(entry);
+        if (XH.routerState.name.includes('.category.')) params.categoryId = entry.category;
+        return params;
+    }
+
+    /** Index of the active doc within its category siblings, or -1. */
+    @computed
+    private get activeSiblingIdx(): number {
+        const {activeDoc, activeCategorySiblings} = this;
+        if (!activeDoc) return -1;
+        return activeCategorySiblings.findIndex(
+            d => d.id === activeDoc.id && d.source === activeDoc.source
+        );
+    }
+
+    /** Previous doc in the current category, for the reader's pager (or null at the start). */
+    @computed
+    get prevDoc(): DocEntry | null {
+        const idx = this.activeSiblingIdx;
+        return idx > 0 ? this.activeCategorySiblings[idx - 1] : null;
+    }
+
+    /** Next doc in the current category, for the reader's pager (or null at the end). */
+    @computed
+    get nextDoc(): DocEntry | null {
+        const {activeSiblingIdx: idx, activeCategorySiblings: sibs} = this;
+        return idx >= 0 && idx < sibs.length - 1 ? sibs[idx + 1] : null;
+    }
+
+    navigatePrev() {
+        const {prevDoc} = this;
+        if (prevDoc) this.navigateToDoc(prevDoc.id, prevDoc.source);
+    }
+
+    navigateNext() {
+        const {nextDoc} = this;
+        if (nextDoc) this.navigateToDoc(nextDoc.id, nextDoc.source);
     }
 
     override onLinked() {

--- a/client-app/src/mobile/docs/category/DocsCategoryModel.ts
+++ b/client-app/src/mobile/docs/category/DocsCategoryModel.ts
@@ -1,0 +1,37 @@
+import {HoistModel, XH} from '@xh/hoist/core';
+import {encodeDocId} from '../../../core/docs/DocUtils';
+import {DocCategory, DocEntry} from '../../../core/docs/types';
+import {DocService} from '../../../core/svc/DocService';
+
+/**
+ * Model for the category document-list screen - level 2 of the docs drill-down. Reads `source` and
+ * `categoryId` live from the route; lists that category's docs and pushes the reader on tap.
+ */
+export class DocsCategoryModel extends HoistModel {
+    private get docService(): DocService {
+        return DocService.instance;
+    }
+
+    get source(): string {
+        return XH.routerState.params.source;
+    }
+
+    get categoryId(): string {
+        return XH.routerState.params.categoryId;
+    }
+
+    get category(): DocCategory | null {
+        return (
+            this.docService.getCategories(this.source).find(c => c.id === this.categoryId) ?? null
+        );
+    }
+
+    get docs(): DocEntry[] {
+        return this.docService.getDocsByCategory(this.source, this.categoryId);
+    }
+
+    /** Push the reader for the given doc (source + categoryId already on the route). */
+    openDoc(entry: DocEntry) {
+        XH.appendRoute('doc', {docId: encodeDocId(entry.id)});
+    }
+}

--- a/client-app/src/mobile/docs/category/DocsCategoryPage.ts
+++ b/client-app/src/mobile/docs/category/DocsCategoryPage.ts
@@ -1,0 +1,48 @@
+import {div} from '@xh/hoist/cmp/layout';
+import {creates, hoistCmp} from '@xh/hoist/core';
+import {Icon} from '@xh/hoist/icon';
+import {panel} from '@xh/hoist/mobile/cmp/panel';
+import {pluralize} from '@xh/hoist/utils/js';
+import {docsListRow} from '../cmp/DocsListRow';
+import {DocsCategoryModel} from './DocsCategoryModel';
+
+/**
+ * Category document-list screen - the second push. Lists the docs in the chosen category; tapping
+ * one opens the reader (back returns here). The app-bar back chevron carries the corpus name.
+ */
+export const docsCategoryPage = hoistCmp.factory({
+    displayName: 'DocsCategoryPage',
+    model: creates(DocsCategoryModel),
+
+    render({model}) {
+        const {category, docs} = model,
+            title = category?.title ?? 'Documents';
+        return panel({
+            className: 'tb-docs-list',
+            scrollable: true,
+            item: div({
+                items: [
+                    div({
+                        className: 'tb-docs-list__header',
+                        items: [
+                            div({className: 'tb-docs-list__header-title', item: title}),
+                            div({
+                                className: 'tb-docs-list__header-sub',
+                                item: pluralize('document', docs.length, true)
+                            })
+                        ]
+                    }),
+                    ...docs.map(doc =>
+                        docsListRow({
+                            key: `${doc.source}:${doc.id}`,
+                            icon: Icon.fileText(),
+                            title: doc.title,
+                            subtitle: doc.description,
+                            onClick: () => model.openDoc(doc)
+                        })
+                    )
+                ]
+            })
+        });
+    }
+});

--- a/client-app/src/mobile/docs/cmp/DocsList.scss
+++ b/client-app/src/mobile/docs/cmp/DocsList.scss
@@ -1,0 +1,68 @@
+// Shared list styling for the docs drill-down screens (corpus category list + category doc list).
+.tb-docs-list {
+  &__header {
+    padding: var(--xh-pad-px);
+    border-bottom: var(--xh-border-solid);
+  }
+
+  &__header-title {
+    font-size: var(--xh-font-size-large-px);
+    font-weight: 600;
+    color: var(--xh-text-color);
+  }
+
+  &__header-sub {
+    margin-top: 2px;
+    font-size: var(--xh-font-size-small-px);
+    color: var(--xh-text-color-muted);
+  }
+
+  &__row {
+    align-items: center;
+    gap: var(--xh-pad-px);
+    min-height: 52px;
+    padding: var(--xh-pad-half-px) var(--xh-pad-px);
+    border-bottom: var(--xh-border-solid);
+    cursor: pointer;
+
+    &:active {
+      background: var(--xh-bg-highlight);
+    }
+  }
+
+  &__row-icon {
+    flex: none;
+    width: 20px;
+    text-align: center;
+    color: var(--xh-text-color-muted);
+  }
+
+  &__row-text {
+    overflow: hidden;
+  }
+
+  &__row-title {
+    font-size: var(--xh-font-size-px);
+    color: var(--xh-text-color);
+  }
+
+  &__row-subtitle {
+    margin-top: 1px;
+    font-size: var(--xh-font-size-small-px);
+    color: var(--xh-text-color-muted);
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
+
+  &__row-count {
+    flex: none;
+    font-size: var(--xh-font-size-small-px);
+    color: var(--xh-text-color-muted);
+  }
+
+  &__row-chevron {
+    flex: none;
+    color: var(--xh-text-color-muted);
+  }
+}

--- a/client-app/src/mobile/docs/cmp/DocsListRow.ts
+++ b/client-app/src/mobile/docs/cmp/DocsListRow.ts
@@ -1,0 +1,49 @@
+import {div, filler, hbox, span, vbox} from '@xh/hoist/cmp/layout';
+import {hoistCmp, HoistProps} from '@xh/hoist/core';
+import {Icon} from '@xh/hoist/icon';
+import {ReactElement, ReactNode} from 'react';
+import './DocsList.scss';
+
+export interface DocsListRowProps extends HoistProps {
+    /** Leading glyph (category / source / doc icon). */
+    icon: ReactElement;
+    title: ReactNode;
+    /** Optional muted second line (e.g. a doc description). */
+    subtitle?: ReactNode;
+    /** Optional trailing count chip (e.g. number of docs in a category). */
+    count?: number;
+    onClick: () => void;
+}
+
+/**
+ * Shared drill-down list row for the mobile docs screens (corpus category list + category doc list):
+ * leading icon, title with optional subtitle, an optional trailing count, and a chevron. Keeps the
+ * two list screens visually identical and DRY.
+ */
+export const docsListRow = hoistCmp.factory<DocsListRowProps>({
+    displayName: 'DocsListRow',
+
+    render({icon, title, subtitle, count, onClick}) {
+        return hbox({
+            className: 'tb-docs-list__row',
+            onClick,
+            items: [
+                div({className: 'tb-docs-list__row-icon', item: icon}),
+                vbox({
+                    className: 'tb-docs-list__row-text',
+                    items: [
+                        div({className: 'tb-docs-list__row-title', item: title}),
+                        subtitle
+                            ? div({className: 'tb-docs-list__row-subtitle', item: subtitle})
+                            : null
+                    ]
+                }),
+                filler(),
+                count != null
+                    ? span({className: 'tb-docs-list__row-count', item: `${count}`})
+                    : null,
+                Icon.chevronRight({className: 'tb-docs-list__row-chevron'})
+            ]
+        });
+    }
+});

--- a/client-app/src/mobile/docs/corpus/DocsCorpusModel.ts
+++ b/client-app/src/mobile/docs/corpus/DocsCorpusModel.ts
@@ -1,0 +1,53 @@
+import {HoistModel, XH} from '@xh/hoist/core';
+import {ReactElement} from 'react';
+import {getCategoryIcon} from '../../../core/docs/DocIcons';
+import {DocService} from '../../../core/svc/DocService';
+
+/** A category row on the corpus screen. */
+export interface CorpusCategory {
+    id: string;
+    title: string;
+    icon: ReactElement;
+    docCount: number;
+}
+
+/**
+ * Model for the corpus category-list screen - level 1 of the docs drill-down. Reads its `source`
+ * live from the route so the title, counts, and category list always reflect the active corpus.
+ */
+export class DocsCorpusModel extends HoistModel {
+    private get docService(): DocService {
+        return DocService.instance;
+    }
+
+    get source(): string {
+        return XH.routerState.params.source;
+    }
+
+    get label(): string {
+        return this.docService.getSourceLabel(this.source);
+    }
+
+    get docCount(): number {
+        return this.docService.getDocCount(this.source);
+    }
+
+    get categoryCount(): number {
+        return this.docService.getCategoryCount(this.source);
+    }
+
+    get categories(): CorpusCategory[] {
+        const {docService, source} = this;
+        return docService.getPopulatedCategories(source).map(cat => ({
+            id: cat.id,
+            title: cat.title,
+            icon: getCategoryIcon(cat.id),
+            docCount: docService.getDocsByCategory(source, cat.id).length
+        }));
+    }
+
+    /** Push into a category's document list. */
+    openCategory(categoryId: string) {
+        XH.appendRoute('category', {categoryId});
+    }
+}

--- a/client-app/src/mobile/docs/corpus/DocsCorpusPage.ts
+++ b/client-app/src/mobile/docs/corpus/DocsCorpusPage.ts
@@ -1,0 +1,47 @@
+import {div} from '@xh/hoist/cmp/layout';
+import {creates, hoistCmp} from '@xh/hoist/core';
+import {panel} from '@xh/hoist/mobile/cmp/panel';
+import {pluralize} from '@xh/hoist/utils/js';
+import {docsListRow} from '../cmp/DocsListRow';
+import {DocsCorpusModel} from './DocsCorpusModel';
+
+/**
+ * Corpus category-list screen - the first push from the landing. Shows the chosen library's
+ * populated categories; tapping one drills into its document list. The app-bar back chevron
+ * (provided by the shell) carries the parent name ("Docs").
+ */
+export const docsCorpusPage = hoistCmp.factory({
+    displayName: 'DocsCorpusPage',
+    model: creates(DocsCorpusModel),
+
+    render({model}) {
+        const {label, docCount, categoryCount, categories} = model;
+        return panel({
+            className: 'tb-docs-list',
+            scrollable: true,
+            item: div({
+                items: [
+                    div({
+                        className: 'tb-docs-list__header',
+                        items: [
+                            div({className: 'tb-docs-list__header-title', item: label}),
+                            div({
+                                className: 'tb-docs-list__header-sub',
+                                item: `${pluralize('doc', docCount, true)} · ${pluralize('category', categoryCount, true)}`
+                            })
+                        ]
+                    }),
+                    ...categories.map(cat =>
+                        docsListRow({
+                            key: cat.id,
+                            icon: cat.icon,
+                            title: cat.title,
+                            count: cat.docCount,
+                            onClick: () => model.openCategory(cat.id)
+                        })
+                    )
+                ]
+            })
+        });
+    }
+});

--- a/client-app/src/mobile/docs/landing/DocsLandingModel.ts
+++ b/client-app/src/mobile/docs/landing/DocsLandingModel.ts
@@ -1,0 +1,73 @@
+import {HoistModel, XH} from '@xh/hoist/core';
+import {ReactElement} from 'react';
+import {getSourceIcon} from '../../../core/docs/DocIcons';
+import {encodeDocId} from '../../../core/docs/DocUtils';
+import {DocEntry} from '../../../core/docs/types';
+import {DocService} from '../../../core/svc/DocService';
+
+/** A corpus card on the docs landing. */
+export interface CorpusCard {
+    source: string;
+    label: string;
+    tagline: string;
+    icon: ReactElement;
+    docCount: number;
+}
+
+/** One-line taglines for the landing cards (phone-specific copy). */
+const TAGLINES: Record<string, string> = {
+    'hoist-react': 'TypeScript + React front-end',
+    'hoist-core': 'Java + Grails server'
+};
+
+/**
+ * Model for the mobile Docs landing - the corpus chooser. Surfaces the available libraries as cards
+ * and the recently-viewed docs, and routes taps into the drill-down stack / search screen. Reads all
+ * data from the shared {@link DocService}; holds no state of its own.
+ */
+export class DocsLandingModel extends HoistModel {
+    private get docService(): DocService {
+        return DocService.instance;
+    }
+
+    get corpora(): CorpusCard[] {
+        const {docService} = this;
+        return docService.sourceNames.map(source => ({
+            source,
+            label: docService.getSourceLabel(source),
+            tagline: TAGLINES[source] ?? '',
+            icon: getSourceIcon(source),
+            docCount: docService.getDocCount(source)
+        }));
+    }
+
+    get recentDocs(): DocEntry[] {
+        return this.docService.recentDocs;
+    }
+
+    getSourceLabel(source: string): string {
+        return this.docService.getSourceLabel(source);
+    }
+
+    /** Push into a corpus's category list. */
+    openCorpus(source: string) {
+        XH.appendRoute('corpus', {source});
+    }
+
+    /** Open the dedicated search screen. */
+    openSearch() {
+        XH.appendRoute('search');
+    }
+
+    /**
+     * Open a recently-viewed doc directly in the reader, rebuilding the full browse stack so back
+     * climbs corpus -> category -> doc as if the user had drilled in.
+     */
+    openRecent(entry: DocEntry) {
+        XH.navigate('default.docs.corpus.category.doc', {
+            source: entry.source,
+            categoryId: entry.category,
+            docId: encodeDocId(entry.id)
+        });
+    }
+}

--- a/client-app/src/mobile/docs/landing/DocsLandingPage.scss
+++ b/client-app/src/mobile/docs/landing/DocsLandingPage.scss
@@ -1,0 +1,158 @@
+.tb-docs-landing {
+  &__body {
+    display: flex;
+    flex-direction: column;
+    gap: calc(var(--xh-pad-px) + var(--xh-pad-half-px));
+    padding: var(--xh-pad-px) var(--xh-pad-double-px);
+  }
+
+  //------------------------
+  // Search trigger
+  //------------------------
+  &__search {
+    align-items: center;
+    gap: var(--xh-pad-half-px);
+    height: 40px;
+    padding: 0 var(--xh-pad-px);
+    background: var(--xh-bg-alt);
+    border: var(--xh-border-solid);
+    border-radius: var(--xh-border-radius-px);
+    color: var(--xh-text-color-muted);
+    cursor: pointer;
+
+    &:active {
+      background: var(--xh-bg-highlight);
+    }
+  }
+
+  &__search-icon {
+    color: var(--xh-text-color-muted);
+  }
+
+  &__search-text {
+    font-size: var(--xh-font-size-px);
+  }
+
+  //------------------------
+  // Intro
+  //------------------------
+  &__intro {
+    font-size: var(--xh-font-size-px);
+    color: var(--xh-text-color-muted);
+    line-height: 1.4;
+  }
+
+  //------------------------
+  // Corpus cards
+  //------------------------
+  &__cards {
+    display: flex;
+    flex-direction: column;
+    gap: var(--xh-pad-half-px);
+  }
+
+  &__card {
+    align-items: center;
+    gap: var(--xh-pad-px);
+    padding: var(--xh-pad-px);
+    background: var(--xh-bg-alt);
+    border: var(--xh-border-solid);
+    border-radius: var(--xh-border-radius-px);
+    cursor: pointer;
+
+    &:active {
+      background: var(--xh-bg-highlight);
+    }
+  }
+
+  &__card-icon {
+    flex: none;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    width: 44px;
+    height: 44px;
+    font-size: 20px;
+    border-radius: var(--xh-border-radius-px);
+    background: var(--xh-bg);
+    color: var(--xh-orange);
+  }
+
+  &__card-text {
+    overflow: hidden;
+  }
+
+  &__card-label {
+    font-size: var(--xh-font-size-large-px);
+    font-weight: 600;
+    color: var(--xh-text-color);
+  }
+
+  &__card-tagline {
+    font-size: var(--xh-font-size-small-px);
+    color: var(--xh-text-color-muted);
+  }
+
+  &__card-count {
+    margin-top: 2px;
+    font-size: var(--xh-font-size-small-px);
+    color: var(--xh-text-color-muted);
+  }
+
+  &__card-chevron {
+    flex: none;
+    color: var(--xh-text-color-muted);
+  }
+
+  //------------------------
+  // Recently viewed
+  //------------------------
+  &__section-title {
+    margin: var(--xh-pad-half-px) 0;
+    font-size: var(--xh-font-size-small-px);
+    font-weight: 600;
+    text-transform: uppercase;
+    letter-spacing: 0.04em;
+    color: var(--xh-text-color-muted);
+  }
+
+  &__recent-row {
+    align-items: center;
+    gap: var(--xh-pad-px);
+    height: 52px;
+    padding: 0 var(--xh-pad-px);
+    border-bottom: var(--xh-border-solid);
+    cursor: pointer;
+
+    &:active {
+      background: var(--xh-bg-highlight);
+    }
+  }
+
+  &__recent-icon {
+    flex: none;
+    color: var(--xh-text-color-muted);
+  }
+
+  &__recent-text {
+    overflow: hidden;
+  }
+
+  &__recent-title {
+    font-size: var(--xh-font-size-px);
+    color: var(--xh-text-color);
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
+
+  &__recent-src {
+    font-size: var(--xh-font-size-small-px);
+    color: var(--xh-text-color-muted);
+  }
+
+  &__recent-chevron {
+    flex: none;
+    color: var(--xh-text-color-muted);
+  }
+}

--- a/client-app/src/mobile/docs/landing/DocsLandingPage.ts
+++ b/client-app/src/mobile/docs/landing/DocsLandingPage.ts
@@ -1,0 +1,124 @@
+import {div, filler, hbox, span, vbox} from '@xh/hoist/cmp/layout';
+import {creates, hoistCmp} from '@xh/hoist/core';
+import {Icon} from '@xh/hoist/icon';
+import {panel} from '@xh/hoist/mobile/cmp/panel';
+import {pluralize} from '@xh/hoist/utils/js';
+import {DocsLandingModel} from './DocsLandingModel';
+import './DocsLandingPage.scss';
+
+/**
+ * Mobile Docs landing - the corpus chooser. A tap-through search field, a one-line intro, the two
+ * libraries as cards, and a "Jump back in" recently-viewed list. The app bar (blade toggle + title +
+ * refresh) is provided by the app shell; this page owns the body.
+ */
+export const docsLandingPage = hoistCmp.factory({
+    displayName: 'DocsLandingPage',
+    model: creates(DocsLandingModel),
+
+    render() {
+        return panel({
+            className: 'tb-docs-landing',
+            scrollable: true,
+            item: div({
+                className: 'tb-docs-landing__body',
+                items: [introBlurb(), searchTrigger(), corpusCards(), recentSection()]
+            })
+        });
+    }
+});
+
+/** A read-only search box styled to look live; tapping it opens the dedicated search screen. */
+const searchTrigger = hoistCmp.factory<DocsLandingModel>({
+    render({model}) {
+        return hbox({
+            className: 'tb-docs-landing__search',
+            onClick: () => model.openSearch(),
+            items: [
+                Icon.search({className: 'tb-docs-landing__search-icon'}),
+                span({className: 'tb-docs-landing__search-text', item: 'Search the docs'})
+            ]
+        });
+    }
+});
+
+const introBlurb = hoistCmp.factory(() =>
+    div({
+        className: 'tb-docs-landing__intro',
+        item: 'Browse the Hoist documentation. Pick a library to start, or search across both.'
+    })
+);
+
+const corpusCards = hoistCmp.factory<DocsLandingModel>({
+    render({model}) {
+        return div({
+            className: 'tb-docs-landing__cards',
+            items: [
+                div({className: 'tb-docs-landing__section-title', item: 'Choose a library'}),
+                ...model.corpora.map(c =>
+                    hbox({
+                        key: c.source,
+                        className: 'tb-docs-landing__card',
+                        onClick: () => model.openCorpus(c.source),
+                        items: [
+                            div({className: 'tb-docs-landing__card-icon', item: c.icon}),
+                            vbox({
+                                className: 'tb-docs-landing__card-text',
+                                items: [
+                                    div({className: 'tb-docs-landing__card-label', item: c.label}),
+                                    div({
+                                        className: 'tb-docs-landing__card-tagline',
+                                        item: c.tagline
+                                    }),
+                                    div({
+                                        className: 'tb-docs-landing__card-count',
+                                        item: pluralize('doc', c.docCount, true)
+                                    })
+                                ]
+                            }),
+                            filler(),
+                            Icon.chevronRight({className: 'tb-docs-landing__card-chevron'})
+                        ]
+                    })
+                )
+            ]
+        });
+    }
+});
+
+const recentSection = hoistCmp.factory<DocsLandingModel>({
+    render({model}) {
+        const {recentDocs} = model;
+        if (!recentDocs.length) return null;
+        return div({
+            className: 'tb-docs-landing__recent',
+            items: [
+                div({className: 'tb-docs-landing__section-title', item: 'Jump back in'}),
+                ...recentDocs.map(entry =>
+                    hbox({
+                        key: `${entry.source}:${entry.id}`,
+                        className: 'tb-docs-landing__recent-row',
+                        onClick: () => model.openRecent(entry),
+                        items: [
+                            Icon.clock({className: 'tb-docs-landing__recent-icon'}),
+                            vbox({
+                                className: 'tb-docs-landing__recent-text',
+                                items: [
+                                    div({
+                                        className: 'tb-docs-landing__recent-title',
+                                        item: entry.title
+                                    }),
+                                    div({
+                                        className: 'tb-docs-landing__recent-src',
+                                        item: model.getSourceLabel(entry.source)
+                                    })
+                                ]
+                            }),
+                            filler(),
+                            Icon.chevronRight({className: 'tb-docs-landing__recent-chevron'})
+                        ]
+                    })
+                )
+            ]
+        });
+    }
+});

--- a/client-app/src/mobile/docs/search/DocsSearchModel.ts
+++ b/client-app/src/mobile/docs/search/DocsSearchModel.ts
@@ -1,0 +1,116 @@
+import {HoistModel, XH} from '@xh/hoist/core';
+import {action, bindable, makeObservable, observable, runInAction} from '@xh/hoist/mobx';
+import {encodeDocId} from '../../../core/docs/DocUtils';
+import {DocEntry} from '../../../core/docs/types';
+import {DocService, DocSearchResult} from '../../../core/svc/DocService';
+
+/** A library-grouped block of search hits. */
+export interface SearchResultGroup {
+    source: string;
+    label: string;
+    results: DocSearchResult[];
+}
+
+/** localStorage key + cap for recent search terms. */
+const RECENT_SEARCHES_KEY = 'docs.recentSearches',
+    RECENT_SEARCHES_MAX = 8;
+
+/**
+ * Model for the dedicated docs search screen. Runs cross-corpus full-text search via the shared
+ * {@link DocService}, enriching each hit with a matched-line snippet, and keeps a persisted list of
+ * recent searches for the empty state. Results are grouped by library for display.
+ */
+export class DocsSearchModel extends HoistModel {
+    @bindable query: string = '';
+    @observable.ref results: DocSearchResult[] = [];
+    @observable.ref recentSearches: string[] = [];
+
+    private get docService(): DocService {
+        return DocService.instance;
+    }
+
+    constructor() {
+        super();
+        makeObservable(this);
+        this.recentSearches = XH.localStorageService.get(RECENT_SEARCHES_KEY, []);
+    }
+
+    override onLinked() {
+        this.docService.ensureIndexBuilt();
+        this.addReaction({
+            track: () => this.query,
+            run: () => this.runSearch(),
+            debounce: 200
+        });
+    }
+
+    /** Results grouped under their library, in the service's source order. */
+    get groupedResults(): SearchResultGroup[] {
+        const {results, docService} = this;
+        return docService.sourceNames
+            .map(source => ({
+                source,
+                label: docService.getSourceLabel(source),
+                results: results.filter(r => r.entry.source === source)
+            }))
+            .filter(g => g.results.length > 0);
+    }
+
+    get hasQuery(): boolean {
+        return !!this.query?.trim();
+    }
+
+    /** Re-run a recent search term. */
+    runRecent(term: string) {
+        this.query = term;
+    }
+
+    @action
+    removeRecent(term: string) {
+        this.recentSearches = this.recentSearches.filter(t => t !== term);
+        XH.localStorageService.set(RECENT_SEARCHES_KEY, this.recentSearches);
+    }
+
+    /** Open a hit in the reader (stacked on search, so back returns to results), recording the term. */
+    selectResult(entry: DocEntry) {
+        this.commitRecent();
+        XH.appendRoute('doc', {source: entry.source, docId: encodeDocId(entry.id)});
+    }
+
+    //------------------
+    // Implementation
+    //------------------
+    private runSearch() {
+        const query = this.query?.trim();
+        if (!query) {
+            runInAction(() => (this.results = []));
+            return;
+        }
+        const terms = this.queryTerms(query),
+            hits = this.docService.searchDocs(query).map(r => ({
+                ...r,
+                matchedTerms: terms,
+                snippet: this.docService.getContentSnippet(r.entry.source, r.entry.id, terms)
+            }));
+        runInAction(() => (this.results = hits));
+    }
+
+    private queryTerms(query: string): string[] {
+        return query
+            .toLowerCase()
+            .split(/\s+/)
+            .filter(t => t.length > 1);
+    }
+
+    /** Persist the current query as a recent search (most recent first, de-duped, capped). */
+    @action
+    private commitRecent() {
+        const term = this.query?.trim();
+        if (!term) return;
+        this.recentSearches = [term, ...this.recentSearches.filter(t => t !== term)].slice(
+            0,
+            RECENT_SEARCHES_MAX
+        );
+        XH.localStorageService.set(RECENT_SEARCHES_KEY, this.recentSearches);
+    }
+}

--- a/client-app/src/mobile/docs/search/DocsSearchPage.scss
+++ b/client-app/src/mobile/docs/search/DocsSearchPage.scss
@@ -1,0 +1,122 @@
+.tb-docs-search {
+  &__bar {
+    padding: var(--xh-pad-half-px) var(--xh-pad-px);
+  }
+
+  // Let the search field fill the toolbar width rather than sitting narrow at the left.
+  &__input {
+    flex: 1;
+    width: 100%;
+  }
+
+  //------------------------
+  // Empty / placeholder
+  //------------------------
+  &__empty {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: var(--xh-pad-px);
+    padding: calc(var(--xh-pad-px) * 3) var(--xh-pad-px);
+    color: var(--xh-text-color-muted);
+    text-align: center;
+  }
+
+  //------------------------
+  // Group headers (recent searches + library result groups)
+  //------------------------
+  &__group-header {
+    display: flex;
+    align-items: center;
+    gap: var(--xh-pad-half-px);
+    padding: var(--xh-pad-px) var(--xh-pad-px) var(--xh-pad-half-px);
+    font-size: var(--xh-font-size-small-px);
+    font-weight: 500;
+    text-transform: uppercase;
+    letter-spacing: 0.04em;
+    color: var(--xh-text-color-muted);
+  }
+
+  //------------------------
+  // Recent searches
+  //------------------------
+  &__recent-row {
+    align-items: center;
+    gap: var(--xh-pad-px);
+    height: 48px;
+    padding: 0 var(--xh-pad-px);
+    border-bottom: var(--xh-border-solid);
+    cursor: pointer;
+
+    &:active {
+      background: var(--xh-bg-highlight);
+    }
+  }
+
+  &__recent-icon {
+    flex: none;
+    color: var(--xh-text-color-muted);
+  }
+
+  &__recent-term {
+    font-size: var(--xh-font-size-px);
+    color: var(--xh-text-color);
+  }
+
+  &__recent-remove {
+    flex: none;
+    padding: var(--xh-pad-half-px);
+    color: var(--xh-text-color-muted);
+    cursor: pointer;
+  }
+
+  //------------------------
+  // Results
+  //------------------------
+  &__hit {
+    padding: var(--xh-pad-px);
+    border-bottom: var(--xh-border-solid);
+    cursor: pointer;
+
+    &:active {
+      background: var(--xh-bg-highlight);
+    }
+  }
+
+  &__hit-title {
+    font-size: var(--xh-font-size-px);
+    font-weight: 600;
+    color: var(--xh-text-color);
+  }
+
+  &__hit-crumb {
+    align-items: center;
+    gap: var(--xh-pad-half-px);
+    margin-top: 2px;
+    font-size: var(--xh-font-size-small-px);
+    color: var(--xh-text-color-muted);
+  }
+
+  &__hit-crumb-sep {
+    font-size: var(--xh-font-size-small-px);
+    opacity: 0.6;
+  }
+
+  &__hit-snippet {
+    margin-top: var(--xh-pad-half-px);
+    font-size: var(--xh-font-size-small-px);
+    color: var(--xh-text-color-muted);
+    line-height: 1.4;
+  }
+
+  //------------------------
+  // Match highlight (token-bound; reads in both themes)
+  //------------------------
+  &__hl {
+    padding: 0 1px;
+    border-radius: 2px;
+    background: var(--xh-intent-warning-trans2, rgba(245, 166, 35, 0.25));
+    color: var(--xh-text-color);
+    font-weight: 600;
+  }
+}

--- a/client-app/src/mobile/docs/search/DocsSearchPage.ts
+++ b/client-app/src/mobile/docs/search/DocsSearchPage.ts
@@ -1,0 +1,169 @@
+import {badge} from '@xh/hoist/cmp/badge';
+import {div, filler, hbox, span} from '@xh/hoist/cmp/layout';
+import {creates, hoistCmp, HoistProps} from '@xh/hoist/core';
+import {Icon} from '@xh/hoist/icon';
+import {textInput} from '@xh/hoist/mobile/cmp/input';
+import {panel} from '@xh/hoist/mobile/cmp/panel';
+import {toolbar} from '@xh/hoist/mobile/cmp/toolbar';
+import {ReactNode} from 'react';
+import {DocService, DocSearchResult} from '../../../core/svc/DocService';
+import {DocsSearchModel} from './DocsSearchModel';
+import './DocsSearchPage.scss';
+
+/**
+ * Dedicated docs search screen. The empty state lists recent searches; as the user types, live
+ * results replace them - spanning both corpuses and grouped under their library. Each hit shows the
+ * matched term highlighted, a category > doc breadcrumb, and the matched content line; tapping opens
+ * the reader. The app-bar back chevron (from the shell) returns to the landing.
+ */
+export const docsSearchPage = hoistCmp.factory({
+    displayName: 'DocsSearchPage',
+    model: creates(DocsSearchModel),
+
+    render({model}) {
+        return panel({
+            className: 'tb-docs-search',
+            tbar: toolbar({
+                className: 'tb-docs-search__bar',
+                item: textInput({
+                    className: 'tb-docs-search__input',
+                    bind: 'query',
+                    commitOnChange: true,
+                    enableClear: true,
+                    leftIcon: Icon.search(),
+                    placeholder: 'Search the docs'
+                })
+            }),
+            scrollable: true,
+            item: model.hasQuery ? results() : recents()
+        });
+    }
+});
+
+//------------------------
+// Empty state - recent searches
+//------------------------
+const recents = hoistCmp.factory<DocsSearchModel>({
+    render({model}) {
+        const {recentSearches} = model;
+        if (!recentSearches.length) {
+            return div({
+                className: 'tb-docs-search__empty',
+                items: [Icon.search({size: '2x'}), span('Search across both libraries.')]
+            });
+        }
+        return div({
+            className: 'tb-docs-search__recents',
+            items: [
+                div({className: 'tb-docs-search__group-header', item: 'Recent searches'}),
+                ...recentSearches.map(term =>
+                    hbox({
+                        key: term,
+                        className: 'tb-docs-search__recent-row',
+                        onClick: () => model.runRecent(term),
+                        items: [
+                            Icon.clock({className: 'tb-docs-search__recent-icon'}),
+                            span({className: 'tb-docs-search__recent-term', item: term}),
+                            filler(),
+                            div({
+                                className: 'tb-docs-search__recent-remove',
+                                onClick: e => {
+                                    e.stopPropagation();
+                                    model.removeRecent(term);
+                                },
+                                item: Icon.x()
+                            })
+                        ]
+                    })
+                )
+            ]
+        });
+    }
+});
+
+//------------------------
+// Results - grouped by library
+//------------------------
+const results = hoistCmp.factory<DocsSearchModel>({
+    render({model}) {
+        const {groupedResults} = model;
+        if (!groupedResults.length) {
+            return div({
+                className: 'tb-docs-search__empty',
+                items: [Icon.search({size: '2x'}), span('No matching docs.')]
+            });
+        }
+        return div({
+            className: 'tb-docs-search__results',
+            items: groupedResults.map(g =>
+                div({
+                    key: g.source,
+                    className: 'tb-docs-search__group',
+                    items: [
+                        div({
+                            className: 'tb-docs-search__group-header',
+                            items: [span(g.label), badge({item: g.results.length})]
+                        }),
+                        ...g.results.map(r =>
+                            resultRow({key: `${r.entry.source}:${r.entry.id}`, result: r})
+                        )
+                    ]
+                })
+            )
+        });
+    }
+});
+
+interface ResultRowProps extends HoistProps<DocsSearchModel> {
+    result: DocSearchResult;
+}
+
+const resultRow = hoistCmp.factory<ResultRowProps>({
+    render({model, result}) {
+        const {entry, snippet, matchedTerms = []} = result,
+            categoryTitle =
+                DocService.instance.getCategories(entry.source).find(c => c.id === entry.category)
+                    ?.title ?? entry.category;
+
+        return div({
+            className: 'tb-docs-search__hit',
+            onClick: () => model.selectResult(entry),
+            items: [
+                div({
+                    className: 'tb-docs-search__hit-title',
+                    items: highlight(entry.title, matchedTerms)
+                }),
+                hbox({
+                    className: 'tb-docs-search__hit-crumb',
+                    items: [
+                        span(categoryTitle),
+                        Icon.chevronRight({className: 'tb-docs-search__hit-crumb-sep'}),
+                        span(entry.title)
+                    ]
+                }),
+                snippet
+                    ? div({
+                          className: 'tb-docs-search__hit-snippet',
+                          items: highlight(snippet, matchedTerms)
+                      })
+                    : null
+            ]
+        });
+    }
+});
+
+/**
+ * Split `text` on any of the given terms (case-insensitive) and wrap the matches in a highlight
+ * span. `String.split` with a single capturing group yields match fragments at the odd indices.
+ */
+function highlight(text: string, terms: string[]): ReactNode[] {
+    const escaped = terms.map(t => t.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')).filter(Boolean);
+    if (!escaped.length) return [text];
+
+    const re = new RegExp(`(${escaped.join('|')})`, 'ig');
+    return text
+        .split(re)
+        .map((part, i) =>
+            i % 2 === 1 ? span({key: i, className: 'tb-docs-search__hl', item: part}) : part
+        );
+}

--- a/client-app/src/mobile/home/widgets/StartHereWidget.ts
+++ b/client-app/src/mobile/home/widgets/StartHereWidget.ts
@@ -27,8 +27,8 @@ const ITEMS: StartHereItem[] = [
     {
         icon: Icon.book(),
         title: 'Read the docs',
-        blurb: 'Core concepts on GitHub',
-        onClick: () => XH.openWindow('https://github.com/xh/hoist-react#readme', 'gitlink')
+        blurb: 'Browse hoist-react + hoist-core',
+        onClick: () => XH.navigate('default.docs')
     },
     {
         icon: Icon.code(),

--- a/client-app/src/mobile/home/widgets/WelcomeWidget.ts
+++ b/client-app/src/mobile/home/widgets/WelcomeWidget.ts
@@ -28,8 +28,7 @@ export const welcomeWidget = hoistCmp.factory({
                             icon: Icon.book(),
                             intent: 'primary',
                             minimal: false,
-                            onClick: () =>
-                                XH.openWindow('https://github.com/xh/hoist-react#readme', 'gitlink')
+                            onClick: () => XH.navigate('default.docs')
                         }),
                         button({
                             icon: Icon.code(),


### PR DESCRIPTION
Promotes the mobile (phone) Docs reader to a top-level Docs section, bringing the phone close to desktop feature parity without recreating its dense double tree. Phone form factor only; tablets continue to load the desktop app.

### Highlights

- **Landing / corpus chooser** - hoist-react and hoist-core as cards with live doc counts, a tap-through search field, and a persisted "Jump back in" recently-viewed list.
- **Drill-down** - iOS-style push navigation: landing to corpus categories to category docs to reader, with the app-bar back chevron carrying the parent screen's name.
- **Reader** - reused as-is save for a within-category prev/next pager and a restructured two-line header (breadcrumb above, doc title + "On this page" below).
- **Search** - dedicated cross-corpus screen: recent searches when empty, live results grouped by library with highlighted matches and matched-line snippets, opening straight into the reader.
- **Entry points** - Docs is now a standalone nav-blade item under Home; the Welcome and Start Here "Read the Docs" CTAs open the in-app landing instead of GitHub.

### Implementation notes

- A single reader page (`doc`) is reused at three route nodes (browse, search, example deep-link), so back-targets are positional and correct for free.
- Shared `core/docs` additions keep desktop and mobile DRY: source/category icon helpers lifted into `DocIcons` (also registers the `react` brand glyph, fixing a previously-blank source icon on both clients), plus doc counts, recently-viewed tracking, and search snippets on `DocService`.
