### PR TITLE
Demo windowed Select/SelectEditor menu auto-sizing

### DIFF
--- a/client-app/src/desktop/tabs/forms/SelectPanel.ts
+++ b/client-app/src/desktop/tabs/forms/SelectPanel.ts
@@ -10,7 +10,12 @@ import {restaurants, usStates} from '../../../core/data';
 import {wrapper} from '../../common';
 import './SelectPanel.scss';
 
-const LARGE_OPTIONS = Array.from({length: 2000}, (_, i) => `Item ${i + 1}`);
+// Varied label lengths so the windowed dropdown demonstrates auto-sizing its menu to the
+// widest content rather than collapsing to the (narrow) control width.
+const LARGE_OPTIONS = Array.from(
+    {length: 2000},
+    (_, i) => `Item ${i + 1}${i % 7 === 0 ? ' - a longer descriptive option label' : ''}`
+);
 
 const STATUS_OPTIONS = [
     {
@@ -306,7 +311,7 @@ const column2 = hoistCmp.factory<SelectPanelModel>(() =>
             }),
             demoRow({
                 label: 'Large list (windowed)',
-                info: 'enableWindowed - 2,000 items virtualized',
+                info: 'enableWindowed - 2,000 items virtualized, menu auto-sizes to content',
                 item: select({
                     bind: 'bigValue',
                     options: LARGE_OPTIONS,

--- a/client-app/src/desktop/tabs/forms/SelectPanel.ts
+++ b/client-app/src/desktop/tabs/forms/SelectPanel.ts
@@ -10,8 +10,7 @@ import {restaurants, usStates} from '../../../core/data';
 import {wrapper} from '../../common';
 import './SelectPanel.scss';
 
-// Varied label lengths so the windowed dropdown demonstrates auto-sizing its menu to the
-// widest content rather than collapsing to the (narrow) control width.
+// Varied label lengths so the windowed menu visibly auto-sizes to its widest content.
 const LARGE_OPTIONS = Array.from(
     {length: 2000},
     (_, i) => `Item ${i + 1}${i % 7 === 0 ? ' - a longer descriptive option label' : ''}`

--- a/client-app/src/desktop/tabs/grids/InlineEditingPanelModel.ts
+++ b/client-app/src/desktop/tabs/grids/InlineEditingPanelModel.ts
@@ -19,6 +19,17 @@ import {wait} from '@xh/hoist/promise';
 import {LocalDate} from '@xh/hoist/utils/datetime';
 import {isEmpty, isNil, max} from 'lodash';
 
+// Real category values come first (seed data + the `category === 'US'` validation rely on them),
+// padded past react-windowed-select's threshold so the `category` editor exercises windowed mode.
+const CATEGORY_OPTIONS = [
+    'US',
+    'BRIC',
+    'Emerging Markets',
+    'EU',
+    'Asia/Pac',
+    ...Array.from({length: 120}, (_, i) => `Region ${i + 1} - extended market category label`)
+];
+
 export class InlineEditingPanelModel extends HoistModel {
     @bindable
     asyncValidation = false;
@@ -332,11 +343,14 @@ export class InlineEditingPanelModel extends HoistModel {
                     field: 'category',
                     width: 80,
                     editable: ifNotRestricted,
+                    // enableWindowed with a large option list in a narrow cell - the dropdown menu
+                    // auto-sizes to the widest option rather than being clamped to the cell width.
                     editor: props =>
                         selectEditor({
                             ...props,
                             inputProps: {
-                                options: ['US', 'BRIC', 'Emerging Markets', 'EU', 'Asia/Pac']
+                                enableWindowed: true,
+                                options: CATEGORY_OPTIONS
                             }
                         })
                 },

--- a/client-app/src/desktop/tabs/grids/InlineEditingPanelModel.ts
+++ b/client-app/src/desktop/tabs/grids/InlineEditingPanelModel.ts
@@ -19,8 +19,8 @@ import {wait} from '@xh/hoist/promise';
 import {LocalDate} from '@xh/hoist/utils/datetime';
 import {isEmpty, isNil, max} from 'lodash';
 
-// Real category values come first (seed data + the `category === 'US'` validation rely on them),
-// padded past react-windowed-select's threshold so the `category` editor exercises windowed mode.
+// Real values first (seed data + `category === 'US'` validation need them), padded past the
+// windowing threshold so the `category` editor exercises windowed mode.
 const CATEGORY_OPTIONS = [
     'US',
     'BRIC',
@@ -343,8 +343,7 @@ export class InlineEditingPanelModel extends HoistModel {
                     field: 'category',
                     width: 80,
                     editable: ifNotRestricted,
-                    // enableWindowed with a large option list in a narrow cell - the dropdown menu
-                    // auto-sizes to the widest option rather than being clamped to the cell width.
+                    // Windowed editor in a narrow cell - menu auto-sizes to content, not cell width.
                     editor: props =>
                         selectEditor({
                             ...props,


### PR DESCRIPTION
Demo changes that exercise the hoist-react fix for windowed dropdown menus being constrained to the control/cell width.

Paired with xh/hoist-react#4452 (fixes xh/hoist-react#4325).

## Changes

- **Forms > Select** - "Large list (windowed)": varied `LARGE_OPTIONS` label lengths so the virtualized menu visibly auto-sizes to its widest content instead of looking identical to a content-width menu.
- **Grids > Inline Editing** - the `category` editor now uses `enableWindowed` with a large option list in a narrow (~80px) cell. This is the exact #4325 scenario. Real category values (`US`, `EU`, `BRIC`, ...) are preserved at the front of the list so the seed data and the `category === 'US'` amount-validation rule still apply.

Before the hoist-react fix these menus were clamped to the control/cell width and truncated long options; now they grow to fit their content while still virtualizing.

## Testing

Verified both demos in the browser against the hoist-react branch (`--env inlineHoist`): the windowed menus auto-size to fit long labels, scroll (virtualized), and the inline-editing validation still behaves.