### PR TITLE
Admin cube tester: adoptRawData A/B harness

### DIFF
--- a/client-app/src/admin/tests/cube/CubeModel.ts
+++ b/client-app/src/admin/tests/cube/CubeModel.ts
@@ -27,7 +27,8 @@ export class CubeModel extends HoistModel {
     }
 
     override async doLoadAsync(loadSpec) {
-        const LTM = this.parent.loadTimesModel;
+        const LTM = this.parent.loadTimesModel,
+            {recordMultiplier} = this.parent;
         let orders = [];
         await LTM.withLoadTime('Fetch orders', async () => {
             orders = await XH.portfolioService.getAllOrdersAsync({loadSpec});
@@ -36,6 +37,16 @@ export class CubeModel extends HoistModel {
                 it.maxConfidence = it.minConfidence = it.confidence;
             });
         });
+
+        // Replicate the fetched orders to stress-test at scale. Copies reuse the same dimension
+        // values (deepening aggregation) with fresh unique ids required by the Cube's idSpec.
+        if (recordMultiplier > 1) {
+            const base = orders;
+            orders = base.slice();
+            for (let k = 1; k < recordMultiplier; k++) {
+                base.forEach(o => orders.push({...o, id: `${o.id}~r${k}`}));
+            }
+        }
 
         const ocTxt = fmtThousands(orders.length) + 'k';
         await LTM.withLoadTime(`Loaded ${ocTxt} orders in Cube`, async () => {

--- a/client-app/src/admin/tests/cube/CubeTestModel.ts
+++ b/client-app/src/admin/tests/cube/CubeTestModel.ts
@@ -1,8 +1,9 @@
 import {GridModel, timeCol, TreeStyle} from '@xh/hoist/cmp/grid';
-import {HoistModel, managed, PlainObject} from '@xh/hoist/core';
+import {fragment, p, pre} from '@xh/hoist/cmp/layout';
+import {HoistModel, managed, PlainObject, XH} from '@xh/hoist/core';
 import {numberEditor, textEditor} from '@xh/hoist/desktop/cmp/grid';
-import {numberRenderer} from '@xh/hoist/format';
-import {bindable, comparer, makeObservable} from '@xh/hoist/mobx';
+import {fmtNumber, numberRenderer} from '@xh/hoist/format';
+import {action, bindable, comparer, makeObservable, observable} from '@xh/hoist/mobx';
 import {wait} from '@xh/hoist/promise';
 import {isEmpty} from 'lodash';
 import {DimensionManagerModel} from './dimensions/DimensionManagerModel';
@@ -12,8 +13,8 @@ import {QueryConfig, View} from '@xh/hoist/data';
 
 export class CubeTestModel extends HoistModel {
     @managed cubeModel: CubeModel;
-    @managed gridModel: GridModel;
-    @managed view: View;
+    @managed @observable.ref gridModel: GridModel;
+    @managed @observable.ref view: View;
     @managed dimManagerModel: DimensionManagerModel;
     @managed loadTimesModel: LoadTimesModel;
 
@@ -24,32 +25,97 @@ export class CubeTestModel extends HoistModel {
     @bindable updateFreq = -1;
     @bindable updateCount = 5;
 
+    /** Zero-copy Store mode under test (hoist-react #4506). Rebuilds grid + view when toggled. */
+    @bindable adoptRawData = false;
+
+    /** Replication factor applied to fetched orders, to stress-test the Cube path at scale. */
+    @bindable recordMultiplier = 1;
+
+    /** Last sampled JS heap in MB (via measureMemory). */
+    @observable heapMB: number = null;
+
+    /** True if the last heap sample was taken without --expose-gc (coarse, directional only). */
+    @observable heapImprecise = false;
+
     constructor() {
         super();
         makeObservable(this);
         this.loadTimesModel = new LoadTimesModel();
-        this.gridModel = this.createGridModel();
         this.cubeModel = new CubeModel(this);
 
-        const {cube} = this.cubeModel;
-
         this.dimManagerModel = new DimensionManagerModel({
-            dimensions: cube.dimensions,
+            dimensions: this.cubeModel.cube.dimensions,
             defaultDimConfig: 'cubeTestDefaultDims',
             userDimPref: 'cubeTestUserDims'
         });
 
-        this.view = cube.createView({
-            query: this.getQuery(),
-            stores: this.gridModel.store,
-            connect: true
-        });
+        this.buildGridAndView();
 
         this.addReaction({
             track: () => this.getQuery(),
             run: () => this.executeQueryAsync(),
             equals: comparer.structural
         });
+
+        // Rebuild grid + connected view when toggling adoptRawData, reconstructing the underlying
+        // Store in the new mode for A/B comparison of memory and update performance.
+        this.addReaction({
+            track: () => this.adoptRawData,
+            run: () => this.buildGridAndView()
+        });
+    }
+
+    // (Re)create the grid and its connected View. The View's connect-time fullUpdate repopulates
+    // the fresh Store from current Cube data, so a rebuild after load needs no explicit reload.
+    private buildGridAndView() {
+        XH.safeDestroy(this.view);
+        XH.safeDestroy(this.gridModel);
+        this.gridModel = this.createGridModel();
+        this.view = this.cubeModel.cube.createView({
+            query: this.getQuery(),
+            stores: this.gridModel.store,
+            connect: true
+        });
+    }
+
+    /** GC (if exposed) and sample the JS heap for a memory read. */
+    @action
+    measureMemory() {
+        const w = window as any,
+            hasGC = typeof w.gc === 'function',
+            mem = (performance as any).memory;
+
+        // window.gc is only present with --js-flags=--expose-gc, and is the detectable proxy for
+        // having launched with the memory flags. Without it we can't force GC before sampling, so
+        // the reading includes uncollected garbage and is only directional - warn the developer.
+        this.heapImprecise = !hasGC;
+        if (hasGC) {
+            w.gc();
+            w.gc();
+        } else {
+            XH.alert({
+                title: 'Imprecise memory reading',
+                message: fragment(
+                    p('For accurate heap capture, relaunch Chrome/Chromium with:'),
+                    pre('--js-flags=--expose-gc --enable-precise-memory-info'),
+                    p(
+                        '--expose-gc lets this tester force garbage collection before sampling; ' +
+                            '--enable-precise-memory-info removes heap-size quantization. Without ' +
+                            'them the reading below includes uncollected garbage and is only a rough ' +
+                            'directional figure - use Chrome DevTools heap snapshots for exact numbers.'
+                    )
+                )
+            });
+        }
+
+        this.heapMB = mem ? Math.round(mem.usedJSHeapSize / 1048576) : null;
+        const mode = this.adoptRawData ? 'adopt' : 'legacy';
+        console.log(
+            `[CubeTest] heap: ${this.heapMB ?? 'n/a'} MB | mode=${mode} | x${this.recordMultiplier}` +
+                (hasGC
+                    ? ''
+                    : ' (imprecise - relaunch with --js-flags=--expose-gc --enable-precise-memory-info)')
+        );
     }
 
     private get fields() {
@@ -110,6 +176,7 @@ export class CubeTestModel extends HoistModel {
             showSummary: this.showSummary,
             store: {
                 loadRootAsSummary: this.showSummary,
+                adoptRawData: this.adoptRawData,
                 fields: [{name: 'cubeDimension', type: 'string'}]
             },
             sortBy: 'time|desc',
@@ -124,14 +191,18 @@ export class CubeTestModel extends HoistModel {
                     groupings = dimManagerModel.value;
                 return groupings.map((it: string) => groupingChooserModel.getDimDisplayName(it));
             },
-            colDefaults: {
-                editable: ({record}) => !record.data.cubeDimension, // Only editable if leaf node
-                setValueFn: ({value, record, field}) => {
-                    const data = {id: record.data.cubeLabel};
-                    data[field] = value;
-                    this.cubeModel.cube.modifyRecordsAsync(data);
-                }
-            },
+            // Editing routes through Cube.modifyRecordsAsync (source of record). Disabled in
+            // adoptRawData mode, which is a read-only projection.
+            colDefaults: this.adoptRawData
+                ? {editable: false}
+                : {
+                      editable: ({record}) => !record.data.cubeDimension, // Only editable if leaf node
+                      setValueFn: ({value, record, field}) => {
+                          const data = {id: record.data.cubeLabel};
+                          data[field] = value;
+                          this.cubeModel.cube.modifyRecordsAsync(data);
+                      }
+                  },
             columns: [
                 {
                     field: 'id',
@@ -218,6 +289,23 @@ export class CubeTestModel extends HoistModel {
                         precision: 0
                     }),
                     hidden: true
+                },
+                {
+                    // Complex-renderer contrast column (Hoist force-refreshes these each update,
+                    // vs. simple columns which ride ag-Grid's own change detection). Verifies the
+                    // zero-copy path repaints both. Reuses `commission`; needs a distinct colId.
+                    field: 'commission',
+                    colId: 'commissionComplex',
+                    headerName: 'Comm (complex)',
+                    align: 'right',
+                    width: 150,
+                    editable: false,
+                    rendererIsComplex: true,
+                    renderer: v =>
+                        fragment(
+                            fmtNumber(v, {precision: 0, ledger: true, colorSpec: true}),
+                            v >= 0 ? ' ▲' : ' ▼'
+                        )
                 },
                 {
                     field: 'time',

--- a/client-app/src/admin/tests/cube/CubeTestPanel.ts
+++ b/client-app/src/admin/tests/cube/CubeTestPanel.ts
@@ -11,13 +11,14 @@ import {dimensionManager} from './dimensions/DimensionManager';
 import {loadTimesPanel} from './LoadTimesPanel';
 import {colChooserButton, button} from '@xh/hoist/desktop/cmp/button';
 import {relativeTimestamp} from '@xh/hoist/cmp/relativetimestamp';
+import {tooltip} from '@xh/hoist/kit/blueprint';
 import './CubeTestPanel.scss';
 
 export const CubeTestPanel = hoistCmp({
     className: 'tb-cube-test-panel',
     model: creates(CubeTestModel),
 
-    render({className}) {
+    render({className, model}) {
         return panel({
             className,
             item: hframe(
@@ -26,7 +27,9 @@ export const CubeTestPanel = hoistCmp({
                     title: 'Grids › Cube Data',
                     icon: Icon.grid(),
                     flex: 1,
-                    item: grid(),
+                    // Pass gridModel explicitly - it is reassigned when adoptRawData toggles, and
+                    // reading the observable ref here rebinds the grid to the rebuilt model.
+                    item: grid({model: model.gridModel}),
                     mask: 'onLoad',
                     tbar: tbar(),
                     bbar: bbar()
@@ -39,6 +42,12 @@ export const CubeTestPanel = hoistCmp({
 
 const tbar = hoistCmp.factory<CubeTestModel>(({model}) =>
     toolbar(
+        tooltip({
+            content:
+                'Zero-copy Store mode (hoist-react #4506) - adopts Cube row objects as record data by reference. Toggling rebuilds the grid + connected View.',
+            item: switchInput({bind: 'adoptRawData', label: 'Adopt Raw', labelSide: 'left'})
+        }),
+        toolbarSep(),
         switchInput({bind: 'showSummary', label: 'Summary?', labelSide: 'left'}),
         switchInput({bind: 'includeLeaves', label: 'Leaves?', labelSide: 'left'}),
         switchInput({bind: 'includeGlobalAgg', label: 'Global Agg?', labelSide: 'left'}),
@@ -65,6 +74,16 @@ const tbar = hoistCmp.factory<CubeTestModel>(({model}) =>
             width: 80
         }),
         toolbarSep(),
+        'x',
+        tooltip({
+            content: 'Replicate fetched orders NxN to stress-test at scale (applied on Load Cube)',
+            item: select({
+                bind: 'recordMultiplier',
+                options: [1, 2, 5, 10, 20, 50],
+                width: 70
+            })
+        }),
+        toolbarSep(),
         button({
             icon: Icon.reset(),
             text: 'Clear Cube',
@@ -87,6 +106,19 @@ const bbar = hoistCmp.factory<CubeTestModel>(({model}) => {
         'Last Updated:',
         relativeTimestamp({timestamp: view.info?.asOf}),
         filler(),
+        model.heapMB != null
+            ? `Heap: ${model.heapMB} MB${model.heapImprecise ? ' (imprecise)' : ''}`
+            : null,
+        tooltip({
+            content:
+                'GC + sample JS heap. For accurate numbers, launch Chrome with --js-flags=--expose-gc --enable-precise-memory-info (otherwise the reading is coarse).',
+            item: button({
+                icon: Icon.chartLine(),
+                text: 'Measure Mem',
+                onClick: () => model.measureMemory()
+            })
+        }),
+        toolbarSep(),
         storeFilterField(),
         colChooserButton()
     );


### PR DESCRIPTION
Extends the Admin **Cube** test tab to exercise hoist-react's new `Store.adoptRawData` zero-copy mode (xh/hoist-react#4507, resolving xh/hoist-react#4506) alongside the legacy copy path.

**Stacked on `grid-tester-data-factory-ab` - this PR targets that branch, not `develop`.**

### Changes

- **"Adopt Raw" toggle** rebuilds the grid + connected `View`, reconstructing the Store in the selected mode for A/B comparison.
- **Complex-renderer contrast column** - verifies both simple- and complex-renderer cells repaint under zero-copy ticks (the primary risk, since the shared row is mutated in place before the new record is built).
- **Order-replication multiplier** to stress the Cube path at scale (e.g. 60k+ facts).
- **Editing gated off** in the read-only adopt mode.
- **"Measure Mem"** GC + heap readout, with an alert and flag guidance when Chrome lacks `--js-flags=--expose-gc` / `--enable-precise-memory-info`.

Used to produce the memory/performance A/B figures in the hoist-react PR.

Hoist P/R Checklist
-------------------

- [x] Caught up with base branch as of last change. _(Stacked on `grid-tester-data-factory-ab`.)_
- [x] Added CHANGELOG entry, or determined not required. _(Internal admin test harness - not required.)_
- [x] Reviewed for breaking changes, added `breaking-change` label + CHANGELOG if so. _(N/A - test harness only.)_
- [x] Updated doc comments / prop-types, or determined not required. _(N/A.)_
- [x] Reviewed and tested on Mobile, or determined not required. _(Desktop admin tester.)_
- [x] Created Toolbox branch / PR, or determined not required. _(This is the Toolbox PR; pairs with xh/hoist-react#4507.)_