### PR TITLE
Demo controls for fmtQuantity `lossless` + `null` precision

### DIFF
--- a/client-app/src/desktop/tabs/other/formats/NumberFormatsPanel.ts
+++ b/client-app/src/desktop/tabs/other/formats/NumberFormatsPanel.ts
@@ -76,6 +76,27 @@ export const numberFormatsPanel = hoistCmp.factory({
                     })
                 }),
                 wrapperOption({
+                    omit: model.fnName !== 'fmtQuantity',
+                    label: 'Lossless',
+                    propName: 'QuantityFormatOptions.lossless',
+                    control: switchInput({model, bind: 'lossless'}),
+                    info: 'Compact to m/b only when no precision is lost, else render the full value.'
+                }),
+                wrapperOption({
+                    omit: model.fnName !== 'fmtQuantity',
+                    label: 'Use Millions',
+                    propName: 'QuantityFormatOptions.useMillions',
+                    control: switchInput({model, bind: 'useMillions'}),
+                    info: 'Compact values >= 1 million into units of millions (m).'
+                }),
+                wrapperOption({
+                    omit: model.fnName !== 'fmtQuantity',
+                    label: 'Use Billions',
+                    propName: 'QuantityFormatOptions.useBillions',
+                    control: switchInput({model, bind: 'useBillions'}),
+                    info: 'Compact values >= 1 billion into units of billions (b).'
+                }),
+                wrapperOption({
                     label: 'Color Spec',
                     propName: 'NumberFormatOptions.colorSpec',
                     control: segmentedControl({
@@ -112,9 +133,13 @@ export const numberFormatsPanel = hoistCmp.factory({
                         width: 100,
                         enableFilter: false,
                         hideSelectedOptionCheck: true,
-                        options: [{label: 'auto', value: -1}, ...range(0, 13)]
+                        options: [
+                            {label: 'null', value: -2},
+                            {label: 'auto', value: -1},
+                            ...range(0, 13)
+                        ]
                     }),
-                    info: `'auto' scales to the value, or fix it.`
+                    info: `null for full precision, 'auto' to scale to the value, or fix it.`
                 }),
                 wrapperOption({
                     label: 'Zero Pad',

--- a/client-app/src/desktop/tabs/other/formats/NumberFormatsPanel.ts
+++ b/client-app/src/desktop/tabs/other/formats/NumberFormatsPanel.ts
@@ -77,13 +77,6 @@ export const numberFormatsPanel = hoistCmp.factory({
                 }),
                 wrapperOption({
                     omit: model.fnName !== 'fmtQuantity',
-                    label: 'Lossless',
-                    propName: 'QuantityFormatOptions.lossless',
-                    control: switchInput({model, bind: 'lossless'}),
-                    info: 'Compact to m/b only when no precision is lost, else render the full value.'
-                }),
-                wrapperOption({
-                    omit: model.fnName !== 'fmtQuantity',
                     label: 'Use Millions',
                     propName: 'QuantityFormatOptions.useMillions',
                     control: switchInput({model, bind: 'useMillions'}),
@@ -95,6 +88,13 @@ export const numberFormatsPanel = hoistCmp.factory({
                     propName: 'QuantityFormatOptions.useBillions',
                     control: switchInput({model, bind: 'useBillions'}),
                     info: 'Compact values >= 1 billion into units of billions (b).'
+                }),
+                wrapperOption({
+                    omit: model.fnName !== 'fmtQuantity',
+                    label: 'Lossless',
+                    propName: 'QuantityFormatOptions.lossless',
+                    control: switchInput({model, bind: 'lossless'}),
+                    info: 'Compact to m/b only when no precision is lost, else render the full value.'
                 }),
                 wrapperOption({
                     label: 'Color Spec',

--- a/client-app/src/desktop/tabs/other/formats/NumberFormatsPanelModel.ts
+++ b/client-app/src/desktop/tabs/other/formats/NumberFormatsPanelModel.ts
@@ -23,6 +23,8 @@ export class NumberFormatsPanelModel extends HoistModel {
         123400.1,
         123450, // tests that rightmost zero is not cut off when precision: 0 && zeroPad: false
         920120.21343,
+        7100100, // tests fmtQuantity `lossless` - stays full, does not collapse to 7.10m
+        7120000, // tests fmtQuantity `lossless` - collapses cleanly to 7.12m
         12345600,
         100000001,
         123456789.12,
@@ -39,7 +41,7 @@ export class NumberFormatsPanelModel extends HoistModel {
     @bindable ledger = false;
     @bindable nullDisplay: string = null;
     @bindable omitFourDigitComma = false;
-    @bindable precision = -1; // -1 => 'auto'
+    @bindable precision = -1; // -2 => null (full), -1 => 'auto'
     @bindable prefix: string = null;
     @bindable strictZero = true;
     @bindable withCommas = true;
@@ -47,6 +49,11 @@ export class NumberFormatsPanelModel extends HoistModel {
     @bindable withSignGlyph = false;
     @bindable zeroDisplay: string = null;
     @bindable zeroPad = -2; // -2 => undefined, -1 => false, 0 => true, # => pad length
+
+    // fmtQuantity-only options.
+    @bindable lossless = false;
+    @bindable useMillions = true;
+    @bindable useBillions = true;
     @bindable positiveColor = '#00aa00';
     @bindable negativeColor = '#cc0000';
     @bindable neutralColor = '#999999';
@@ -93,7 +100,10 @@ export class NumberFormatsPanelModel extends HoistModel {
             withCommas: this.withCommas,
             withPlusSign: this.withPlusSign,
             withSignGlyph: this.withSignGlyph,
-            zeroPad: this.toZeroPad(this.zeroPad)
+            zeroPad: this.toZeroPad(this.zeroPad),
+            lossless: this.lossless,
+            useMillions: this.useMillions,
+            useBillions: this.useBillions
         };
 
         try {
@@ -105,7 +115,9 @@ export class NumberFormatsPanelModel extends HoistModel {
     }
 
     private toPrecision(formVal: number) {
-        return formVal === -1 ? 'auto' : formVal;
+        if (formVal === -2) return null;
+        if (formVal === -1) return 'auto';
+        return formVal;
     }
 
     private toZeroPad(formVal: number) {

--- a/client-app/src/desktop/tabs/other/formats/NumberFormatsPanelModel.ts
+++ b/client-app/src/desktop/tabs/other/formats/NumberFormatsPanelModel.ts
@@ -51,9 +51,9 @@ export class NumberFormatsPanelModel extends HoistModel {
     @bindable zeroPad = -2; // -2 => undefined, -1 => false, 0 => true, # => pad length
 
     // fmtQuantity-only options.
-    @bindable lossless = false;
     @bindable useMillions = true;
     @bindable useBillions = true;
+    @bindable lossless = false;
     @bindable positiveColor = '#00aa00';
     @bindable negativeColor = '#cc0000';
     @bindable neutralColor = '#999999';
@@ -101,9 +101,9 @@ export class NumberFormatsPanelModel extends HoistModel {
             withPlusSign: this.withPlusSign,
             withSignGlyph: this.withSignGlyph,
             zeroPad: this.toZeroPad(this.zeroPad),
-            lossless: this.lossless,
             useMillions: this.useMillions,
-            useBillions: this.useBillions
+            useBillions: this.useBillions,
+            lossless: this.lossless
         };
 
         try {


### PR DESCRIPTION
Wires up the **Other › Format Numbers** demo panel to exercise recent formatting changes from hoist-react.

### Changes
- Added `lossless`, `useMillions`, and `useBillions` switches, shown only when `fmtQuantity` is the selected formatter.
- Added a `null` option to the precision picker, exercising `fmtNumber`'s new full-precision handling.
- Added two sample values (`7,100,100` and `7,120,000`) that demonstrate the lossless cutoff (`7,100,100` stays full; `7,120,000` collapses cleanly to `7.12m`).

### Dependency
Depends on the `lossless` option added in the corresponding hoist-react PR. Run with inline hoist (or once a snapshot including it is published) to see the new behavior. Typecheck/lint pass against the current published snapshot since the options object is passed dynamically.