### PR TITLE
Added select perf test case, test cases to mobile

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@
 ### Technical
 
 * Migrated client-app package management from yarn classic to pnpm, with the version pinned via `packageManager`. Run `corepack enable pnpm` once before your next install.
+* Added a Tests section to the mobile app, gated on `HOIST_ADMIN_READER`, so test harnesses no longer live in the demo pages.
+* Added async `Select` performance tester, reproducing the O(n²) option merge fixed in hoist-react #4589. Options are served by a new `SelectTestController`; each tester reports the main-thread block per query.
 * Overhauled the admin Grid test panel into a fuller Store performance harness. Test data is now generated on the server and loaded via streaming NDJSON or conventional JSON, options cover the Store's memory-related configs (`useRawAsData`, `freezeData`, `retainRaw`, `reuseRecords`) along with string interning and server-generated field values, parameter sets can be saved as named `ViewManager` configs, and a repeatable benchmark dialog measures heap and load-time costs across runs. The panel itself was redesigned around the same documented options sidebar used by the desktop example apps.
 
 ### Libraries

--- a/client-app/src/admin/tests/select/SelectTestModel.ts
+++ b/client-app/src/admin/tests/select/SelectTestModel.ts
@@ -1,6 +1,6 @@
-import {HoistModel, PlainObject} from '@xh/hoist/core';
-import {bindable, observable, makeObservable} from '@xh/hoist/mobx';
-import {times} from 'lodash';
+import {HoistModel, PlainObject, XH} from '@xh/hoist/core';
+import {action, bindable, observable, makeObservable, runInAction} from '@xh/hoist/mobx';
+import {take, times} from 'lodash';
 
 export class SelectTestModel extends HoistModel {
     @bindable
@@ -46,9 +46,36 @@ export class SelectTestModel extends HoistModel {
     @bindable
     idNotInOpts: number = 99;
 
+    // Shape follows perfEnableMulti - a single value, or an array of them.
+    @bindable.ref
+    perfValue: string | string[];
+
+    @bindable
+    perfEnableMulti = false;
+
+    @bindable
+    perfEnableCreate = false;
+
+    @bindable
+    numPerfOptions = 16000;
+
+    @bindable
+    perfLatency = 300;
+
+    // Ms the main thread was blocked following each of the last few async queries - see noteBlock().
+    @observable.ref
+    blockTimes: number[] = [];
+
     constructor() {
         super();
         makeObservable(this);
+
+        // Single- and multi-mode values have different shapes - clear on toggle so a value left
+        // over from one mode is never handed to the other.
+        this.addReaction({
+            track: () => this.perfEnableMulti,
+            run: () => runInAction(() => (this.perfValue = null))
+        });
         this.addReaction({
             track: () => this.numOptions,
             run: () => (this.bigOptions = times(this.numOptions, i => `option: ${i}`)),
@@ -77,5 +104,37 @@ export class SelectTestModel extends HoistModel {
     // Lookup returns both selectable and not-selectable records.
     lookupEmployeeById(id: number) {
         return this.employees.find(it => it.id === id);
+    }
+
+    //------------------------
+    // Async merge perf - repro for hoist-react #4589
+    //------------------------
+    // Type one character (broad match, `numPerfOptions` results), then a second (narrow match, 2
+    // results). Both keystrokes blocked the main thread for seconds prior to that fix, the second
+    // one on options accumulated by the first rather than on its own 2-row payload.
+    async queryPerfOptionsAsync(query: string) {
+        const ret = await XH.fetchJson({
+            url: 'selectTest/symbols',
+            params: {query, count: this.numPerfOptions, latency: this.perfLatency}
+        });
+        this.noteBlock();
+        return ret;
+    }
+
+    @action
+    clearBlockTimes() {
+        this.blockTimes = [];
+    }
+
+    // Time the gap between this query resolving and the next macrotask. Select merges the result
+    // into its options in the microtask continuation of `await queryFn`, so a timer queued here
+    // cannot fire until that merge has run - making the delta the block the merge caused. React's
+    // own render is not necessarily inside the window, but the trace put it at <1% of the total.
+    private noteBlock() {
+        const start = performance.now();
+        setTimeout(() => {
+            const ms = Math.round(performance.now() - start);
+            runInAction(() => (this.blockTimes = take([ms, ...this.blockTimes], 5)));
+        });
     }
 }

--- a/client-app/src/admin/tests/select/SelectTestPanel.ts
+++ b/client-app/src/admin/tests/select/SelectTestPanel.ts
@@ -1,10 +1,11 @@
 import {box, div, hbox, label, p} from '@xh/hoist/cmp/layout';
 
 import {creates, hoistCmp, XH} from '@xh/hoist/core';
-import {numberInput, select} from '@xh/hoist/desktop/cmp/input';
+import {button} from '@xh/hoist/desktop/cmp/button';
+import {numberInput, select, switchInput} from '@xh/hoist/desktop/cmp/input';
 import {panel} from '@xh/hoist/desktop/cmp/panel';
 import {Icon} from '@xh/hoist/icon/Icon';
-import {isUndefined} from 'lodash';
+import {isEmpty, isUndefined} from 'lodash';
 import {restaurants, usStates} from '../../../core/data';
 import {SelectTestModel} from './SelectTestModel';
 import './SelectTestPanel.scss';
@@ -129,12 +130,58 @@ export const SelectTestPanel = hoistCmp({
                             enableClear: true,
                             placeholder: 'Select an employee...'
                         }
+                    }),
+                    // Repro for the O(n²) async option merge fixed in hoist-react #4589 - type one
+                    // character for a large result, then a second for a 2-option result. Both
+                    // keystrokes blocked for seconds before that fix.
+                    //
+                    // enableCreate still blocks the second keystroke: react-select's Creatable
+                    // scans every option to decide whether to offer a "Create..." entry, lowercasing
+                    // each label and value, on each input change. enableMulti is not in that path.
+                    example({
+                        name: 'queryFn - large async result (#4589)',
+                        bind: 'perfValue',
+                        selectProps: {
+                            width: 350,
+                            queryFn: query => model.queryPerfOptionsAsync(query),
+                            enableMulti: model.perfEnableMulti,
+                            enableCreate: model.perfEnableCreate,
+                            enableClear: true,
+                            placeholder: 'Type one char, then a second...'
+                        },
+                        extraItems: [
+                            numberInput({bind: 'numPerfOptions', valueLabel: ' options'}),
+                            numberInput({bind: 'perfLatency', valueLabel: 'ms latency'}),
+                            switchInput({bind: 'perfEnableMulti', label: 'enableMulti'}),
+                            switchInput({bind: 'perfEnableCreate', label: 'enableCreate'}),
+                            blockTimes()
+                        ]
                     })
                 ]
             })
         });
     }
 });
