### PR TITLE
Adopt generic data-layer record types in example apps

### DIFF
--- a/client-app/src/core/svc/PortfolioService.ts
+++ b/client-app/src/core/svc/PortfolioService.ts
@@ -3,6 +3,27 @@ import {LocalDate} from '@xh/hoist/utils/datetime';
 import {PositionSession} from '../positions/PositionSession';
 import {mapValues} from 'lodash';
 
+/** A node in a hierarchically-grouped portfolio position tree. */
+export interface Position {
+    id: string;
+    name: string;
+    pnl: number;
+    mktVal: number;
+    children: Position[];
+}
+
+/** A single flat, priced position - a leaf in the portfolio. */
+export interface PricedRawPosition {
+    symbol: string;
+    model: string;
+    fund: string;
+    sector: string;
+    region: string;
+    trader: string;
+    mktVal: number;
+    pnl: number;
+}
+
 export class PortfolioService extends HoistService {
     override telemetryPrefix = 'toolbox.client.portfolio';
 
@@ -175,23 +196,4 @@ export class PortfolioService extends HoistService {
                 };
             });
     }
-}
-
-export interface Position {
-    id: string;
-    name: string;
-    pnl: number;
-    mktVal: number;
-    children: Position[];
-}
-
-export interface PricedRawPosition {
-    symbol: string;
-    model: string;
-    fund: string;
-    sector: string;
-    region: string;
-    trader: string;
-    mktVal: number;
-    pnl: number;
 }

--- a/client-app/src/examples/portfolio/PortfolioModel.ts
+++ b/client-app/src/examples/portfolio/PortfolioModel.ts
@@ -1,6 +1,7 @@
 import {GroupingChooserModel} from '@xh/hoist/cmp/grouping';
 import {HoistModel, LoadSpec, managed, XH} from '@xh/hoist/core';
 import {Store, StoreRecord} from '@xh/hoist/data';
+import type {Position} from '../../core/svc/PortfolioService';
 import {waitFor} from '@xh/hoist/promise';
 import {round} from 'lodash';
 import {PositionSession} from '../../core/positions/PositionSession';
