### PR TITLE
Type the SelectPanel status optionRenderer instead of casting

### DIFF
--- a/client-app/src/desktop/tabs/forms/SelectPanel.ts
+++ b/client-app/src/desktop/tabs/forms/SelectPanel.ts
@@ -38,6 +38,8 @@ const STATUS_OPTIONS = [
     }
 ];
 
+type StatusOption = (typeof STATUS_OPTIONS)[number];
+
 const DESSERTS = [
     {label: 'Cookies', options: ['Oatmeal', 'Chocolate Chip', 'Peanut Butter']},
     {label: 'Cakes', options: ['Red Velvet', 'Tres Leches', "German's Chocolate", 'Cheesecake']},
@@ -287,19 +289,19 @@ const column2 = hoistCmp.factory<SelectPanelModel>(() =>
                     options: STATUS_OPTIONS,
                     enableClear: true,
                     placeholder: 'Status...',
-                    optionRenderer: opt =>
+                    optionRenderer: (opt: StatusOption) =>
                         hbox({
                             alignItems: 'center',
                             flex: 1,
                             items: [
-                                statusDot((opt as any).color),
+                                statusDot(opt.color),
                                 vbox({
                                     flex: 1,
                                     items: [
                                         span(opt.label),
                                         span({
                                             className: 'xh-text-color-muted xh-font-size-small',
-                                            item: (opt as any).description
+                                            item: opt.description
                                         })
                                     ]
                                 })


### PR DESCRIPTION
Types the status-dot `optionRenderer` demo in `SelectPanel` instead of casting, dropping two `as any` casts on the option's custom fields:

```ts
type StatusOption = (typeof STATUS_OPTIONS)[number];

select({
    options: STATUS_OPTIONS,
    optionRenderer: (opt: StatusOption) =>
        hbox({items: [statusDot(opt.color), ..., span({item: opt.description})]})
});
```

One annotation on the closure argument replaces the casts, and gives the renderer real completion and typo checking on `color`/`description`. This is the recommended pattern for custom fields carried on a `SelectOption` (see xh/hoist-react#4467), so the reference app should model it.

Stands alone - needs no hoist-react changes, and type-checks against the published `@xh/hoist`.