+
+// Ms the main thread was blocked after each recent query resolved - the merge cost.
+const blockTimes = hoistCmp.factory<SelectTestModel>(({model}) =>
+    hbox({
+        alignItems: 'center',
+        items: [
+            label(
+                isEmpty(model.blockTimes)
+                    ? 'blocked: --'
+                    : 'blocked: ' + model.blockTimes.map(it => `${it}ms`).join(', ')
+            ),
+            button({
+                text: 'Clear',
+                minimal: true,
+                omit: isEmpty(model.blockTimes),
+                onClick: () => model.clearBlockTimes()
+            })
+        ]
+    })
+);
 
 const example = hoistCmp.factory<SelectTestModel>(
     ({model, name, bind, selectProps, extraItems = []}) =>

--- a/client-app/src/mobile/AppModel.ts
+++ b/client-app/src/mobile/AppModel.ts
@@ -38,6 +38,7 @@ import {popoverPage} from './popover/PopoverPage';
 import {popupsPage} from './popups/PopupsPage';
 import {selectPage} from './select/SelectPage';
 import {tabsPage} from './tabs/TabsPage';
+import {mobileTests} from './tests/TestsCatalog';
 
 export class AppModel extends BaseAppModel {
     static instance: AppModel;
@@ -74,6 +75,7 @@ export class AppModel extends BaseAppModel {
             {id: 'icons', content: iconPage},
             {id: 'mask', content: maskPage},
             {id: 'pinPad', content: pinPadPage},
+            ...mobileTests().map(it => ({id: it.id, content: it.content})),
             // Standalone Docs section: landing (corpus chooser) -> corpus -> category -> reader,
             // plus a dedicated search screen. The reader (`doc`) is reused at every mount point.
             {id: 'docs', content: docsLandingPage},
@@ -92,6 +94,8 @@ export class AppModel extends BaseAppModel {
         // (3) a child of the search screen (back returns to the results). The standalone Docs section
         // (`docs`) is the corpus-chooser landing - a top-level destination reached from the nav blade.
         const docReaderRoute = () => ({name: 'doc', path: '/doc/:source/:docId?section'});
+
+        const testRoutes = mobileTests().map(it => ({name: it.id, path: `/tests/${it.path}`}));
 
         const examples = [
             {name: 'grid', path: '/grid', children: [{name: 'gridDetail', path: '/:id<\\d+>'}]},
@@ -129,6 +133,7 @@ export class AppModel extends BaseAppModel {
                 path: '/mobile',
                 children: [
                     ...examples.map(r => ({...r, children: [...r.children, docReaderRoute()]})),
+                    ...testRoutes,
                     {
                         name: 'docs',
                         path: '/docs',

--- a/client-app/src/mobile/cmp/navBlade/NavBladeModel.ts
+++ b/client-app/src/mobile/cmp/navBlade/NavBladeModel.ts
@@ -2,7 +2,9 @@ import {HoistModel, XH} from '@xh/hoist/core';
 import {Icon} from '@xh/hoist/icon';
 import {action, bindable, makeObservable, observable} from '@xh/hoist/mobx';
 import {ReactElement} from 'react';
+import {isEmpty} from 'lodash';
 import {DocService} from '../../../core/svc/DocService';
+import {mobileTests} from '../../tests/TestsCatalog';
 
 /** A single navigable leaf within the blade - maps to a fully-qualified app route. */
 export interface NavBladeItem {
@@ -54,62 +56,77 @@ export class NavBladeModel extends HoistModel {
         return DOCS_ROUTE;
     }
 
-    readonly groups: NavBladeGroup[] = [
-        {
-            id: 'gridsAndData',
-            text: 'Grids & Data',
-            icon: Icon.grid(),
-            items: [
-                {text: 'Grid', route: 'default.grid'},
-                {text: 'TreeGrid', route: 'default.treeGrid'},
-                {text: 'ZoneGrid', route: 'default.zoneGrid'},
-                {text: 'DataView', route: 'default.dataView'}
-            ]
-        },
-        {
-            id: 'charts',
-            text: 'Charts',
-            icon: Icon.chartLine(),
-            items: [
-                {text: 'Chart', route: 'default.chart'},
-                {text: 'TreeMap', route: 'default.treeMap'}
-            ]
-        },
-        {
-            id: 'forms',
-            text: 'Forms',
-            icon: Icon.edit(),
-            items: [
-                {text: 'Form', route: 'default.form'},
-                {text: 'Inputs', route: 'default.inputs'},
-                {text: 'Select', route: 'default.select'}
-            ]
-        },
-        {
-            id: 'layout',
-            text: 'Layout',
-            icon: Icon.layout(),
-            items: [
-                {text: 'Containers', route: 'default.containers'},
-                {text: 'Panel', route: 'default.panel'},
-                {text: 'Tabs', route: 'default.tabs'}
-            ]
-        },
-        {
-            id: 'components',
-            text: 'Components',
-            icon: Icon.cube(),
-            items: [
-                {text: 'Badges', route: 'default.badges'},
-                {text: 'Buttons', route: 'default.buttons'},
-                {text: 'Icons', route: 'default.icons'},
-                {text: 'Mask', route: 'default.mask'},
-                {text: 'PinPad', route: 'default.pinPad'},
-                {text: 'Popover', route: 'default.popover'},
-                {text: 'Popups', route: 'default.popups'}
-            ]
-        }
-    ];
+    /** Example groups, plus a Tests group for users with access to the test harnesses. */
+    get groups(): NavBladeGroup[] {
+        const testSpecs = mobileTests(),
+            mobileTestNavBladeGroup = isEmpty(testSpecs)
+                ? [
+                      {
+                          id: 'tests',
+                          text: 'Tests',
+                          icon: Icon.stopwatch(),
+                          items: testSpecs.map(it => ({text: it.title, route: `default.${it.id}`}))
+                      }
+                  ]
+                : [];
+        return [
+            {
+                id: 'gridsAndData',
+                text: 'Grids & Data',
+                icon: Icon.grid(),
+                items: [
+                    {text: 'Grid', route: 'default.grid'},
+                    {text: 'TreeGrid', route: 'default.treeGrid'},
+                    {text: 'ZoneGrid', route: 'default.zoneGrid'},
+                    {text: 'DataView', route: 'default.dataView'}
+                ]
+            },
+            {
+                id: 'charts',
+                text: 'Charts',
+                icon: Icon.chartLine(),
+                items: [
+                    {text: 'Chart', route: 'default.chart'},
+                    {text: 'TreeMap', route: 'default.treeMap'}
+                ]
+            },
+            {
+                id: 'forms',
+                text: 'Forms',
+                icon: Icon.edit(),
+                items: [
+                    {text: 'Form', route: 'default.form'},
+                    {text: 'Inputs', route: 'default.inputs'},
+                    {text: 'Select', route: 'default.select'}
+                ]
+            },
+            {
+                id: 'layout',
+                text: 'Layout',
+                icon: Icon.layout(),
+                items: [
+                    {text: 'Containers', route: 'default.containers'},
+                    {text: 'Panel', route: 'default.panel'},
+                    {text: 'Tabs', route: 'default.tabs'}
+                ]
+            },
+            {
+                id: 'components',
+                text: 'Components',
+                icon: Icon.cube(),
+                items: [
+                    {text: 'Badges', route: 'default.badges'},
+                    {text: 'Buttons', route: 'default.buttons'},
+                    {text: 'Icons', route: 'default.icons'},
+                    {text: 'Mask', route: 'default.mask'},
+                    {text: 'PinPad', route: 'default.pinPad'},
+                    {text: 'Popover', route: 'default.popover'},
+                    {text: 'Popups', route: 'default.popups'}
+                ]
+            },
+            ...mobileTestNavBladeGroup
+        ];
+    }
 
     constructor() {
         super();

--- a/client-app/src/mobile/tests/TestsCatalog.ts
+++ b/client-app/src/mobile/tests/TestsCatalog.ts
@@ -1,0 +1,39 @@
+import {Content, XH} from '@xh/hoist/core';
+import {Icon} from '@xh/hoist/icon';
+import {ReactElement} from 'react';
+import {selectTestPage} from './select/SelectTestPage';
+
+/**
+ * A mobile test harness - the single source for its Navigator page, its route, and its nav blade
+ * entry, so adding a test requires only an entry here plus its page.
+ */
+export interface MobileTestSpec {
+    /** Navigator page id and route name segment - must be unique across all mobile pages. */
+    id: string;
+    /** Path segment, mounted under `/tests`. */
+    path: string;
+    /** Nav blade label, also used as the app bar title. */
+    title: string;
+    icon: ReactElement;
+    content: Content;
+}
+
+const TESTS: MobileTestSpec[] = [
+    {
+        id: 'selectTest',
+        path: 'select',
+        title: 'Select',
+        icon: Icon.chevronDown(),
+        content: selectTestPage
+    }
+];
+
+/**
+ * Test harnesses available to the current user, gated on the same role their server-side endpoints
+ * require. Generates both the routes and nav blade from a single spec to keep them consistent.
+ *
+ * Hidden from non-admin-reader users.
+ */
+export function mobileTests(): MobileTestSpec[] {
+    return XH.getUser()?.isHoistAdminReader ? TESTS : [];
+}

--- a/client-app/src/mobile/tests/select/SelectTestPage.ts
+++ b/client-app/src/mobile/tests/select/SelectTestPage.ts
@@ -1,0 +1,69 @@
+import {div, hbox, label, p, vbox} from '@xh/hoist/cmp/layout';
+import {creates, hoistCmp} from '@xh/hoist/core';
+import {button} from '@xh/hoist/mobile/cmp/button';
+import {numberInput, select} from '@xh/hoist/mobile/cmp/input';
+import {panel} from '@xh/hoist/mobile/cmp/panel';
+import {isEmpty} from 'lodash';
+import {SelectTestPageModel} from './SelectTestPageModel';
+
+/**
+ * Mobile async `Select` merge perf tester - see {@link SelectTestPageModel} for the bug it covers.
+ * Type one character for a large result, then a second for a 2-option result; both keystrokes
+ * blocked the main thread for seconds before hoist-react #4589.
+ */
+export const selectTestPage = hoistCmp.factory({
+    displayName: 'SelectTestPage',
+    model: creates(SelectTestPageModel),
+
+    render({model}) {
+        return panel({
+            scrollable: true,
+            item: vbox({
+                className: 'xh-pad',
+                items: [
+                    p(
+                        'Type one character for a large result, then a second for a 2-option result.'
+                    ),
+                    label('Options returned for a one-character query'),
+                    numberInput({bind: 'numOptions', width: '100%'}),
+                    label('Server latency (ms)'),
+                    numberInput({bind: 'latency', width: '100%'}),
+                    select({
+                        bind: 'value',
+                        queryFn: query => model.queryOptionsAsync(query),
+                        enableCreate: true,
+                        enableFilter: true,
+                        enableFullscreen: true,
+                        width: '100%',
+                        placeholder: 'Type one char, then a second...'
+                    }),
+                    div({
+                        className: 'xh-text-color-muted xh-font-size-small',
+                        item: 'value: ' + JSON.stringify(model.value)
+                    }),
+                    blockTimes()
+                ]
+            })
+        });
+    }
+});
+
+// Ms the main thread was blocked after each recent query resolved - the merge cost.
+const blockTimes = hoistCmp.factory<SelectTestPageModel>(({model}) =>
+    hbox({
+        alignItems: 'center',
+        items: [
+            label(
+                isEmpty(model.blockTimes)
+                    ? 'blocked: --'
+                    : 'blocked: ' + model.blockTimes.map(it => `${it}ms`).join(', ')
+            ),
+            button({
+                text: 'Clear',
+                minimal: true,
+                omit: isEmpty(model.blockTimes),
+                onClick: () => model.clearBlockTimes()
+            })
+        ]
+    })
+);

--- a/client-app/src/mobile/tests/select/SelectTestPageModel.ts
+++ b/client-app/src/mobile/tests/select/SelectTestPageModel.ts
@@ -1,0 +1,52 @@
+import {HoistModel, XH} from '@xh/hoist/core';
+import {action, bindable, makeObservable, observable, runInAction} from '@xh/hoist/mobx';
+import {take} from 'lodash';
+
+/**
+ * Repro for the O(n²) async option merge fixed in hoist-react #4589, which the mobile
+ * `SelectInputModel` carried identically to its desktop counterpart.
+ *
+ * Mobile `Select` has no multi-select mode, but the bug reproduces without one: the dominant cost
+ * in the reported trace was the union de-duping the incoming result against *itself*, which is
+ * independent of the current selection.
+ */
+export class SelectTestPageModel extends HoistModel {
+    @bindable value: string = null;
+
+    @bindable numOptions = 16000;
+
+    @bindable latency = 300;
+
+    // Ms the main thread was blocked following each of the last few queries - see noteBlock().
+    @observable.ref blockTimes: number[] = [];
+
+    constructor() {
+        super();
+        makeObservable(this);
+    }
+
+    async queryOptionsAsync(query: string) {
+        const ret = await XH.fetchJson({
+            url: 'selectTest/symbols',
+            params: {query, count: this.numOptions, latency: this.latency}
+        });
+        this.noteBlock();
+        return ret;
+    }
+
+    @action
+    clearBlockTimes() {
+        this.blockTimes = [];
+    }
+
+    // Time the gap between this query resolving and the next macrotask. Select merges the result
+    // into its options in the microtask continuation of `await queryFn`, so a timer queued here
+    // cannot fire until that merge has run - making the delta the block the merge caused.
+    private noteBlock() {
+        const start = performance.now();
+        setTimeout(() => {
+            const ms = Math.round(performance.now() - start);
+            runInAction(() => (this.blockTimes = take([ms, ...this.blockTimes], 5)));
+        });
+    }
+}

--- a/grails-app/controllers/io/xh/toolbox/admin/SelectTestController.groovy
+++ b/grails-app/controllers/io/xh/toolbox/admin/SelectTestController.groovy
@@ -1,0 +1,73 @@
+package io.xh.toolbox.admin
+
+import io.xh.hoist.security.AccessRequiresRole
+import io.xh.toolbox.BaseController
+
+/**
+ * Serves generated option data for the async `Select` performance testers in Admin > Tests > Select
+ * and the mobile Tests > Select page.
+ *
+ * Stands in for the security-symbol typeahead that surfaced the O(n²) option merge in hoist-react's
+ * async `Select` (xh/hoist-react#4589), and returns the same response shape as that case - a plain
+ * JSON array of strings, ~318KB decoded at 16,000 options.
+ *
+ * The dataset is deliberately rigged to the two-keystroke timeline from that issue's Chrome trace
+ * rather than to any realistic symbol distribution: a query of one character or less returns the
+ * full requested `count`, and any longer query returns just NARROW_COUNT. That reproduces the
+ * traced broad-then-narrow sequence on demand. The narrow query is the interesting one - its cost
+ * comes entirely from the options accumulated by the query before it, not from its own tiny payload.
+ *
+ * Strict on its params: an out-of-range `count` or `latency` fails the request rather than being
+ * clamped, so a mistyped param cannot quietly serve one dataset under another's label.
+ */
+@AccessRequiresRole('HOIST_ADMIN_READER')
+class SelectTestController extends BaseController {
+
+    /** Options returned when the query is longer than one character - the trace's narrow result. */
+    static final int NARROW_COUNT = 2
+
+    static final int DEFAULT_COUNT = 16_000
+
+    /** Upper bounds - this app is publicly deployed, so neither param is left unbounded. */
+    static final int MAX_COUNT = 50_000
+    static final int MAX_LATENCY = 2000
+
+    /**
+     * Return symbols matching `query` as a plain JSON array of strings.
+     *
+     * @param count - symbols to return for a broad (<= 1 char) query. Defaults to DEFAULT_COUNT.
+     * @param latency - ms to stall before responding, to stage the traced timeline (a response
+     *      landing while a later keystroke's query is still buffered). Defaults to none.
+     */
+    def symbols(String query, Integer count, Integer latency) {
+        String q = (query ?: '').toUpperCase()
+        int total = count ?: DEFAULT_COUNT,
+            delay = latency ?: 0
+
+        if (total <= 1 || total > MAX_COUNT) {
+            throw new IllegalArgumentException("count must be between 1 and $MAX_COUNT - got $total")
+        }
+        if (delay <= 0 || delay > MAX_LATENCY) {
+            throw new IllegalArgumentException(
+                "latency must be between 0 and $MAX_LATENCY - got $delay"
+            )
+        }
+
+        if (delay) Thread.sleep(delay)
+
+        renderJSON(generateSymbols(q, q.length() <= 1 ? total : NARROW_COUNT))
+    }
+
+    //------------------------
+    // Implementation
+    //------------------------
+    /**
+     * Generate `count` distinct symbols, each carrying `query` as its prefix so every result is a
+     * match for what the user typed. Suffixes are sequential rather than random: repeating a query
+     * must return the same options, or the client's retention of them could not be reasoned about.
+     */
+    private static List<String> generateSymbols(String query, int count) {
+        String prefix = query ?: 'S'
+        return (0..<count).collect { "$prefix$it" as String }
+    }
+}


### PR DESCRIPTION
Adds a select performance test case for https://github.com/xh/hoist-react/pull/4590 / https://github.com/xh/hoist-react/issues/4589

Adds a testing catalog for introducing mobile app tests, and adds a mobile counterpart to the above select performance test case.

Some mobile app pages are broken right now - https://github.com/xh/hoist-react/pull/4596 - so this is a draft until mobile is fixed and I can test the harness.