### PR TITLE
Store testers: adapt to hoist-react store-simple - `projectionOnly`, `denseRecordThreshold` + `reuseRecords`

### DIFF
--- a/client-app/src/admin/tests/columnFilters/view/ViewColumnFilterPanelModel.ts
+++ b/client-app/src/admin/tests/columnFilters/view/ViewColumnFilterPanelModel.ts
@@ -132,7 +132,6 @@ export class ViewColumnFilterPanelModel extends HoistModel {
             treeMode: true,
             store: {
                 projectionOnly: true,
-                reuseRecords: 'cubeRowVersion',
                 idEncodesTreePath: true
             },
             treeStyle: TreeStyle.HIGHLIGHTS_AND_BORDERS,

--- a/client-app/src/admin/tests/columnFilters/view/ViewColumnFilterPanelModel.ts
+++ b/client-app/src/admin/tests/columnFilters/view/ViewColumnFilterPanelModel.ts
@@ -131,7 +131,7 @@ export class ViewColumnFilterPanelModel extends HoistModel {
         return new GridModel({
             treeMode: true,
             store: {
-                freezeData: true,
+                projectionOnly: true,
                 idEncodesTreePath: true
             },
             treeStyle: TreeStyle.HIGHLIGHTS_AND_BORDERS,

--- a/client-app/src/admin/tests/columnFilters/view/ViewColumnFilterPanelModel.ts
+++ b/client-app/src/admin/tests/columnFilters/view/ViewColumnFilterPanelModel.ts
@@ -132,6 +132,7 @@ export class ViewColumnFilterPanelModel extends HoistModel {
             treeMode: true,
             store: {
                 projectionOnly: true,
+                reuseRecords: 'cubeRowVersion',
                 idEncodesTreePath: true
             },
             treeStyle: TreeStyle.HIGHLIGHTS_AND_BORDERS,

--- a/client-app/src/admin/tests/cube/CubeModel.ts
+++ b/client-app/src/admin/tests/cube/CubeModel.ts
@@ -35,6 +35,8 @@ export class CubeModel extends HoistModel {
             orders.forEach(it => {
                 it.pctCommission = it.commission;
                 it.maxConfidence = it.minConfidence = it.confidence;
+                // Reuse digest - order times are stable within a server-side portfolio
+                it.rev = it.time;
             });
         });
 
@@ -63,6 +65,7 @@ export class CubeModel extends HoistModel {
 
         return new Cube({
             idSpec: 'id',
+            reuseRecords: 'rev',
             fields: [
                 {name: 'symbol', isDimension: true},
                 {name: 'sector', isDimension: true},
@@ -97,6 +100,7 @@ export class CubeModel extends HoistModel {
 
             order.commission = newCom;
             order.pctCommission = newCom;
+            order.rev++;
 
             return order;
         });

--- a/client-app/src/admin/tests/cube/CubeTestModel.ts
+++ b/client-app/src/admin/tests/cube/CubeTestModel.ts
@@ -28,8 +28,8 @@ export class CubeTestModel extends HoistModel {
     /** Read-only projection Store mode under test (hoist-react #4521). Rebuilds grid + view when toggled. */
     @bindable projectionOnly = false;
 
-    /** Version-based record reuse on the connected Store - `reuseRecords: 'cubeRowVersion'`. */
-    @bindable reuseRecords = false;
+    /** Record reuse on the connected Store - a digest installed automatically by the View. */
+    @bindable reuseRecords = true;
 
     /** StoreRecord instance survival across the last Store data change. */
     @observable.ref reuseStats: {reused: number; total: number} = null;
@@ -104,6 +104,9 @@ export class CubeTestModel extends HoistModel {
             stores: this.gridModel.store,
             connect: true
         });
+        // The View installs a reuse digest on its connected store automatically - null it back
+        // out via the same internal hook to restore the no-reuse baseline for A/B comparison.
+        if (!this.reuseRecords) this.gridModel.store.setDigestFn(() => null);
     }
 
     /** GC (if exposed) and sample the JS heap for a memory read. */
@@ -205,7 +208,6 @@ export class CubeTestModel extends HoistModel {
             store: {
                 loadRootAsSummary: this.showSummary,
                 projectionOnly: this.projectionOnly,
-                reuseRecords: this.reuseRecords ? 'cubeRowVersion' : false,
                 fields: [{name: 'cubeDimension', type: 'string'}]
             },
             sortBy: 'time|desc',

--- a/client-app/src/admin/tests/cube/CubeTestModel.ts
+++ b/client-app/src/admin/tests/cube/CubeTestModel.ts
@@ -25,8 +25,8 @@ export class CubeTestModel extends HoistModel {
     @bindable updateFreq = -1;
     @bindable updateCount = 5;
 
-    /** Zero-copy Store mode under test (hoist-react #4506). Rebuilds grid + view when toggled. */
-    @bindable useRawAsData = false;
+    /** Read-only projection Store mode under test (hoist-react #4521). Rebuilds grid + view when toggled. */
+    @bindable projectionOnly = false;
 
     /** Replication factor applied to fetched orders, to stress-test the Cube path at scale. */
     @bindable recordMultiplier = 1;
@@ -57,10 +57,10 @@ export class CubeTestModel extends HoistModel {
             equals: comparer.structural
         });
 
-        // Rebuild grid + connected view when toggling useRawAsData, reconstructing the underlying
+        // Rebuild grid + connected view when toggling projectionOnly, reconstructing the underlying
         // Store in the new mode for A/B comparison of memory and update performance.
         this.addReaction({
-            track: () => this.useRawAsData,
+            track: () => this.projectionOnly,
             run: () => this.buildGridAndView()
         });
     }
@@ -109,7 +109,7 @@ export class CubeTestModel extends HoistModel {
         }
 
         this.heapMB = mem ? Math.round(mem.usedJSHeapSize / 1048576) : null;
-        const mode = this.useRawAsData ? 'rawAsData' : 'legacy';
+        const mode = this.projectionOnly ? 'projection' : 'default';
         console.log(
             `[CubeTest] heap: ${this.heapMB ?? 'n/a'} MB | mode=${mode} | x${this.recordMultiplier}` +
                 (hasGC
@@ -176,7 +176,7 @@ export class CubeTestModel extends HoistModel {
             showSummary: this.showSummary,
             store: {
                 loadRootAsSummary: this.showSummary,
-                useRawAsData: this.useRawAsData,
+                projectionOnly: this.projectionOnly,
                 fields: [{name: 'cubeDimension', type: 'string'}]
             },
             sortBy: 'time|desc',
@@ -191,8 +191,9 @@ export class CubeTestModel extends HoistModel {
                     groupings = dimManagerModel.value;
                 return groupings.map((it: string) => groupingChooserModel.getDimDisplayName(it));
             },
-            // Editing routes through Cube.modifyRecordsAsync (source of record), and is exercised in
-            // both modes - useRawAsData no longer implies a read-only Store.
+            // Editing routes through Cube.modifyRecordsAsync (source of record), not
+            // Store.modifyRecords - so it works in both modes, including projectionOnly, where
+            // direct local Store modification would throw.
             colDefaults: {
                 editable: ({record}) => !record.data.cubeDimension, // Only editable if leaf node
                 setValueFn: ({value, record, field}) => {

--- a/client-app/src/admin/tests/cube/CubeTestModel.ts
+++ b/client-app/src/admin/tests/cube/CubeTestModel.ts
@@ -9,7 +9,7 @@ import {isEmpty} from 'lodash';
 import {DimensionManagerModel} from './dimensions/DimensionManagerModel';
 import {LoadTimesModel} from './LoadTimesModel';
 import {CubeModel} from './CubeModel';
-import {QueryConfig, View} from '@xh/hoist/data';
+import {QueryConfig, StoreRecord, View} from '@xh/hoist/data';
 
 export class CubeTestModel extends HoistModel {
     @managed cubeModel: CubeModel;
@@ -27,6 +27,12 @@ export class CubeTestModel extends HoistModel {
 
     /** Read-only projection Store mode under test (hoist-react #4521). Rebuilds grid + view when toggled. */
     @bindable projectionOnly = false;
+
+    /** Version-based record reuse on the connected Store - `reuseRecords: 'cubeRowVersion'`. */
+    @bindable reuseRecords = false;
+
+    /** StoreRecord instance survival across the last Store data change. */
+    @observable.ref reuseStats: {reused: number; total: number} = null;
 
     /** Replication factor applied to fetched orders, to stress-test the Cube path at scale. */
     @bindable recordMultiplier = 1;
@@ -57,12 +63,34 @@ export class CubeTestModel extends HoistModel {
             equals: comparer.structural
         });
 
-        // Rebuild grid + connected view when toggling projectionOnly, reconstructing the underlying
+        // Rebuild grid + connected view when toggling store modes, reconstructing the underlying
         // Store in the new mode for A/B comparison of memory and update performance.
         this.addReaction({
-            track: () => this.projectionOnly,
+            track: () => [this.projectionOnly, this.reuseRecords],
             run: () => this.buildGridAndView()
         });
+
+        // Direct readout of record reuse - count instances surviving each Store data change by
+        // identity against the prior recordset. Resets to 0% across mode-toggle rebuilds.
+        this.addReaction({
+            track: () => this.gridModel.store.records,
+            run: (recs, prevRecs) => this.updateReuseStats(recs, prevRecs)
+        });
+    }
+
+    @action
+    private updateReuseStats(recs: StoreRecord[], prevRecs: StoreRecord[]) {
+        if (isEmpty(prevRecs) || isEmpty(recs)) {
+            this.reuseStats = null;
+            return;
+        }
+        const prevById = new Map(prevRecs.map(r => [r.id, r])),
+            reused = recs.filter(r => prevById.get(r.id) === r).length,
+            total = recs.length;
+        this.reuseStats = {reused, total};
+        console.log(
+            `[CubeTest] records reused: ${reused}/${total} | projection=${this.projectionOnly} | reuse=${this.reuseRecords}`
+        );
     }
 
     // (Re)create the grid and its connected View. The View's connect-time fullUpdate repopulates
@@ -177,6 +205,7 @@ export class CubeTestModel extends HoistModel {
             store: {
                 loadRootAsSummary: this.showSummary,
                 projectionOnly: this.projectionOnly,
+                reuseRecords: this.reuseRecords ? 'cubeRowVersion' : false,
                 fields: [{name: 'cubeDimension', type: 'string'}]
             },
             sortBy: 'time|desc',

--- a/client-app/src/admin/tests/cube/CubeTestPanel.ts
+++ b/client-app/src/admin/tests/cube/CubeTestPanel.ts
@@ -49,7 +49,7 @@ const tbar = hoistCmp.factory<CubeTestModel>(({model}) =>
         }),
         tooltip({
             content:
-                "Version-based record reuse on the connected Store - `reuseRecords: 'cubeRowVersion'`. Toggling rebuilds the grid + connected View.",
+                'Record reuse on the connected Store - a digest installed automatically by the connected View. Toggle off for a no-reuse baseline. Toggling rebuilds the grid + connected View.',
             item: switchInput({bind: 'reuseRecords', label: 'Reuse Records', labelSide: 'left'})
         }),
         toolbarSep(),

--- a/client-app/src/admin/tests/cube/CubeTestPanel.ts
+++ b/client-app/src/admin/tests/cube/CubeTestPanel.ts
@@ -47,6 +47,11 @@ const tbar = hoistCmp.factory<CubeTestModel>(({model}) =>
                 'Read-only projection Store mode (hoist-react #4521) - uses Cube row objects as record data by reference. Toggling rebuilds the grid + connected View.',
             item: switchInput({bind: 'projectionOnly', label: 'Projection Only', labelSide: 'left'})
         }),
+        tooltip({
+            content:
+                "Version-based record reuse on the connected Store - `reuseRecords: 'cubeRowVersion'`. Toggling rebuilds the grid + connected View.",
+            item: switchInput({bind: 'reuseRecords', label: 'Reuse Records', labelSide: 'left'})
+        }),
         toolbarSep(),
         switchInput({bind: 'showSummary', label: 'Summary?', labelSide: 'left'}),
         switchInput({bind: 'includeLeaves', label: 'Leaves?', labelSide: 'left'}),
@@ -99,13 +104,21 @@ const tbar = hoistCmp.factory<CubeTestModel>(({model}) =>
 );
 
 const bbar = hoistCmp.factory<CubeTestModel>(({model}) => {
-    const {view} = model;
+    const {view, reuseStats} = model;
     return toolbar(
         storeCountLabel({store: view.cube.store, unit: 'cube facts'}),
         hspacer(2),
         'Last Updated:',
         relativeTimestamp({timestamp: view.info?.asOf}),
         filler(),
+        reuseStats
+            ? tooltip({
+                  content:
+                      'StoreRecord instances preserved across the last grid Store data change, by identity.',
+                  item: `Reused: ${reuseStats.reused.toLocaleString()}/${reuseStats.total.toLocaleString()}`
+              })
+            : null,
+        reuseStats ? toolbarSep() : null,
         model.heapMB != null
             ? `Heap: ${model.heapMB} MB${model.heapImprecise ? ' (imprecise)' : ''}`
             : null,

--- a/client-app/src/admin/tests/cube/CubeTestPanel.ts
+++ b/client-app/src/admin/tests/cube/CubeTestPanel.ts
@@ -27,7 +27,7 @@ export const CubeTestPanel = hoistCmp({
                     title: 'Grids › Cube Data',
                     icon: Icon.grid(),
                     flex: 1,
-                    // Pass gridModel explicitly - it is reassigned when useRawAsData toggles, and
+                    // Pass gridModel explicitly - it is reassigned when projectionOnly toggles, and
                     // reading the observable ref here rebinds the grid to the rebuilt model.
                     item: grid({model: model.gridModel}),
                     mask: 'onLoad',
@@ -44,8 +44,8 @@ const tbar = hoistCmp.factory<CubeTestModel>(({model}) =>
     toolbar(
         tooltip({
             content:
-                'Zero-copy Store mode (hoist-react #4506) - uses Cube row objects as record data by reference. Toggling rebuilds the grid + connected View.',
-            item: switchInput({bind: 'useRawAsData', label: 'Raw as Data', labelSide: 'left'})
+                'Read-only projection Store mode (hoist-react #4521) - uses Cube row objects as record data by reference. Toggling rebuilds the grid + connected View.',
+            item: switchInput({bind: 'projectionOnly', label: 'Projection Only', labelSide: 'left'})
         }),
         toolbarSep(),
         switchInput({bind: 'showSummary', label: 'Summary?', labelSide: 'left'}),

--- a/client-app/src/admin/tests/grids/GridTestBenchmarkModel.ts
+++ b/client-app/src/admin/tests/grids/GridTestBenchmarkModel.ts
@@ -75,7 +75,7 @@ export const SCENARIO_LABELS: Record<BenchmarkScenario, string> = {
  * domain are not trustworthy and are deliberately never presented on their own.
  *
  * Results accumulate (and persist to local storage) so several configs can be compared side by
- * side. Persistence matters here because toggling `useRawAsData` or `freezeData` reloads the
+ * side. Persistence matters here because toggling `projectionOnly` or `freezeData` reloads the
  * app - without it, each side of that A/B would land in a different session's results.
  *
  * Each row captures the full config that produced it, and reports only what was measured - no
@@ -440,7 +440,8 @@ export class GridTestBenchmarkModel extends HoistModel {
                 records,
                 declaredFields: parent.declaredFieldCount,
                 populatedFields: parent.populatedFieldCount,
-                useRawAsData: parent.useRawAsData,
+                projectionOnly: parent.projectionOnly,
+                sparseRecordData: parent.sparseRecordData,
                 freezeData: parent.freezeData,
                 retainRaw: parent.retainRaw,
                 reuseRecords: parent.reuseRecords,
@@ -512,7 +513,8 @@ export class GridTestBenchmarkModel extends HoistModel {
                     {name: 'records', type: FT.INT},
                     {name: 'declaredFields', type: FT.INT},
                     {name: 'populatedFields', type: FT.INT},
-                    {name: 'useRawAsData', type: FT.BOOL},
+                    {name: 'projectionOnly', type: FT.BOOL},
+                    {name: 'sparseRecordData', type: FT.BOOL},
                     {name: 'freezeData', type: FT.BOOL},
                     {name: 'retainRaw', type: FT.BOOL},
                     {name: 'reuseRecords', type: FT.BOOL},
@@ -674,7 +676,8 @@ export class GridTestBenchmarkModel extends HoistModel {
                     groupId: 'flags',
                     headerName: 'Store + Fetch Flags',
                     children: [
-                        {field: 'useRawAsData', headerName: 'RawAsData', ...boolCol},
+                        {field: 'projectionOnly', headerName: 'Projection', ...boolCol},
+                        {field: 'sparseRecordData', headerName: 'Sparse', ...boolCol},
                         {field: 'freezeData', headerName: 'Freeze', ...boolCol},
                         {field: 'retainRaw', headerName: 'RetainRaw', ...boolCol},
                         {field: 'reuseRecords', headerName: 'Reuse', ...boolCol},

--- a/client-app/src/admin/tests/grids/GridTestBenchmarkModel.ts
+++ b/client-app/src/admin/tests/grids/GridTestBenchmarkModel.ts
@@ -441,7 +441,7 @@ export class GridTestBenchmarkModel extends HoistModel {
                 declaredFields: parent.declaredFieldCount,
                 populatedFields: parent.populatedFieldCount,
                 projectionOnly: parent.projectionOnly,
-                sparseMaxFields: parent.sparseMaxFields,
+                denseRecordThreshold: parent.denseRecordThreshold,
                 freezeData: parent.freezeData,
                 retainRaw: parent.retainRaw,
                 reuseRecords: parent.reuseRecords,
@@ -514,7 +514,7 @@ export class GridTestBenchmarkModel extends HoistModel {
                     {name: 'declaredFields', type: FT.INT},
                     {name: 'populatedFields', type: FT.INT},
                     {name: 'projectionOnly', type: FT.BOOL},
-                    {name: 'sparseMaxFields', type: FT.INT},
+                    {name: 'denseRecordThreshold', type: FT.INT},
                     {name: 'freezeData', type: FT.BOOL},
                     {name: 'retainRaw', type: FT.BOOL},
                     {name: 'reuseRecords', type: FT.BOOL},
@@ -678,10 +678,10 @@ export class GridTestBenchmarkModel extends HoistModel {
                     children: [
                         {field: 'projectionOnly', headerName: 'Projection', ...boolCol},
                         {
-                            field: 'sparseMaxFields',
-                            headerName: 'SparseMax',
+                            field: 'denseRecordThreshold',
+                            headerName: 'DenseThresh',
                             align: 'right',
-                            width: 95
+                            width: 100
                         },
                         {field: 'freezeData', headerName: 'Freeze', ...boolCol},
                         {field: 'retainRaw', headerName: 'RetainRaw', ...boolCol},

--- a/client-app/src/admin/tests/grids/GridTestBenchmarkModel.ts
+++ b/client-app/src/admin/tests/grids/GridTestBenchmarkModel.ts
@@ -441,7 +441,7 @@ export class GridTestBenchmarkModel extends HoistModel {
                 declaredFields: parent.declaredFieldCount,
                 populatedFields: parent.populatedFieldCount,
                 projectionOnly: parent.projectionOnly,
-                sparseRecordData: parent.sparseRecordData,
+                sparseMaxFields: parent.sparseMaxFields,
                 freezeData: parent.freezeData,
                 retainRaw: parent.retainRaw,
                 reuseRecords: parent.reuseRecords,
@@ -514,7 +514,7 @@ export class GridTestBenchmarkModel extends HoistModel {
                     {name: 'declaredFields', type: FT.INT},
                     {name: 'populatedFields', type: FT.INT},
                     {name: 'projectionOnly', type: FT.BOOL},
-                    {name: 'sparseRecordData', type: FT.BOOL},
+                    {name: 'sparseMaxFields', type: FT.INT},
                     {name: 'freezeData', type: FT.BOOL},
                     {name: 'retainRaw', type: FT.BOOL},
                     {name: 'reuseRecords', type: FT.BOOL},
@@ -677,7 +677,12 @@ export class GridTestBenchmarkModel extends HoistModel {
                     headerName: 'Store + Fetch Flags',
                     children: [
                         {field: 'projectionOnly', headerName: 'Projection', ...boolCol},
-                        {field: 'sparseRecordData', headerName: 'Sparse', ...boolCol},
+                        {
+                            field: 'sparseMaxFields',
+                            headerName: 'SparseMax',
+                            align: 'right',
+                            width: 95
+                        },
                         {field: 'freezeData', headerName: 'Freeze', ...boolCol},
                         {field: 'retainRaw', headerName: 'RetainRaw', ...boolCol},
                         {field: 'reuseRecords', headerName: 'Reuse', ...boolCol},

--- a/client-app/src/admin/tests/grids/GridTestModel.ts
+++ b/client-app/src/admin/tests/grids/GridTestModel.ts
@@ -50,7 +50,7 @@ const INTERN_KEY = 'gridTest';
  */
 const RECORD_DATA_FLAGS: Array<{prop: string; label: string}> = [
     {prop: 'projectionOnly', label: 'Projection Only'},
-    {prop: 'sparseMaxFields', label: 'Sparse Max Fields'},
+    {prop: 'denseRecordThreshold', label: 'Dense Record Threshold'},
     {prop: 'freezeData', label: 'Freeze Data'}
 ];
 
@@ -164,15 +164,14 @@ export class GridTestModel extends HoistModel {
     @persist
     @bindable
     projectionOnly = false;
-    // Override of Store's experimental `sparseMaxFields` - the populated (non-default) field
-    // count at/below which a record's data takes the sparse representation, vs. a fixed-shape
-    // clone of the shared per-Store template. Null applies the Hoist default; 0 forces the fixed
-    // shape for all records; a large value forces sparse for all (the pre-v87 behavior). Inert
-    // under Projection Only, which skips record data construction entirely. Changing reloads
-    // the app.
+    // Override of Store's experimental `denseRecordThreshold` - the populated (non-default)
+    // field count at/above which a record's data takes its fixed dense shape, vs. the sparse
+    // form. Null applies the Hoist default; 1 forces the dense shape for all records; 999 forces
+    // sparse for all (the pre-v87 behavior). Inert under Projection Only, which skips record
+    // data construction entirely. Changing reloads the app.
     @persist
     @bindable
-    sparseMaxFields: number = null;
+    denseRecordThreshold: number = null;
     // The Store's `freezeData` config - defaulted to Hoist's own default so measurements reflect
     // what apps actually run. Changes how record data objects are built and stored, so toggling
     // it reloads the app - see the reaction below.
@@ -621,7 +620,7 @@ export class GridTestModel extends HoistModel {
                 projectionOnly: this.projectionOnly,
                 retainRaw,
                 reuseRecords: this.reuseRecords && retainRaw && !this.projectionOnly,
-                experimental: {sparseMaxFields: this.sparseMaxFields}
+                experimental: {denseRecordThreshold: this.denseRecordThreshold}
             };
 
         if (enableXssProtection) {

--- a/client-app/src/admin/tests/grids/GridTestModel.ts
+++ b/client-app/src/admin/tests/grids/GridTestModel.ts
@@ -49,7 +49,8 @@ const INTERN_KEY = 'gridTest';
  * (`retainRaw`, `reuseRecords`, `internStrings`) - those can be flipped and re-measured in place.
  */
 const RECORD_DATA_FLAGS: Array<{prop: string; label: string}> = [
-    {prop: 'useRawAsData', label: 'Use Raw As Data'},
+    {prop: 'projectionOnly', label: 'Projection Only'},
+    {prop: 'sparseRecordData', label: 'Sparse Record Data'},
     {prop: 'freezeData', label: 'Freeze Data'}
 ];
 
@@ -153,15 +154,23 @@ export class GridTestModel extends HoistModel {
     @persist
     @bindable
     categoryCount = 8;
-    // The Store's `useRawAsData` config - each raw object becomes its record's `data` by reference,
-    // so a row costs one object instead of two. Mutually exclusive with `reuseRecords` (Store
-    // throws), and a different record-data representation, so toggling it reloads the app. Valid
-    // here only because the test data arrives already in final form - the extra fields are untyped
-    // and the base fields are already numbers/strings, so no `Field.parseVal` is needed. Note XSS
-    // protection is inert under it, as nothing is parsed.
+    // The Store's `projectionOnly` config - a read-only projection where each raw object becomes
+    // its record's `data` by reference, so a row costs one object instead of two. Mutually
+    // exclusive with `reuseRecords` (Store throws), and a different record-data representation, so
+    // toggling it reloads the app. Valid here only because the test data arrives already in final
+    // form and is never locally modified - the extra fields are untyped and the base fields are
+    // already numbers/strings, so no `Field.parseVal` is needed. Note XSS protection is inert
+    // under it, as nothing is parsed.
     @persist
     @bindable
-    useRawAsData = false;
+    projectionOnly = false;
+    // The Store's temporary `experimental.sparseRecordData` flag - restores the pre-v87 sparse
+    // record data representation (own properties for non-default values only, defaults via a
+    // shared prototype) for A/B comparison against the fixed-shape default. Inert under
+    // Projection Only, which skips record data construction entirely. Toggling reloads the app.
+    @persist
+    @bindable
+    sparseRecordData = false;
     // The Store's `freezeData` config - defaulted to Hoist's own default so measurements reflect
     // what apps actually run. Changes how record data objects are built and stored, so toggling
     // it reloads the app - see the reaction below.
@@ -314,11 +323,11 @@ export class GridTestModel extends HoistModel {
             }
         });
 
-        // Store throws if `useRawAsData` is paired with `reuseRecords`. Clear it on the way in.
+        // Store throws if `projectionOnly` is paired with `reuseRecords`. Clear it on the way in.
         this.addReaction({
-            track: () => this.useRawAsData,
-            run: useRawAsData => {
-                if (!useRawAsData) return;
+            track: () => this.projectionOnly,
+            run: projectionOnly => {
+                if (!projectionOnly) return;
                 runInAction(() => (this.reuseRecords = false));
             }
         });
@@ -604,9 +613,10 @@ export class GridTestModel extends HoistModel {
                 // Belt-and-braces throughout - Store throws on each illegal pairing below. The UI
                 // disables the switches and reactions clear them, but a config restored from the
                 // ViewManager could still arrive holding an incompatible combination.
-                useRawAsData: this.useRawAsData,
+                projectionOnly: this.projectionOnly,
                 retainRaw,
-                reuseRecords: this.reuseRecords && retainRaw && !this.useRawAsData
+                reuseRecords: this.reuseRecords && retainRaw && !this.projectionOnly,
+                experimental: {sparseRecordData: this.sparseRecordData}
             };
 
         if (enableXssProtection) {

--- a/client-app/src/admin/tests/grids/GridTestModel.ts
+++ b/client-app/src/admin/tests/grids/GridTestModel.ts
@@ -50,7 +50,7 @@ const INTERN_KEY = 'gridTest';
  */
 const RECORD_DATA_FLAGS: Array<{prop: string; label: string}> = [
     {prop: 'projectionOnly', label: 'Projection Only'},
-    {prop: 'sparseRecordData', label: 'Sparse Record Data'},
+    {prop: 'sparseMaxFields', label: 'Sparse Max Fields'},
     {prop: 'freezeData', label: 'Freeze Data'}
 ];
 
@@ -164,13 +164,15 @@ export class GridTestModel extends HoistModel {
     @persist
     @bindable
     projectionOnly = false;
-    // The Store's temporary `experimental.sparseRecordData` flag - restores the pre-v87 sparse
-    // record data representation (own properties for non-default values only, defaults via a
-    // shared prototype) for A/B comparison against the fixed-shape default. Inert under
-    // Projection Only, which skips record data construction entirely. Toggling reloads the app.
+    // Override of Store's experimental `sparseMaxFields` - the populated (non-default) field
+    // count at/below which a record's data takes the sparse representation, vs. a fixed-shape
+    // clone of the shared per-Store template. Null applies the Hoist default; 0 forces the fixed
+    // shape for all records; a large value forces sparse for all (the pre-v87 behavior). Inert
+    // under Projection Only, which skips record data construction entirely. Changing reloads
+    // the app.
     @persist
     @bindable
-    sparseRecordData = false;
+    sparseMaxFields: number = null;
     // The Store's `freezeData` config - defaulted to Hoist's own default so measurements reflect
     // what apps actually run. Changes how record data objects are built and stored, so toggling
     // it reloads the app - see the reaction below.
@@ -204,7 +206,7 @@ export class GridTestModel extends HoistModel {
 
     // Snapshot of RECORD_DATA_FLAGS as of page load - i.e. the values this page's Stores were
     // built with. Compared against on change to decide whether a reload is required.
-    private recordDataFlagsAtLoad: boolean[];
+    private recordDataFlagsAtLoad: Array<boolean | number>;
     // Set while a reload confirmation is already in flight, to avoid stacking dialogs.
     private confirmingReload = false;
 
@@ -347,7 +349,7 @@ export class GridTestModel extends HoistModel {
     }
 
     /** Current values of the flags that require a fresh page when changed. */
-    private get recordDataFlagState(): boolean[] {
+    private get recordDataFlagState(): Array<boolean | number> {
         return RECORD_DATA_FLAGS.map(it => this[it.prop]);
     }
 
@@ -385,7 +387,10 @@ export class GridTestModel extends HoistModel {
         if (isEmpty(changed)) return;
 
         const summary = changed
-            .map(it => `${it.label} ${this[it.prop] ? 'on' : 'off'}`)
+            .map(it => {
+                const v = this[it.prop];
+                return `${it.label} ${typeof v === 'boolean' ? (v ? 'on' : 'off') : (v ?? 'default')}`;
+            })
             .join(' and ');
 
         this.confirmingReload = true;
@@ -616,7 +621,7 @@ export class GridTestModel extends HoistModel {
                 projectionOnly: this.projectionOnly,
                 retainRaw,
                 reuseRecords: this.reuseRecords && retainRaw && !this.projectionOnly,
-                experimental: {sparseRecordData: this.sparseRecordData}
+                experimental: {sparseMaxFields: this.sparseMaxFields}
             };
 
         if (enableXssProtection) {

--- a/client-app/src/admin/tests/grids/GridTestPanel.ts
+++ b/client-app/src/admin/tests/grids/GridTestPanel.ts
@@ -288,12 +288,12 @@ const recordDataOptions = (model: GridTestModel) =>
                 control: switchInput({model, bind: 'projectionOnly'})
             }),
             wrapperOption({
-                label: 'Sparse max fields',
-                propName: 'experimental.sparseMaxFields',
-                info: 'Populated (non-default) field count at/below which a record data object takes the sparse representation, vs. a fixed-shape clone of the shared template. Blank = Hoist default. 0 = fixed shape for all records; large = sparse for all (pre-v87). Inert under Projection Only. Changing reloads the app.',
+                label: 'Dense record threshold',
+                propName: 'experimental.denseRecordThreshold',
+                info: 'Populated (non-default) field count at/above which a record data object takes its fixed dense shape, vs. the sparse form. Blank = Hoist default. 1 = dense shape for all records; 999 = sparse for all (pre-v87). Inert under Projection Only. Changing reloads the app.',
                 control: numberInput({
                     model,
-                    bind: 'sparseMaxFields',
+                    bind: 'denseRecordThreshold',
                     width: 60,
                     placeholder: 'default',
                     disabled: model.projectionOnly

--- a/client-app/src/admin/tests/grids/GridTestPanel.ts
+++ b/client-app/src/admin/tests/grids/GridTestPanel.ts
@@ -137,7 +137,7 @@ export const GridTestPanel = hoistCmp({
  * disabled control retain their customized value (inert, guarded at point of use in
  * GridTestModel / the server) and take effect again when their precondition is restored - they
  * are deliberately not cleared. The exception is combinations Store itself throws on
- * (`useRawAsData` / `reuseRecords` / `retainRaw`): those are actively cleared by model reactions
+ * (`projectionOnly` / `reuseRecords` / `retainRaw`): those are actively cleared by model reactions
  * and re-guarded in `createGridModel()`, covering values restored from saved configs that never
  * passed through these controls.
  *
@@ -266,12 +266,12 @@ const loadingOptions = (model: GridTestModel) =>
             wrapperOption({
                 label: 'XSS protection',
                 propName: 'FieldSpec.enableXssProtection',
-                info: 'Sanitize string values on parse. Inert under Use Raw As Data, where nothing is parsed.',
+                info: 'Sanitize string values on parse. Inert under Projection Only, where nothing is parsed.',
                 control: switchInput({
                     model,
-                    value: model.enableXssProtection && !model.useRawAsData,
+                    value: model.enableXssProtection && !model.projectionOnly,
                     onChange: v => runInAction(() => (model.enableXssProtection = v)),
-                    disabled: model.useRawAsData
+                    disabled: model.projectionOnly
                 })
             })
         ]
@@ -282,10 +282,20 @@ const recordDataOptions = (model: GridTestModel) =>
         label: 'Record Data',
         items: [
             wrapperOption({
-                label: 'Use raw as data',
-                propName: 'StoreConfig.useRawAsData',
-                info: 'Each raw object becomes its record data by reference - one object per row instead of two. Toggling reloads the app.',
-                control: switchInput({model, bind: 'useRawAsData'})
+                label: 'Projection only',
+                propName: 'StoreConfig.projectionOnly',
+                info: 'Read-only projection - each raw object becomes its record data by reference, one object per row instead of two. Toggling reloads the app.',
+                control: switchInput({model, bind: 'projectionOnly'})
+            }),
+            wrapperOption({
+                label: 'Sparse record data',
+                propName: 'experimental.sparseRecordData',
+                info: 'Temporary - restores the pre-v87 sparse record data representation for A/B comparison against the fixed-shape default. Inert under Projection Only, where no data objects are built. Toggling reloads the app.',
+                control: switchInput({
+                    model,
+                    bind: 'sparseRecordData',
+                    disabled: model.projectionOnly
+                })
             }),
             wrapperOption({
                 label: 'Freeze data',
@@ -296,15 +306,15 @@ const recordDataOptions = (model: GridTestModel) =>
             wrapperOption({
                 label: 'Retain raw',
                 propName: 'StoreConfig.retainRaw',
-                info: model.useRawAsData
-                    ? 'Inert under Use Raw As Data - record data is the raw object, so it stays reachable regardless.'
+                info: model.projectionOnly
+                    ? 'Inert under Projection Only - record data is the raw object, so it stays reachable regardless.'
                     : "Off drops each record's reference to its raw data object (Hoist default on), letting it be GC'd after parsing. Required by Reuse Records.",
-                // Displays locked-on under Use Raw As Data - genuinely true, not just a UI
+                // Displays locked-on under Projection Only - genuinely true, not just a UI
                 // convention: Store attaches `raw` unconditionally in that mode.
                 control: switchInput({
-                    value: model.useRawAsData || model.retainRaw,
+                    value: model.projectionOnly || model.retainRaw,
                     onChange: v => runInAction(() => (model.retainRaw = v)),
-                    disabled: model.useRawAsData
+                    disabled: model.projectionOnly
                 })
             }),
             wrapperOption({
@@ -314,7 +324,7 @@ const recordDataOptions = (model: GridTestModel) =>
                 control: switchInput({
                     model,
                     bind: 'reuseRecords',
-                    disabled: !model.retainRaw || model.useRawAsData
+                    disabled: !model.retainRaw || model.projectionOnly
                 })
             })
         ]

--- a/client-app/src/admin/tests/grids/GridTestPanel.ts
+++ b/client-app/src/admin/tests/grids/GridTestPanel.ts
@@ -288,12 +288,14 @@ const recordDataOptions = (model: GridTestModel) =>
                 control: switchInput({model, bind: 'projectionOnly'})
             }),
             wrapperOption({
-                label: 'Sparse record data',
-                propName: 'experimental.sparseRecordData',
-                info: 'Temporary - restores the pre-v87 sparse record data representation for A/B comparison against the fixed-shape default. Inert under Projection Only, where no data objects are built. Toggling reloads the app.',
-                control: switchInput({
+                label: 'Sparse max fields',
+                propName: 'experimental.sparseMaxFields',
+                info: 'Populated (non-default) field count at/below which a record data object takes the sparse representation, vs. a fixed-shape clone of the shared template. Blank = Hoist default. 0 = fixed shape for all records; large = sparse for all (pre-v87). Inert under Projection Only. Changing reloads the app.',
+                control: numberInput({
                     model,
-                    bind: 'sparseRecordData',
+                    bind: 'sparseMaxFields',
+                    width: 60,
+                    placeholder: 'default',
                     disabled: model.projectionOnly
                 })
             }),


### PR DESCRIPTION
Companion to xh/hoist-react#4534.

- Renamed the obsolete `useRawAsData` to `projectionOnly` across the cube and grid testers - toggles, wrapper options, interlocks and benchmark columns. The ViewColumnFilterPanel's View-connected store now sets `projectionOnly: true`.
- Grid tester: added a reload-gated `denseRecordThreshold` numberInput driving Store's experimental record-data representation override (blank = Hoist default, `1` = fixed dense shape for all records, `999` = sparse for all / pre-v87). Recorded and displayed in benchmark results for side-by-side comparison.
- Cube tester: added a `Reuse Records` toggle configuring the connected store with `reuseRecords: 'cubeRowVersion'` (rebuilds grid + View on change, composable with the `Projection Only` toggle), plus a live record-instance-survival readout - bbar label and console log counting StoreRecord instances preserved by identity across each Store data change. Used to validate the version-based reuse work in-app: streaming ticks with reuse enabled show every changed value taking a fresh record instance (no swallowed updates) while unchanged rows retain identity across updates, filter changes, and full cube reloads.

**Merge only after xh/hoist-react#4534 merges and a snapshot publishes** - typecheck fails against earlier snapshots, which predate `projectionOnly`, the experimental threshold, and version-based `reuseRecords`.