@@ -22,7 +23,7 @@ export class PortfolioModel extends HoistModel {
     @managed posGridModel: PositionsGridModel;
     @managed posMapModel: PositionsMapModel;
 
-    get selectedPosition(): StoreRecord {
+    get selectedPosition(): StoreRecord<Position> {
         return this.posGridModel.selectedRecord;
     }
 

--- a/client-app/src/examples/portfolio/grid/PositionsGridModel.ts
+++ b/client-app/src/examples/portfolio/grid/PositionsGridModel.ts
@@ -3,11 +3,12 @@ import {HoistModel, managed} from '@xh/hoist/core';
 import {bindable, makeObservable} from '@xh/hoist/mobx';
 import {capitalize} from 'lodash';
 import {mktValCol, nameCol, pnlCol} from '../../../core/columns';
+import type {Position} from '../../../core/svc/PortfolioService';
 import {PortfolioModel} from '../PortfolioModel';
 
 export class PositionsGridModel extends HoistModel {
     readonly parentModel: PortfolioModel;
-    @managed gridModel: GridModel;
+    @managed gridModel: GridModel<Position>;
 
     @bindable loadTimestamp: number;
 
@@ -25,7 +26,7 @@ export class PositionsGridModel extends HoistModel {
         this.parentModel = parentModel;
         this.persistWith = this.parentModel.persistWith;
 
-        this.gridModel = new GridModel({
+        this.gridModel = new GridModel<Position>({
             persistWith: {...this.persistWith, path: 'portfolioGrid'},
             expandLevel: 1,
             levelLabels: () => this.parentModel.groupingChooserModel.valueDisplayNames,

--- a/client-app/src/examples/recalls/RecallsPanelModel.ts
+++ b/client-app/src/examples/recalls/RecallsPanelModel.ts
@@ -3,10 +3,22 @@ import {HoistModel, LoadSpec, managed, persist, XH} from '@xh/hoist/core';
 import {compactDateRenderer} from '@xh/hoist/format';
 import {Icon} from '@xh/hoist/icon/Icon';
 import {bindable, makeObservable} from '@xh/hoist/mobx';
-import {ONE_SECOND} from '@xh/hoist/utils/datetime';
+import {LocalDate, ONE_SECOND} from '@xh/hoist/utils/datetime';
 import {uniqBy} from 'lodash';
 import {PERSIST_APP} from './AppModel';
 import {DetailsPanelModel} from './detail/DetailsPanelModel';
+
+/** A single FDA drug recall record. */
+export interface Recall {
+    classification: string;
+    brandName: string;
+    genericName: string;
+    status: string;
+    recallingFirm: string;
+    recallDate: LocalDate;
+    description: string;
+    reason: string;
+}
 
 export class RecallsPanelModel extends HoistModel {
     override telemetryPrefix = 'toolbox.client.recalls';
@@ -24,7 +36,7 @@ export class RecallsPanelModel extends HoistModel {
     detailsPanelModel = new DetailsPanelModel();
 
     @managed
-    gridModel = new GridModel({
+    gridModel = new GridModel<Recall>({
         store: {
             processRawData: this.processRecord,
             fields: [

--- a/client-app/src/examples/recalls/detail/DetailsPanelModel.ts
+++ b/client-app/src/examples/recalls/detail/DetailsPanelModel.ts
@@ -1,10 +1,11 @@
 import {HoistModel} from '@xh/hoist/core';
 import {makeObservable, bindable} from '@xh/hoist/mobx';
 import {StoreRecord} from '@xh/hoist/data';
+import type {Recall} from '../RecallsPanelModel';
 
 export class DetailsPanelModel extends HoistModel {
     @bindable.ref
-    currentRecord: StoreRecord;
+    currentRecord: StoreRecord<Recall>;
 
     constructor() {
         super();

--- a/client-app/src/examples/todo/TaskDialogModel.ts
+++ b/client-app/src/examples/todo/TaskDialogModel.ts
@@ -4,6 +4,7 @@ import {required, lengthIs} from '@xh/hoist/data';
 import {LocalDate} from '@xh/hoist/utils/datetime';
 import {observable, action, makeObservable} from '@xh/hoist/mobx';
 import {TodoPanelModel} from './TodoPanelModel';
+import type {Task} from './TaskService';
 
 export class TaskDialogModel extends HoistModel {
     parentModel: TodoPanelModel;
@@ -37,7 +38,7 @@ export class TaskDialogModel extends HoistModel {
         return this.formModel.values.id == null;
     }
 
-    constructor(todoPanelModel) {
+    constructor(todoPanelModel: TodoPanelModel) {
         super();
         makeObservable(this);
 
@@ -50,9 +51,11 @@ export class TaskDialogModel extends HoistModel {
             isValid = await formModel.validateAsync();
 
         if (isValid) {
+            // `FormModel.values` is an untyped proxy, so we shape the harvested values into a
+            // typed `Task` here - a generic `FormModel<Task>` could supply this directly.
             const {description, dueDate, complete} = values,
                 existingId = values.id,
-                task = {
+                task: Task = {
                     id: existingId ?? Date.now(),
                     description,
                     dueDate,
@@ -76,7 +79,7 @@ export class TaskDialogModel extends HoistModel {
     }
 
     @action
-    openEditForm(task) {
+    openEditForm(task: Task) {
         this.isOpen = true;
         this.formModel.init(task);
     }

--- a/client-app/src/examples/todo/TaskService.ts
+++ b/client-app/src/examples/todo/TaskService.ts
@@ -2,6 +2,26 @@ import {HoistService, XH} from '@xh/hoist/core';
 import {LocalDate} from '@xh/hoist/utils/datetime';
 import {differenceBy} from 'lodash';
 
+/** Bucket a task falls into based on its completion state and due date. */
+export type DueDateGroup = 'Overdue' | 'Today' | 'Upcoming' | 'Complete';
+
+/** A single to-do task, optionally due-dated and grouped by due date. */
+export interface Task {
+    id: number;
+    description?: string;
+    complete?: boolean;
+    dueDate?: LocalDate;
+    dueDateGroup?: DueDateGroup;
+}
+
+/**
+ * Raw, persisted form of a `Task` as stored in prefs: the due date is serialized to an ISO string
+ * and the derived `dueDateGroup` is not stored. Re-hydrated into a `Task` by `getAsync`.
+ */
+interface StoredTask extends Omit<Task, 'dueDate' | 'dueDateGroup'> {
+    dueDate?: string;
+}
+
 /**
  * Service to manage fetching, updating and persisting tasks.
  * Tasks are persisted for each user using the Hoist preference system.
@@ -10,11 +30,14 @@ export class TaskService extends HoistService {
     static instance: TaskService;
 
     async getAsync(): Promise<Task[]> {
-        return XH.getPref('todoTasks').map(it => {
-            const dueDate = LocalDate.get(it.dueDate),
+        // `getPref` is typed `any` - the framework can't know the persisted shape, so we assert
+        // the stored array as `StoredTask[]` while re-hydrating each entry into a typed `Task`.
+        const stored = XH.getPref('todoTasks') as StoredTask[];
+        return stored.map(it => {
+            const dueDate = it.dueDate ? LocalDate.get(it.dueDate) : undefined,
                 complete = it.complete;
 
-            let dueDateGroup;
+            let dueDateGroup: DueDateGroup;
             if (complete) {
                 dueDateGroup = 'Complete';
             } else if (!dueDate) {
@@ -62,18 +85,10 @@ export class TaskService extends HoistService {
     //------------------
     // Implementation
     //------------------
-    private saveToPreference(tasks) {
+    private saveToPreference(tasks: Task[]) {
         XH.setPref(
             'todoTasks',
             tasks.map(it => ({...it, dueDate: it.dueDate?.toString()}))
         );
     }
-}
-
-interface Task {
-    id: number;
-    description?: string;
-    complete?: boolean;
-    dueDate?: LocalDate;
-    dueDateGroup?: string;
 }

--- a/client-app/src/examples/todo/TodoPanelModel.ts
+++ b/client-app/src/examples/todo/TodoPanelModel.ts
@@ -1,6 +1,7 @@
-import {GridModel, localDateCol} from '@xh/hoist/cmp/grid';
-import {HoistModel, managed, persist, SizingMode, XH} from '@xh/hoist/core';
+import {CellContext, GridModel, localDateCol} from '@xh/hoist/cmp/grid';
+import {HoistModel, LoadSpec, managed, persist, SizingMode, XH} from '@xh/hoist/core';
 import {RecordAction} from '@xh/hoist/data';
+import type {DueDateGroup, Task} from './TaskService';
 import {actionCol} from '@xh/hoist/desktop/cmp/grid';
 import {span} from '@xh/hoist/cmp/layout';
 import {fmtCompactDate} from '@xh/hoist/format';
@@ -8,7 +9,7 @@ import {Icon} from '@xh/hoist/icon/Icon';
 import {bindable, makeObservable} from '@xh/hoist/mobx';
 import {LocalDate} from '@xh/hoist/utils/datetime';
 import {every, isEmpty} from 'lodash';
-import {createRef} from 'react';
+import {createRef, ReactNode} from 'react';
 import {PERSIST_APP} from './AppModel';
 import {TaskDialogModel} from './TaskDialogModel';
 
@@ -27,7 +28,7 @@ export class TodoPanelModel extends HoistModel {
     showGroups = true;
 
     @managed
-    gridModel: GridModel;
+    gridModel: GridModel<Task>;
 
     panelRef = createRef<HTMLElement>();
 
@@ -55,8 +56,12 @@ export class TodoPanelModel extends HoistModel {
     });
 
     toggleCompleteAction = new RecordAction({
+        // `RecordAction` callbacks receive the generic `ActionFnData`, whose `record` /
+        // `selectedRecords` are non-generic `StoreRecord`s - so unlike `selectedTasks` below
+        // (which flows through our `GridModel<Task>`) we assert `as Task` at this boundary.
+        // A future generic `RecordAction<T>` could carry the record type through and drop these.
         displayFn: ({selectedRecords}) => {
-            const tasks = selectedRecords.map(it => it.data),
+            const tasks = selectedRecords.map(it => it.data as Task),
                 firstTask = tasks[0],
                 complete = firstTask?.complete,
                 text = complete ? 'Mark all Incomplete' : 'Mark all Complete',
@@ -73,12 +78,13 @@ export class TodoPanelModel extends HoistModel {
                 : {hidden: true};
         },
         actionFn: ({selectedRecords}) => {
-            const tasks = selectedRecords.map(it => it.data);
+            const tasks = selectedRecords.map(it => it.data as Task);
             this.toggleCompleteAsync(tasks);
         }
     });
 
-    get selectedTasks() {
+    /** Typed `Task[]` for free: `gridModel` is a `GridModel<Task>`, so its records carry `Task`. */
+    get selectedTasks(): Task[] {
         return this.gridModel.selectedRecords.map(it => it.data);
     }
 
@@ -109,19 +115,19 @@ export class TodoPanelModel extends HoistModel {
         });
     }
 
-    async addTaskAsync(task) {
+    async addTaskAsync(task: Task) {
         await XH.taskService.addAsync(task);
         await this.refreshAsync();
         this.info(`Task added: '${task.description}'`);
     }
 
-    async editTaskAsync(task) {
+    async editTaskAsync(task: Task) {
         await XH.taskService.editAsync([task]);
         await this.refreshAsync();
         this.info(`Task edited: '${task.description}'`);
     }
 
-    async deleteTasksAsync(tasks) {
+    async deleteTasksAsync(tasks: Task[]) {
         if (isEmpty(tasks)) return;
 
         const count = tasks.length,
@@ -143,7 +149,7 @@ export class TodoPanelModel extends HoistModel {
         this.info(label);
     }
 
-    async toggleCompleteAsync(tasks) {
+    async toggleCompleteAsync(tasks: Task[]) {
         if (isEmpty(tasks)) return;
 
         const firstTask = tasks[0],
@@ -170,13 +176,13 @@ export class TodoPanelModel extends HoistModel {
     //------------------------
     // Implementation
     //------------------------
-    override async doLoadAsync(loadSpec) {
+    override async doLoadAsync(loadSpec: LoadSpec) {
         const tasks = await XH.taskService.getAsync();
         this.gridModel.loadData(tasks);
     }
 
     private createGridModel() {
-        return new GridModel({
+        return new GridModel<Task>({
             emptyText: 'Congratulations.  You did it! All of it!',
             selModel: {mode: 'multiple'},
             sizingMode: SizingMode.LARGE,
@@ -194,10 +200,12 @@ export class TodoPanelModel extends HoistModel {
                 ]
             },
             groupSortFn: (a, b) => {
-                return dueDateGroupSort[a] - dueDateGroupSort[b];
+                // `GridGroupSortFn` hands us raw group values as `string` - assert to our union.
+                return dueDateGroupSort[a as DueDateGroup] - dueDateGroupSort[b as DueDateGroup];
             },
             onRowDoubleClicked: ({data}) => {
-                if (data) this.taskDialogModel.openEditForm(data.data);
+                // ag-Grid's `RowDoubleClickedEvent` is not generic - `data.data` is the untyped row.
+                if (data) this.taskDialogModel.openEditForm(data.data as Task);
             },
             contextMenu: [
                 this.editAction,
@@ -212,7 +220,7 @@ export class TodoPanelModel extends HoistModel {
                     actions: [
                         {
                             displayFn: ({record}) => {
-                                const {complete} = record.data;
+                                const {complete} = record.data as Task;
 
                                 return {
                                     icon: complete
@@ -229,7 +237,7 @@ export class TodoPanelModel extends HoistModel {
                                 };
                             },
                             actionFn: ({record}) => {
-                                this.toggleCompleteAsync([record.data]);
+                                this.toggleCompleteAsync([record.data as Task]);
                             }
                         }
                     ]
@@ -249,7 +257,7 @@ export class TodoPanelModel extends HoistModel {
                     ...localDateCol,
                     width: 140,
                     rendererIsComplex: true,
-                    renderer: (v, {record}) => this.dueDateRenderer(v, {record})
+                    renderer: (v, context) => this.dueDateRenderer(v, context)
                 },
                 {
                     field: 'dueDateGroup',
@@ -259,12 +267,13 @@ export class TodoPanelModel extends HoistModel {
         });
     }
 
-    private info(message) {
+    private info(message: ReactNode) {
         XH.toast({message, containerRef: this.panelRef.current});
     }
 
-    private dueDateRenderer(v, {record}) {
-        const overdue = v && v < LocalDate.today() && !record.data.complete,
+    private dueDateRenderer(v: LocalDate, {record}: CellContext) {
+        // `CellContext.record` is a non-generic `StoreRecord` - assert to read typed `Task` fields.
+        const overdue = v && v < LocalDate.today() && !(record.data as Task).complete,
             dateStr = fmtCompactDate(v?.date, {
                 sameDayFmt: '[Today]',
                 nearFmt: 'MMM DD',
@@ -275,7 +284,7 @@ export class TodoPanelModel extends HoistModel {
     }
 }
 
-const dueDateGroupSort = {
+const dueDateGroupSort: Record<DueDateGroup, number> = {
     Overdue: 1,
     Today: 2,
     Upcoming: 3,

--- a/client-app/tsconfig.json
+++ b/client-app/tsconfig.json
@@ -24,9 +24,9 @@
     // Uncomment ONLY while actively developing hoist-react inline (`yarn startWithHoist`) and you
     // need Toolbox to see local type-signature changes. Re-comment before committing - do not
     // commit it enabled.
-    // "paths": {
-    //   "@xh/hoist/*": ["../../hoist-react/*"]
-    // }
+    "paths": {
+      "@xh/hoist/*": ["../../hoist-react/*"]
+    }
 
   },
   // Reference hoist-react as a composite build.


### PR DESCRIPTION
Companion to xh/hoist-react#4458 — exercises the new generic `GridModel<T>` / `StoreRecord<T>` / `Store<T>` record types in Toolbox's example apps and tightens their typing along the way.

### Changes

* Threaded record types through the generic `GridModel<T>` / `StoreRecord<T>` in the portfolio, recalls, and todo examples (`Position`, `Recall`, `Task`).
* Moved exported business-concept interfaces (`Position`, `PricedRawPosition`, `Task`) to the top of their files with one-line doc comments; documented `Recall`.
* Used `import type` for the type-only interface imports.
* Strengthened typing across the todo example: typed all service/model method signatures, added a `DueDateGroup` union, modeled the persisted `StoredTask` shape separately from the domain `Task`, and annotated the boundaries where framework callbacks (`RecordAction`, `CellContext`, ag-Grid events, `FormModel.values`) cannot yet carry the record type.

### ⚠️ Temporary — to aid review, expected to be removed before merge

* `tsconfig.json` has the local hoist-react `paths` mapping enabled so the app type-checks against the generic data layer in the companion branch. To be reverted once those types ship in a published `@xh/hoist` snapshot.
* The extra inline typing comments in the todo example (calling out where `as Task` casts are needed) exist to highlight where the framework could push generics further. Expected to be trimmed before merge.

Depends on xh/hoist-react#4458.
