### PR TITLE
Cube tester updates for tiered grid transaction handling

### DIFF
--- a/client-app/src/admin/tests/cube/CubeModel.ts
+++ b/client-app/src/admin/tests/cube/CubeModel.ts
@@ -4,16 +4,18 @@ import {fmtThousands} from '@xh/hoist/format';
 import {makeObservable, observable} from '@xh/hoist/mobx';
 import {times} from 'lodash';
 import {SECONDS} from '@xh/hoist/utils/datetime';
-import {Timer} from '@xh/hoist/utils/async';
 import {PctTotalAggregator} from './PctTotalAggregator';
 import {CubeTestModel} from './CubeTestModel';
 
 export class CubeModel extends HoistModel {
     @managed @observable.ref cube: Cube;
     @managed orders: PlainObject[] = [];
-    @managed timer: Timer;
 
     parent: CubeTestModel;
+
+    // Plain setInterval rather than Timer - sub-second rates fall below Timer's 500ms floor.
+    private updateIntervalId = null;
+    private streamInFlight = false;
 
     constructor(parent) {
         super();
@@ -21,11 +23,21 @@ export class CubeModel extends HoistModel {
         this.parent = parent;
         this.cube = this.createCube();
 
-        this.timer = Timer.create({
-            runFn: () => this.streamChangesAsync(),
-            interval: () => parent.updateFreq ?? -1,
-            intervalUnits: SECONDS
+        this.addReaction({
+            track: () => parent.updateFreq,
+            run: freq => this.restartUpdateStream(freq)
         });
+    }
+
+    private restartUpdateStream(freq: number) {
+        clearInterval(this.updateIntervalId);
+        this.updateIntervalId =
+            freq > 0 ? setInterval(() => this.streamChangesAsync(), freq * SECONDS) : null;
+    }
+
+    override destroy() {
+        clearInterval(this.updateIntervalId);
+        super.destroy();
     }
 
     override async doLoadAsync(loadSpec) {
@@ -96,9 +108,10 @@ export class CubeModel extends HoistModel {
         });
     }
 
+    // Skip ticks that arrive while a prior update is still applying, as Timer would have done.
     private async streamChangesAsync() {
         const {orders} = this;
-        if (!orders.length) return;
+        if (!orders.length || this.streamInFlight) return;
         const {updateCount, loadTimesModel: LTM} = this.parent;
         const updates = times(updateCount, () => {
             const random = Math.floor(Math.random() * orders.length),
@@ -113,8 +126,13 @@ export class CubeModel extends HoistModel {
             return order;
         });
 
-        await LTM.withLoadTime(`Updated ${updateCount} orders in Cube`, async () => {
-            await this.cube.updateDataAsync(updates, {asOf: Date.now()});
-        });
+        this.streamInFlight = true;
+        try {
+            await LTM.withLoadTime(`Updated ${updateCount} orders in Cube`, async () => {
+                await this.cube.updateDataAsync(updates, {asOf: Date.now()});
+            });
+        } finally {
+            this.streamInFlight = false;
+        }
     }
 }

--- a/client-app/src/admin/tests/cube/CubeTestModel.ts
+++ b/client-app/src/admin/tests/cube/CubeTestModel.ts
@@ -29,6 +29,7 @@ export class CubeTestModel extends HoistModel {
 
     @bindable projectionOnly = true;
     @bindable reuseRecords = true;
+    @bindable throttleSort = false;
 
     /** Set explicitly in both directions, overriding any app-wide `xhStoreExperimental` default. */
     @bindable patchRecords = true;
@@ -87,6 +88,12 @@ export class CubeTestModel extends HoistModel {
             run: ratio => this.applyMaxPatchRatio(ratio)
         });
 
+        // Applied live to the existing GridModel - read on each transaction and by its sort timer.
+        this.addReaction({
+            track: () => this.streamingSortInterval,
+            run: interval => (this.gridModel.streamingSortInterval = interval)
+        });
+
         // Re-apply on selection change, and when a rebuild installs fresh diagnostics objects.
         this.addReaction({
             track: () => [this.logStages, this.cubeModel.cube, this.view, this.gridModel],
@@ -135,6 +142,10 @@ export class CubeTestModel extends HoistModel {
 
     get maxPatchRatio(): number {
         return this.patchRecords ? 0.1 : 0;
+    }
+
+    get streamingSortInterval(): number {
+        return this.throttleSort ? 5 * SECONDS : null;
     }
 
     private applyMaxPatchRatio(ratio: number) {
@@ -249,6 +260,7 @@ export class CubeTestModel extends HoistModel {
                 experimental: {maxPatchRatio: this.maxPatchRatio},
                 fields: [{name: 'cubeDimension', type: 'string'}]
             },
+            streamingSortInterval: this.streamingSortInterval,
             sortBy: 'time|desc',
             emptyText: 'No records found...',
             colChooserModel: true,

--- a/client-app/src/admin/tests/cube/CubeTestModel.ts
+++ b/client-app/src/admin/tests/cube/CubeTestModel.ts
@@ -29,7 +29,10 @@ export class CubeTestModel extends HoistModel {
 
     @bindable projectionOnly = true;
     @bindable reuseRecords = true;
-    @bindable throttleSort = false;
+
+    /** Grid experimental sort flags, applied live for A/B tuning. */
+    @bindable deferredSortFactor = 4;
+    @bindable deltaSortRatio = 50;
 
     /** Set explicitly in both directions, overriding any app-wide `xhStoreExperimental` default. */
     @bindable patchRecords = true;
@@ -88,10 +91,10 @@ export class CubeTestModel extends HoistModel {
             run: ratio => this.applyMaxPatchRatio(ratio)
         });
 
-        // Applied live to the existing GridModel - read on each transaction and by its sort timer.
+        // Applied live to the existing GridModel - the flags are read on each sort decision.
         this.addReaction({
-            track: () => this.streamingSortInterval,
-            run: interval => (this.gridModel.streamingSortInterval = interval)
+            track: () => [this.deferredSortFactor, this.deltaSortRatio],
+            run: () => this.applySortFlags()
         });
 
         // Re-apply on selection change, and when a rebuild installs fresh diagnostics objects.
@@ -144,8 +147,10 @@ export class CubeTestModel extends HoistModel {
         return this.patchRecords ? 0.1 : 0;
     }
 
-    get streamingSortInterval(): number {
-        return this.throttleSort ? 5 * SECONDS : null;
+    private applySortFlags() {
+        const {experimental} = this.gridModel;
+        experimental.deferredSortFactor = this.deferredSortFactor;
+        experimental.deltaSortRatio = this.deltaSortRatio;
     }
 
     private applyMaxPatchRatio(ratio: number) {
@@ -260,7 +265,10 @@ export class CubeTestModel extends HoistModel {
                 experimental: {maxPatchRatio: this.maxPatchRatio},
                 fields: [{name: 'cubeDimension', type: 'string'}]
             },
-            streamingSortInterval: this.streamingSortInterval,
+            experimental: {
+                deferredSortFactor: this.deferredSortFactor,
+                deltaSortRatio: this.deltaSortRatio
+            },
             sortBy: 'time|desc',
             emptyText: 'No records found...',
             colChooserModel: true,

--- a/client-app/src/admin/tests/cube/CubeTestModel.ts
+++ b/client-app/src/admin/tests/cube/CubeTestModel.ts
@@ -29,7 +29,6 @@ export class CubeTestModel extends HoistModel {
 
     @bindable projectionOnly = true;
     @bindable reuseRecords = true;
-    @bindable deltaSort = false;
 
     /** Set explicitly in both directions, overriding any app-wide `xhStoreExperimental` default. */
     @bindable patchRecords = true;
@@ -78,7 +77,7 @@ export class CubeTestModel extends HoistModel {
 
         // Reconstruct the Store in the new mode, for A/B comparison.
         this.addReaction({
-            track: () => [this.projectionOnly, this.reuseRecords, this.deltaSort],
+            track: () => [this.projectionOnly, this.reuseRecords],
             run: () => this.buildGridAndView()
         });
 
@@ -250,7 +249,6 @@ export class CubeTestModel extends HoistModel {
                 experimental: {maxPatchRatio: this.maxPatchRatio},
                 fields: [{name: 'cubeDimension', type: 'string'}]
             },
-            experimental: {deltaSort: this.deltaSort},
             sortBy: 'time|desc',
             emptyText: 'No records found...',
             colChooserModel: true,

--- a/client-app/src/admin/tests/cube/CubeTestPanel.ts
+++ b/client-app/src/admin/tests/cube/CubeTestPanel.ts
@@ -79,11 +79,12 @@ const storeBar = hoistCmp.factory<CubeTestModel>(() =>
         switchInput({bind: 'projectionOnly', label: 'Projection Only', labelSide: 'left'}),
         switchInput({bind: 'reuseRecords', label: 'Reuse Records', labelSide: 'left'}),
         switchInput({bind: 'patchRecords', label: 'Patch Records', labelSide: 'left'}),
+        switchInput({bind: 'throttleSort', label: 'Throttle Sort', labelSide: 'left'}),
         filler(),
         'Update Secs: ',
         select({
             bind: 'updateFreq',
-            options: [-1, 1, 2, 5, 10, 20],
+            options: [-1, 0.1, 0.5, 1, 2, 5, 10, 20],
             width: 80
         }),
         hspacer(5),

--- a/client-app/src/admin/tests/cube/CubeTestPanel.ts
+++ b/client-app/src/admin/tests/cube/CubeTestPanel.ts
@@ -79,7 +79,6 @@ const storeBar = hoistCmp.factory<CubeTestModel>(() =>
         switchInput({bind: 'projectionOnly', label: 'Projection Only', labelSide: 'left'}),
         switchInput({bind: 'reuseRecords', label: 'Reuse Records', labelSide: 'left'}),
         switchInput({bind: 'patchRecords', label: 'Patch Records', labelSide: 'left'}),
-        switchInput({bind: 'deltaSort', label: 'Delta Sort', labelSide: 'left'}),
         filler(),
         'Update Secs: ',
         select({

--- a/client-app/src/admin/tests/cube/CubeTestPanel.ts
+++ b/client-app/src/admin/tests/cube/CubeTestPanel.ts
@@ -79,7 +79,20 @@ const storeBar = hoistCmp.factory<CubeTestModel>(() =>
         switchInput({bind: 'projectionOnly', label: 'Projection Only', labelSide: 'left'}),
         switchInput({bind: 'reuseRecords', label: 'Reuse Records', labelSide: 'left'}),
         switchInput({bind: 'patchRecords', label: 'Patch Records', labelSide: 'left'}),
-        switchInput({bind: 'throttleSort', label: 'Throttle Sort', labelSide: 'left'}),
+        toolbarSep(),
+        'Defer Factor: ',
+        select({
+            bind: 'deferredSortFactor',
+            options: [0, 1, 4, 8, 16],
+            width: 70
+        }),
+        hspacer(5),
+        'Delta Ratio: ',
+        select({
+            bind: 'deltaSortRatio',
+            options: [0, 25, 50, 75, 90],
+            width: 70
+        }),
         filler(),
         'Update Secs: ',
         select({

--- a/client-app/src/admin/tests/cube/DiagnosticsPanel.ts
+++ b/client-app/src/admin/tests/cube/DiagnosticsPanel.ts
@@ -59,7 +59,7 @@ export const diagnosticsPanel = hoistCmp.factory({
                         diagSection(
                             'Grid',
                             gridModel.diagnostics,
-                            ['genTransaction', 'applyTransaction'],
+                            ['genTransaction', 'applyTransaction', 'sortFlush'],
                             asOf,
                             count(gridRows, 'visible rows')
                         ),
@@ -227,7 +227,9 @@ function opDetail(op: PlainObject): string {
             ? [`reused ${n(op.reused)}`, `rebuilt ${n(op.rebuilt)}`, `created ${n(op.created)}`]
             : op.columns != null
               ? [`cols ${n(op.columns)}`, `recs ${n(op.records)}`]
-              : [`upd ${n(op.update)}`, `add ${n(op.add)}`, `rem ${n(op.remove)}`];
+              : op.pending != null
+                ? [`pending ${n(op.pending)}`, `of ${n(op.total)}`]
+                : [`upd ${n(op.update)}`, `add ${n(op.add)}`, `rem ${n(op.remove)}`];
 
     return parts.join(' · ');
 }


### PR DESCRIPTION
Companion to xh/hoist-react#4588 (tiered ag-Grid transaction handling).

- Removed the `Delta Sort` toggle - that PR removes `GridExperimentalFlags.deltaSort`, with Hoist now managing ag-Grid delta sorting automatically per transaction, so the A/B toggle no longer has anything to switch.
- Added a `Throttle Sort` toggle, applying the new `GridModel.streamingSortInterval` prop (at 5s) live to the running grid.
- Added sub-second update stream rates (0.1s, 0.5s) to exercise streaming sort throttling under rapid updates. The stream now runs on a plain `setInterval`, as `Timer`'s 500ms floor blocks sub-second rates - overlapping ticks are skipped, matching prior `Timer` behavior.

The tester's other toggles (Projection Only, Reuse Records, Patch Records) and diagnostics panel are unchanged and were used to validate the hoist-react PR's results at 40k and 400k rows.