### PR TITLE
Add DateRangePicker demo page

### DIFF
--- a/client-app/src/desktop/AppModel.ts
+++ b/client-app/src/desktop/AppModel.ts
@@ -22,7 +22,14 @@ import {
 } from './tabs/charts';
 import {docsTab} from './tabs/docs/DocsTab';
 import {examplesTab} from './tabs/examples/ExamplesTab';
-import {formPanel, inputsPanel, pickerPanel, selectPanel, toolbarFormPanel} from './tabs/forms';
+import {
+    dateRangePickerPanel,
+    formPanel,
+    inputsPanel,
+    pickerPanel,
+    selectPanel,
+    toolbarFormPanel
+} from './tabs/forms';
 import {
     agGridView,
     columnChooserPanel,
@@ -280,6 +287,7 @@ export class AppModel extends BaseAppModel {
                             {name: 'inputs', path: '/inputs'},
                             {name: 'select', path: '/select'},
                             {name: 'picker', path: '/picker'},
+                            {name: 'dateRangePicker', path: '/dateRangePicker'},
                             {name: 'toolbarForms', path: '/toolbarForms'}
                         ]
                     },
@@ -459,6 +467,11 @@ export class AppModel extends BaseAppModel {
                         {id: 'inputs', title: 'Hoist Inputs', content: inputsPanel},
                         {id: 'select', title: 'Select', content: selectPanel},
                         {id: 'picker', title: 'Picker', content: pickerPanel},
+                        {
+                            id: 'dateRangePicker',
+                            title: 'DateRangePicker',
+                            content: dateRangePickerPanel
+                        },
                         {id: 'toolbarForms', title: 'Toolbar Forms', content: toolbarFormPanel}
                     ]
                 }

--- a/client-app/src/desktop/common/Wrapper.scss
+++ b/client-app/src/desktop/common/Wrapper.scss
@@ -148,6 +148,17 @@
     min-height: 26px;
   }
 
+  // Label centered against the first of a stack of inputs, rather than the whole stack.
+  &__option-row--top {
+    align-items: flex-start;
+
+    .tbox-wrapper__option-label {
+      display: grid;
+      align-items: center;
+      min-height: 30px;
+    }
+  }
+
   &__option-label {
     flex: 1;
     min-width: 0;

--- a/client-app/src/desktop/common/Wrapper.ts
+++ b/client-app/src/desktop/common/Wrapper.ts
@@ -6,6 +6,7 @@ import {panel} from '@xh/hoist/desktop/cmp/panel';
 import {Icon} from '@xh/hoist/icon';
 import {bindable, makeObservable} from '@xh/hoist/mobx';
 import {isArray, isEmpty} from 'lodash';
+import classNames from 'classnames';
 import {ReactElement, ReactNode} from 'react';
 import {toolboxLink, ToolboxLinkProps} from '../../core/cmp/ToolboxLink';
 import './Wrapper.scss';
@@ -172,6 +173,11 @@ interface WrapperOptionProps extends HoistProps {
      * Use to describe what the option does or why a developer might reach for it.
      */
     info?: ReactNode;
+    /**
+     * True to align the label with the top of the control rather than its vertical center - for a
+     * control that stacks several inputs, so the label sits beside the first of them.
+     */
+    alignTop?: boolean;
 }
 
 /**
@@ -182,14 +188,17 @@ interface WrapperOptionProps extends HoistProps {
  */
 export const [WrapperOption, wrapperOption] = hoistCmp.withFactory<WrapperOptionProps>({
     displayName: 'WrapperOption',
-    render({label, control, propName, info}) {
+    render({label, control, propName, info, alignTop}) {
         return div({
             className: 'tbox-wrapper__option',
             // Native tooltip with the full property name - useful when the revealed pill ellipsizes.
             title: propName,
             items: [
                 div({
-                    className: 'tbox-wrapper__option-row',
+                    className: classNames(
+                        'tbox-wrapper__option-row',
+                        alignTop && 'tbox-wrapper__option-row--top'
+                    ),
                     items: [
                         div({
                             className: 'tbox-wrapper__option-label',

--- a/client-app/src/desktop/common/grid/SampleGridModel.ts
+++ b/client-app/src/desktop/common/grid/SampleGridModel.ts
@@ -120,13 +120,12 @@ export class SampleGridModel extends HoistModel {
             levelLabels: () => {
                 return [...this.groupingChooserModel.valueDisplayNames, 'Company'];
             },
-            groupSortFn: (a, b, groupField) => {
-                if (a === b) return 0;
+            groupSortFn: (a, b, groupField, {gridModel}) => {
                 if (groupField === 'winLose') {
+                    if (a === b) return 0;
                     return a === 'Winner' ? -1 : 1;
-                } else {
-                    return a < b ? -1 : 1;
                 }
+                return gridModel.defaultGroupSortFn(a, b);
             },
             restoreDefaultsFn: () => this.restoreDefaultsFn(),
             colDefaults: {
@@ -210,8 +209,9 @@ export class SampleGridModel extends HoistModel {
             allowEmpty: true,
             commitOnChange: true,
             dimensions: [
-                {name: 'city', displayName: 'City'},
-                {name: 'winLose', displayName: 'Win/Lose'}
+                {name: 'city'},
+                {name: 'winLose', displayName: 'Win/Lose'},
+                {name: 'trade_date'}
             ],
             initialValue: []
         });

--- a/client-app/src/desktop/tabs/forms/DateRangePickerPanel.scss
+++ b/client-app/src/desktop/tabs/forms/DateRangePickerPanel.scss
@@ -1,0 +1,86 @@
+.tb-drp-panel {
+  &__title {
+    font-weight: 600;
+    color: var(--xh-text-color-headings);
+  }
+
+  &__stat {
+    align-items: baseline;
+    gap: 6px;
+    font-family: var(--xh-font-family-mono);
+    font-size: var(--xh-font-size-small-px);
+  }
+
+  &__stat-label {
+    font-family: var(--xh-font-family);
+    font-size: var(--xh-font-size-small-px);
+    font-weight: 600;
+    text-transform: uppercase;
+    letter-spacing: 0.06em;
+    color: var(--xh-text-color-muted);
+  }
+
+  &__side {
+    width: 460px;
+    flex: none;
+    border-right: var(--xh-border-solid);
+  }
+
+  &__readout {
+    flex: none;
+  }
+
+  &__readout-row {
+    display: flex;
+    align-items: baseline;
+    gap: var(--xh-pad-px);
+    padding: 4px var(--xh-pad-px);
+    border-bottom: 1px solid var(--xh-border-color);
+
+    &:last-child {
+      border-bottom: none;
+    }
+  }
+
+  &__readout-label {
+    width: 130px;
+    flex: none;
+    font-size: var(--xh-font-size-small-px);
+    color: var(--xh-text-color-muted);
+  }
+
+  &__readout-value {
+    flex: 1;
+    min-width: 0;
+    overflow-wrap: anywhere;
+    font-size: var(--xh-font-size-small-px);
+  }
+
+  &__variants {
+    flex: 1;
+  }
+
+  &__variant {
+    padding: var(--xh-pad-px);
+    border-bottom: 1px solid var(--xh-border-color);
+
+    &:last-child {
+      border-bottom: none;
+    }
+  }
+
+  &__variant-label {
+    font-weight: 600;
+  }
+
+  &__variant-body {
+    margin-top: 6px;
+    display: flex;
+  }
+
+  &__narrow-host {
+    padding: 4px;
+    border: 1px dashed var(--xh-border-color);
+    border-radius: var(--xh-border-radius-px);
+  }
+}

--- a/client-app/src/desktop/tabs/forms/DateRangePickerPanel.ts
+++ b/client-app/src/desktop/tabs/forms/DateRangePickerPanel.ts
@@ -1,0 +1,487 @@
+import {grid, GridModel, localDateCol, numberCol} from '@xh/hoist/cmp/grid';
+import {box, code, div, filler, hbox, hframe, span, vbox, vframe} from '@xh/hoist/cmp/layout';
+import {creates, hoistCmp, HoistModel, type Intent, managed} from '@xh/hoist/core';
+import {parseFilter} from '@xh/hoist/data';
+import {
+    DATE_RANGE_PICKER_TABS,
+    DATE_RANGE_PRESET_TOKENS,
+    dateRangePicker,
+    DateRangePickerModel,
+    type DateRangePickerTab,
+    type DateRangePreset,
+    type DateRangePresetToken,
+    DEFAULT_DATE_RANGE_PRESETS,
+    type LocalDateRange
+} from '@xh/hoist/desktop/cmp/daterange';
+import {dateInput, picker, select, switchInput} from '@xh/hoist/desktop/cmp/input';
+import {panel} from '@xh/hoist/desktop/cmp/panel';
+import {toolbar, toolbarSep} from '@xh/hoist/desktop/cmp/toolbar';
+import {fmtNumber} from '@xh/hoist/format';
+import {Icon} from '@xh/hoist/icon';
+import {bindable, computed, makeObservable} from '@xh/hoist/mobx';
+import {LocalDate} from '@xh/hoist/utils/datetime';
+import {isEmpty} from 'lodash';
+import {wrapper, wrapperOption, wrapperOptionGroup} from '../../common';
+import './DateRangePickerPanel.scss';
+
+export const dateRangePickerPanel = hoistCmp.factory({
+    displayName: 'DateRangePickerPanel',
+    model: creates(() => DateRangePickerPanelModel),
+
+    render({model}) {
+        return wrapper({
+            title: 'DateRangePicker',
+            icon: Icon.calendarRange(),
+            description: [
+                '`DateRangePicker` is a dropdown control for selecting a period of time - one compact',
+                'trigger that can express presets (MTD, Last 30 Days, ...), relative lookbacks, calendar',
+                'months and years, and custom ranges of dates. Its popover offers a tab for each of those',
+                'selection shapes, and the backing model controls which tabs and presets appear.',
+                '',
+                'The applied value is a single `DateRangeSelection` - plain JSON that persists as-is and',
+                're-resolves as the anchor date moves, so a saved `mtd` stays month-to-date. The',
+                '`DateRangePickerModel` resolves it to current and prior `LocalDateRange`s and to',
+                '`FieldFilterSpec`s ready to apply to a Store or query. The grid here is filtered by',
+                "the picker's `currentRangeFilter`, with the prior range summarized for comparison.",
+                '',
+                'Use the options to reconfigure the main picker in the toolbar. The smaller examples',
+                'below the readout show a stretched trigger adapting to a narrow host, a single-tab',
+                'month picker, and a picker with app-defined presets.'
+            ],
+            links: [
+                {
+                    url: '$TB/client-app/src/desktop/tabs/forms/DateRangePickerPanel.ts',
+                    notes: 'This example.'
+                },
+                {
+                    url: '$HR/desktop/cmp/daterange/DateRangePicker.ts',
+                    notes: 'Hoist component.'
+                },
+                {
+                    url: '$HR/cmp/daterange/DateRangePickerModel.ts',
+                    notes: 'Hoist component model - config, value, ranges, and filters.'
+                },
+                {
+                    url: '$HR/cmp/daterange/DateRangePresets.ts',
+                    notes: 'Built-in presets, and the shape of app-defined ones.'
+                }
+            ],
+            options: [
+                wrapperOptionGroup({
+                    label: 'Component',
+                    items: [
+                        wrapperOption({
+                            label: 'Style as input',
+                            propName: 'DateRangePickerProps.styleButtonAsInput',
+                            control: switchInput({bind: 'styleButtonAsInput'})
+                        }),
+                        wrapperOption({
+                            label: 'Show range',
+                            propName: 'DateRangePickerProps.showRange',
+                            control: switchInput({bind: 'showRange'})
+                        }),
+                        wrapperOption({
+                            label: 'Step buttons',
+                            propName: 'DateRangePickerProps.showStepButtons',
+                            info: 'Previous/next buttons move the applied range by its own length.',
+                            control: switchInput({bind: 'showStepButtons'})
+                        }),
+                        wrapperOption({
+                            label: 'Footer note',
+                            propName: 'DateRangePickerProps.footerNote',
+                            control: switchInput({bind: 'showFooterNote'})
+                        }),
+                        wrapperOption({
+                            label: 'Intent',
+                            propName: 'DateRangePickerProps.intent',
+                            control: select({
+                                bind: 'intent',
+                                enableClear: true,
+                                enableFilter: false,
+                                placeholder: 'None',
+                                width: 120,
+                                options: ['primary', 'success', 'warning', 'danger']
+                            })
+                        })
+                    ]
+                }),
+                wrapperOptionGroup({
+                    label: 'Model',
+                    items: [
+                        wrapperOption({
+                            label: 'Tabs',
+                            propName: 'DateRangePickerConfig.tabs',
+                            control: picker({
+                                bind: 'tabs',
+                                enableMulti: true,
+                                enableFilter: false,
+                                displayNoun: 'tab',
+                                multiSelectButtonStyle: 'values',
+                                width: 180,
+                                options: DATE_RANGE_PICKER_TABS
+                            })
+                        }),
+                        wrapperOption({
+                            label: 'Presets',
+                            propName: 'DateRangePickerConfig.presets',
+                            control: picker({
+                                bind: 'presets',
+                                enableMulti: true,
+                                enableSelectAll: true,
+                                enableClear: true,
+                                displayNoun: 'preset',
+                                width: 180,
+                                options: DATE_RANGE_PRESET_TOKENS
+                            })
+                        }),
+                        wrapperOption({
+                            label: 'Commit on change',
+                            propName: 'DateRangePickerConfig.commitOnChange',
+                            info: 'Relative and custom drafts apply as they change - no Apply or Cancel.',
+                            control: switchInput({model: model.pickerModel, bind: 'commitOnChange'})
+                        }),
+                        wrapperOption({
+                            label: 'Anchor date',
+                            propName: 'DateRangePickerConfig.anchorDate',
+                            info: 'Relative and to-date selections resolve against this date.',
+                            control: dateInput({
+                                bind: 'anchorDate',
+                                valueType: 'localDate',
+                                width: 130
+                            })
+                        }),
+                        wrapperOption({
+                            label: 'Allow future dates',
+                            propName: 'DateRangePickerConfig.maxDate',
+                            info: 'Sets maxDate one year past the anchor. Off, nothing beyond the anchor is selectable.',
+                            control: switchInput({bind: 'allowFutureDates'})
+                        }),
+                        wrapperOption({
+                            label: 'Date format',
+                            propName: 'DateRangePickerConfig.dateFormat',
+                            control: select({
+                                bind: 'dateFormat',
+                                enableFilter: false,
+                                width: 140,
+                                options: ['YYYY-MM-DD', 'MM/DD/YYYY', 'DD MMM YYYY']
+                            })
+                        })
+                    ]
+                })
+            ],
+            item: panel({
+                className: 'tb-drp-panel',
+                width: '100%',
+                height: '100%',
+                maxWidth: 1400,
+                tbar: mainToolbar(),
+                item: hframe(
+                    vframe({className: 'tb-drp-panel__side', items: [readout(), variants()]}),
+                    grid({model: model.gridModel})
+                )
+            })
+        });
+    }
+});
+
+//------------------------------------------------------------------
+// Main picker + filtered grid stats
+//------------------------------------------------------------------
+const mainToolbar = hoistCmp.factory<DateRangePickerPanelModel>(({model}) => {
+    const {pickerModel, stats} = model;
+    return toolbar(
+        dateRangePicker({
+            model: pickerModel,
+            styleButtonAsInput: model.styleButtonAsInput,
+            showRange: model.showRange,
+            showStepButtons: model.showStepButtons,
+            intent: model.intent,
+            footerNote: model.showFooterNote ? undefined : null,
+            testId: 'drp'
+        }),
+        toolbarSep(),
+        span({className: 'tb-drp-panel__title', item: pickerModel.displayName}),
+        filler(),
+        statBlock({label: 'Current', stat: stats.current}),
+        toolbarSep(),
+        statBlock({label: 'Prior', stat: stats.prior})
+    );
+});
+
+interface RangeStat {
+    count: number;
+    total: number;
+}
+
+const statBlock = hoistCmp.factory<DateRangePickerPanelModel>(({label, stat}) =>
+    hbox({
+        className: 'tb-drp-panel__stat',
+        items: [
+            span({className: 'tb-drp-panel__stat-label', item: label}),
+            stat
+                ? span(
+                      `${fmtNumber(stat.count, {precision: 0})} days · ${fmtNumber(stat.total, {
+                          precision: 0,
+                          prefix: '$'
+                      })}`
+                  )
+                : span({className: 'xh-text-color-muted', item: 'n/a'})
+        ]
+    })
+);
+
+//------------------------------------------------------------------
+// Readout of the model's derived values
+//------------------------------------------------------------------
+const readout = hoistCmp.factory<DateRangePickerPanelModel>(({model}) => {
+    const {pickerModel: m} = model,
+        fmtRange = (r: LocalDateRange) => (r ? m.fmtRange(r) : 'null');
+    return panel({
+        title: 'DateRangePickerModel',
+        icon: Icon.code(),
+        compactHeader: true,
+        className: 'tb-drp-panel__readout',
+        items: [
+            readoutRow({label: 'value', value: JSON.stringify(m.value)}),
+            readoutRow({label: 'label', value: m.label}),
+            readoutRow({label: 'rangeLabel', value: m.rangeLabel}),
+            readoutRow({label: 'displayName', value: m.displayName}),
+            readoutRow({label: 'currentRange', value: fmtRange(m.currentRange)}),
+            readoutRow({label: 'priorRange', value: fmtRange(m.priorRange)}),
+            readoutRow({label: 'anchorDate', value: m.anchorDate.isoString}),
+            readoutRow({
+                label: 'currentRangeFilter',
+                value: JSON.stringify(m.currentRangeFilter)
+            })
+        ]
+    });
+});
+
+const readoutRow = hoistCmp.factory(({label, value}) =>
+    div({
+        className: 'tb-drp-panel__readout-row',
+        items: [
+            span({className: 'tb-drp-panel__readout-label', item: label}),
+            code({className: 'tb-drp-panel__readout-value', item: value})
+        ]
+    })
+);
+
+//------------------------------------------------------------------
+// Other configurations
+//------------------------------------------------------------------
+const variants = hoistCmp.factory<DateRangePickerPanelModel>(({model}) =>
+    panel({
+        title: 'Other Configurations',
+        icon: Icon.gears(),
+        compactHeader: true,
+        className: 'tb-drp-panel__variants',
+        items: [
+            variantRow({
+                label: 'Stretched into a narrow host',
+                info: 'flex: 1 - the trigger measures its width and drops the dates when they no longer fit.',
+                item: box({
+                    className: 'tb-drp-panel__narrow-host',
+                    width: 200,
+                    item: dateRangePicker({model: model.pickerModel, flex: 1, testId: 'drp-narrow'})
+                })
+            }),
+            variantRow({
+                label: 'Single tab - months and years only',
+                info: "tabs: ['monthYear'] - no rail, and the popover shrinks to fit.",
+                item: dateRangePicker({model: model.monthPickerModel, testId: 'drp-month'})
+            }),
+            variantRow({
+                label: 'App-defined presets, outlined trigger',
+                info: 'A fiscal-year preset alongside built-ins, presets + custom tabs, styleButtonAsInput: false.',
+                item: dateRangePicker({
+                    model: model.fiscalPickerModel,
+                    styleButtonAsInput: false,
+                    buttonProps: {icon: Icon.chartLine()},
+                    testId: 'drp-fiscal'
+                })
+            })
+        ]
+    })
+);
+
+const variantRow = hoistCmp.factory(({label, info, children}) =>
+    vbox({
+        className: 'tb-drp-panel__variant',
+        items: [
+            span({className: 'tb-drp-panel__variant-label', item: label}),
+            span({className: 'xh-text-color-muted xh-font-size-small', item: info}),
+            div({className: 'tb-drp-panel__variant-body', item: children})
+        ]
+    })
+);
+
+//------------------------------------------------------------------
+// Model
+//------------------------------------------------------------------
+class DateRangePickerPanelModel extends HoistModel {
+    @managed pickerModel: DateRangePickerModel;
+    @managed monthPickerModel: DateRangePickerModel;
+    @managed fiscalPickerModel: DateRangePickerModel;
+    @managed gridModel: GridModel;
+
+    // Component options
+    @bindable styleButtonAsInput = true;
+    @bindable showRange = true;
+    @bindable showStepButtons = true;
+    @bindable showFooterNote = true;
+    @bindable intent: Intent = null;
+
+    // Model options
+    @bindable.ref tabs: DateRangePickerTab[] = [...DATE_RANGE_PICKER_TABS];
+    @bindable.ref presets: DateRangePresetToken[] = [...DEFAULT_DATE_RANGE_PRESETS];
+    @bindable.ref anchorDate: LocalDate = LocalDate.today();
+    @bindable allowFutureDates = false;
+    @bindable dateFormat = 'YYYY-MM-DD';
+
+    /** Record counts and totals within the current and prior ranges, across all loaded data. */
+    @computed
+    get stats(): {current: RangeStat; prior: RangeStat} {
+        const {pickerModel, gridModel} = this,
+            records = gridModel.store.allRecords,
+            statFor = (range: LocalDateRange): RangeStat => {
+                if (!range) return null;
+                const specs = pickerModel.getRangeFilter(range),
+                    testFn = isEmpty(specs) ? null : parseFilter(specs).getTestFn(gridModel.store),
+                    matches = testFn ? records.filter(testFn) : records;
+                return {
+                    count: matches.length,
+                    total: matches.reduce((sum, r) => sum + r.data.amount, 0)
+                };
+            };
+        return {current: statFor(pickerModel.currentRange), prior: statFor(pickerModel.priorRange)};
+    }
+
+    constructor() {
+        super();
+        makeObservable(this);
+
+        this.pickerModel = new DateRangePickerModel({
+            anchorDate: () => this.anchorDate,
+            filterField: 'date',
+            // Weekdays less a few fixed-date holidays - drives the `lastBusinessDay` preset.
+            isBusinessDay: d => d.isWeekday && !FIXED_HOLIDAYS.includes(d.format('MM-DD')),
+            persistWith: {localStorageKey: 'toolboxDateRangePicker'}
+        });
+
+        this.monthPickerModel = new DateRangePickerModel({
+            tabs: ['monthYear'],
+            initialValue: {kind: 'month', year: LocalDate.today().moment.year(), month: 1}
+        });
+
+        this.fiscalPickerModel = new DateRangePickerModel({
+            tabs: ['presets', 'custom'],
+            presets: [FISCAL_YTD, LAST_FISCAL_YEAR, 'qtd', 'ytd', 'last90Days'],
+            initialValue: 'fytd'
+        });
+
+        this.gridModel = new GridModel({
+            xhName: 'dateRangePickerDemo',
+            store: {
+                fields: [
+                    {name: 'date', type: 'localDate'},
+                    {name: 'category', type: 'string'},
+                    {name: 'amount', type: 'number'}
+                ]
+            },
+            sortBy: 'date|desc',
+            emptyText: 'No records within the selected range.',
+            columns: [
+                {field: 'date', ...localDateCol},
+                {field: 'category', width: 120},
+                {
+                    field: 'amount',
+                    ...numberCol,
+                    width: 110,
+                    renderer: v => fmtNumber(v, {precision: 0, prefix: '$'})
+                },
+                {colId: 'spacer', flex: 1, headerName: '', sortable: false, resizable: false}
+            ]
+        });
+        this.gridModel.loadData(generateRecords());
+
+        this.addReaction(
+            {
+                track: () => this.pickerModel.currentRangeFilter,
+                run: filter => this.gridModel.store.setFilter(filter),
+                fireImmediately: true
+            },
+            {
+                // The picker allows clearing every tab - hold the last configuration until one is
+                // selected again, as the model requires at least one.
+                track: () => this.tabs,
+                run: tabs => {
+                    if (!isEmpty(tabs)) this.pickerModel.setTabs(tabs);
+                }
+            },
+            {track: () => this.presets, run: presets => this.pickerModel.setPresets(presets)},
+            {track: () => this.dateFormat, run: fmt => (this.pickerModel.dateFormat = fmt)},
+            {
+                track: () => [this.allowFutureDates, this.anchorDate],
+                run: () => {
+                    const {allowFutureDates, anchorDate} = this;
+                    this.pickerModel.setMaxDate(
+                        allowFutureDates ? anchorDate.add(1, 'years') : null
+                    );
+                }
+            }
+        );
+    }
+}
+
+/** New Year's Day, Independence Day, and Christmas - enough to show `isBusinessDay` in action. */
+const FIXED_HOLIDAYS = ['01-01', '07-04', '12-25'];
+
+//------------------------------------------------------------------
+// App-defined presets - a July 1 fiscal year
+//------------------------------------------------------------------
+const fiscalYearStart = (date: LocalDate): LocalDate => {
+    const start = LocalDate.get(`${date.moment.year()}-07-01`);
+    return start <= date ? start : start.subtract(1, 'years');
+};
+
+const FISCAL_YTD: DateRangePreset = {
+    token: 'fytd',
+    label: 'FYTD',
+    name: 'Fiscal Year to Date (from Jul 1)',
+    resolve: ({anchorDate}) => ({start: fiscalYearStart(anchorDate), end: anchorDate}),
+    resolvePrior: ({start, end}) => ({
+        start: start.subtract(1, 'years'),
+        end: end.subtract(1, 'years')
+    })
+};
+
+const LAST_FISCAL_YEAR: DateRangePreset = {
+    token: 'lastFy',
+    label: ({anchorDate}) => `FY${fiscalYearStart(anchorDate).format('YY')}`,
+    name: ({anchorDate}) => `Last Fiscal Year (FY${fiscalYearStart(anchorDate).format('YY')})`,
+    resolve: ({anchorDate}) => {
+        const end = fiscalYearStart(anchorDate).previousDay();
+        return {start: end.add(1, 'days').subtract(1, 'years'), end};
+    }
+};
+
+//------------------------------------------------------------------
+// Sample data - one record per day, deterministic
+//------------------------------------------------------------------
+const CATEGORIES = ['Sales', 'Service', 'Support', 'Licensing'];
+
+function generateRecords() {
+    const start = LocalDate.today().subtract(3, 'years').startOfYear(),
+        end = LocalDate.today().add(1, 'years'),
+        ret = [];
+    for (let day = start, i = 0; day <= end; day = day.nextDay(), i++) {
+        ret.push({
+            id: day.isoString,
+            date: day,
+            category: CATEGORIES[(i * 7) % CATEGORIES.length],
+            amount: 250 + ((i * 7919) % 1750)
+        });
+    }
+    return ret;
+}

--- a/client-app/src/desktop/tabs/forms/DateRangePickerPanel.ts
+++ b/client-app/src/desktop/tabs/forms/DateRangePickerPanel.ts
@@ -6,6 +6,7 @@ import {
     DATE_RANGE_PICKER_TABS,
     DATE_RANGE_PRESET_TOKENS,
     dateRangePicker,
+    type DateRangeFormat,
     DateRangePickerModel,
     type DateRangePickerTab,
     type DateRangePreset,
@@ -20,7 +21,7 @@ import {fmtNumber} from '@xh/hoist/format';
 import {Icon} from '@xh/hoist/icon';
 import {bindable, computed, makeObservable} from '@xh/hoist/mobx';
 import {LocalDate} from '@xh/hoist/utils/datetime';
-import {isEmpty} from 'lodash';
+import {isEmpty, sortBy} from 'lodash';
 import {wrapper, wrapperOption, wrapperOptionGroup} from '../../common';
 import './DateRangePickerPanel.scss';
 
@@ -34,12 +35,14 @@ export const dateRangePickerPanel = hoistCmp.factory({
             icon: Icon.calendarRange(),
             description: [
                 '`DateRangePicker` is a dropdown control for selecting a period of time - one compact',
-                'trigger that can express presets (MTD, Last 30 Days, ...), relative lookbacks, calendar',
+                'trigger that can express presets (MTD, Prev 30 Days, ...), relative lookbacks, calendar',
                 'months and years, and custom ranges of dates. Its popover offers a tab for each of those',
                 'selection shapes, and the backing model controls which tabs and presets appear.',
                 '',
                 'The applied value is a single `DateRangeSelection` - plain JSON that persists as-is and',
-                're-resolves as the anchor date moves, so a saved `mtd` stays month-to-date. The',
+                're-resolves as the anchor day moves, so a saved `mtd` stays month-to-date. The step',
+                'buttons (and arrow keys on the trigger) walk a preset or lookback back and forth',
+                'without changing what it is - stepped ranges keep rolling with the day. The',
                 '`DateRangePickerModel` resolves it to current and prior `LocalDateRange`s and to',
                 '`FieldFilterSpec`s ready to apply to a Store or query. The grid here is filtered by',
                 "the picker's `currentRangeFilter`, with the prior range summarized for comparison.",
@@ -141,29 +144,73 @@ export const dateRangePickerPanel = hoistCmp.factory({
                             control: switchInput({model: model.pickerModel, bind: 'commitOnChange'})
                         }),
                         wrapperOption({
-                            label: 'Anchor date',
-                            propName: 'DateRangePickerConfig.anchorDate',
-                            info: 'Relative and to-date selections resolve against this date.',
+                            label: 'Anchor day',
+                            propName: 'DateRangePickerConfig.anchorDay',
+                            alignTop: true,
+                            info: 'Relative and to-date selections resolve against this day. The live modes follow the clock; a pinned date never moves.',
+                            control: vbox({
+                                gap: 6,
+                                alignItems: 'flex-start',
+                                items: [
+                                    select({
+                                        bind: 'anchorMode',
+                                        enableFilter: false,
+                                        width: 130,
+                                        options: [
+                                            {value: 'localDay', label: "'localDay'"},
+                                            {value: 'appDay', label: "'appDay'"},
+                                            {value: 'pinned', label: 'LocalDate'}
+                                        ]
+                                    }),
+                                    dateInput({
+                                        omit: model.anchorMode !== 'pinned',
+                                        bind: 'anchorDate',
+                                        valueType: 'localDate',
+                                        width: 130
+                                    })
+                                ]
+                            })
+                        }),
+                        wrapperOption({
+                            label: 'Business day mode',
+                            propName: 'DateRangePickerConfig.businessDayMode',
+                            info: 'Single days step by business day (weekdays less a few fixed holidays here). Multi-day ranges are unaffected.',
+                            control: switchInput({
+                                model: model.pickerModel,
+                                bind: 'businessDayMode'
+                            })
+                        }),
+                        wrapperOption({
+                            label: 'Max date',
+                            propName: 'DateRangePickerConfig.maxDate',
+                            info: 'Latest selectable date. Empty, it is the anchor date, so nothing in the future is selectable.',
                             control: dateInput({
-                                bind: 'anchorDate',
+                                bind: 'maxDate',
                                 valueType: 'localDate',
+                                enableClear: true,
                                 width: 130
                             })
                         }),
                         wrapperOption({
-                            label: 'Allow future dates',
-                            propName: 'DateRangePickerConfig.maxDate',
-                            info: 'Sets maxDate one year past the anchor. Off, nothing beyond the anchor is selectable.',
-                            control: switchInput({bind: 'allowFutureDates'})
-                        }),
-                        wrapperOption({
                             label: 'Date format',
                             propName: 'DateRangePickerConfig.dateFormat',
+                            info: 'For the two ends of a range.',
                             control: select({
                                 bind: 'dateFormat',
                                 enableFilter: false,
-                                width: 140,
+                                width: 150,
                                 options: ['YYYY-MM-DD', 'MM/DD/YYYY', 'DD MMM YYYY']
+                            })
+                        }),
+                        wrapperOption({
+                            label: 'Single day format',
+                            propName: 'DateRangePickerConfig.singleDayFormat',
+                            info: 'For a single day, and the anchor date in the footer. The last option is a function that adds the year only outside the current one.',
+                            control: select({
+                                bind: 'singleDayFormat',
+                                enableFilter: false,
+                                width: 150,
+                                options: Object.keys(DAY_FORMATS)
                             })
                         })
                     ]
@@ -199,8 +246,6 @@ const mainToolbar = hoistCmp.factory<DateRangePickerPanelModel>(({model}) => {
             footerNote: model.showFooterNote ? undefined : null,
             testId: 'drp'
         }),
-        toolbarSep(),
-        span({className: 'tb-drp-panel__title', item: pickerModel.displayName}),
         filler(),
         statBlock({label: 'Current', stat: stats.current}),
         toolbarSep(),
@@ -248,7 +293,9 @@ const readout = hoistCmp.factory<DateRangePickerPanelModel>(({model}) => {
             readoutRow({label: 'displayName', value: m.displayName}),
             readoutRow({label: 'currentRange', value: fmtRange(m.currentRange)}),
             readoutRow({label: 'priorRange', value: fmtRange(m.priorRange)}),
+            readoutRow({label: 'anchorDay', value: JSON.stringify(m.anchorDay)}),
             readoutRow({label: 'anchorDate', value: m.anchorDate.isoString}),
+            readoutRow({label: 'today', value: m.today.isoString}),
             readoutRow({
                 label: 'currentRangeFilter',
                 value: JSON.stringify(m.currentRangeFilter)
@@ -288,7 +335,7 @@ const variants = hoistCmp.factory<DateRangePickerPanelModel>(({model}) =>
             }),
             variantRow({
                 label: 'Single tab - months and years only',
-                info: "tabs: ['monthYear'] - no rail, and the popover shrinks to fit.",
+                info: "tabs: ['period'] - no rail, and the popover shrinks to fit.",
                 item: dateRangePicker({model: model.monthPickerModel, testId: 'drp-month'})
             }),
             variantRow({
@@ -334,10 +381,16 @@ class DateRangePickerPanelModel extends HoistModel {
 
     // Model options
     @bindable.ref tabs: DateRangePickerTab[] = [...DATE_RANGE_PICKER_TABS];
-    @bindable.ref presets: DateRangePresetToken[] = [...DEFAULT_DATE_RANGE_PRESETS];
+    // The defaults plus Prev Day, so the demo shows a single-day walk from both presets.
+    @bindable.ref presets: DateRangePresetToken[] = sortBy(
+        [...DEFAULT_DATE_RANGE_PRESETS, 'prevDay'],
+        it => DATE_RANGE_PRESET_TOKENS.indexOf(it)
+    );
+    @bindable anchorMode: 'localDay' | 'appDay' | 'pinned' = 'localDay';
     @bindable.ref anchorDate: LocalDate = LocalDate.today();
-    @bindable allowFutureDates = false;
+    @bindable.ref maxDate: LocalDate = null;
     @bindable dateFormat = 'YYYY-MM-DD';
+    @bindable singleDayFormat: keyof typeof DAY_FORMATS = 'ddd MMM D';
 
     /** Record counts and totals within the current and prior ranges, across all loaded data. */
     @computed
@@ -362,22 +415,20 @@ class DateRangePickerPanelModel extends HoistModel {
         makeObservable(this);
 
         this.pickerModel = new DateRangePickerModel({
-            // The anchor input can be cleared - the model requires a date, so fall back to today.
-            anchorDate: () => this.anchorDate ?? LocalDate.today(),
             filterField: 'date',
-            // Weekdays less a few fixed-date holidays - drives the `lastBusinessDay` preset.
+            // Weekdays less a few fixed-date holidays - the calendar behind `businessDayMode`.
             isBusinessDay: d => d.isWeekday && !FIXED_HOLIDAYS.includes(d.format('MM-DD')),
             persistWith: {localStorageKey: 'toolboxDateRangePicker'}
         });
 
         this.monthPickerModel = new DateRangePickerModel({
-            tabs: ['monthYear'],
+            tabs: ['period'],
             initialValue: {kind: 'month', year: LocalDate.today().moment.year(), month: 1}
         });
 
         this.fiscalPickerModel = new DateRangePickerModel({
             tabs: ['presets', 'custom'],
-            presets: [FISCAL_YTD, LAST_FISCAL_YEAR, 'qtd', 'ytd', 'last90Days'],
+            presets: [FISCAL_YTD, PREV_FISCAL_YEAR, 'qtd', 'ytd', 'prev90Days'],
             initialValue: 'fytd'
         });
 
@@ -417,23 +468,60 @@ class DateRangePickerPanelModel extends HoistModel {
                 // selected again, as the model requires at least one.
                 track: () => this.tabs,
                 run: tabs => {
-                    if (!isEmpty(tabs)) this.pickerModel.setTabs(tabs);
-                }
-            },
-            {track: () => this.presets, run: presets => this.pickerModel.setPresets(presets)},
-            {track: () => this.dateFormat, run: fmt => (this.pickerModel.dateFormat = fmt)},
-            {
-                track: () => [this.allowFutureDates, this.anchorDate],
-                run: () => {
-                    const {allowFutureDates, anchorDate} = this;
-                    this.pickerModel.setMaxDate(
-                        allowFutureDates ? anchorDate.add(1, 'years') : null
+                    if (isEmpty(tabs)) return;
+                    // As with presets below - catalog order, not pick order.
+                    this.pickerModel.setTabs(
+                        sortBy(tabs, it => DATE_RANGE_PICKER_TABS.indexOf(it))
                     );
                 }
-            }
+            },
+            {
+                // The picker appends in pick order - present presets in their catalog order instead.
+                track: () => this.presets,
+                run: presets =>
+                    this.pickerModel.setPresets(
+                        sortBy(presets, it => DATE_RANGE_PRESET_TOKENS.indexOf(it))
+                    )
+            },
+            // These options have their own defaults on this model - apply them at once, so the
+            // picker starts where the options say rather than at its own defaults.
+            {
+                track: () => this.dateFormat,
+                run: fmt => (this.pickerModel.dateFormat = fmt),
+                fireImmediately: true
+            },
+            {
+                track: () => this.singleDayFormat,
+                run: key => (this.pickerModel.singleDayFormat = DAY_FORMATS[key]),
+                fireImmediately: true
+            },
+            {
+                // The pinned date input can be cleared - the model requires a date, so fall back
+                // to today until one is entered.
+                track: () => [this.anchorMode, this.anchorDate],
+                run: () => {
+                    const {anchorMode, anchorDate} = this;
+                    this.pickerModel.setAnchorDay(
+                        anchorMode === 'pinned' ? (anchorDate ?? LocalDate.today()) : anchorMode
+                    );
+                },
+                fireImmediately: true
+            },
+            {track: () => this.maxDate, run: maxDate => this.pickerModel.setMaxDate(maxDate)}
         );
     }
 }
+
+/** Day formats offered by the demo - strings, plus a function that adds the year only when needed. */
+const DAY_FORMATS: Record<string, DateRangeFormat> = {
+    'ddd MMM D': 'ddd MMM D',
+    'ddd MMM D, YYYY': 'ddd MMM D, YYYY',
+    'YYYY-MM-DD': 'YYYY-MM-DD',
+    'Year if not current': d =>
+        d.format(
+            d.moment.year() === LocalDate.today().moment.year() ? 'ddd MMM D' : 'ddd MMM D, YYYY'
+        )
+};
 
 /** New Year's Day, Independence Day, and Christmas - enough to show `isBusinessDay` in action. */
 const FIXED_HOLIDAYS = ['01-01', '07-04', '12-25'];
@@ -457,10 +545,10 @@ const FISCAL_YTD: DateRangePreset = {
     })
 };
 
-const LAST_FISCAL_YEAR: DateRangePreset = {
-    token: 'lastFy',
+const PREV_FISCAL_YEAR: DateRangePreset = {
+    token: 'prevFy',
     label: ({anchorDate}) => `FY${fiscalYearStart(anchorDate).format('YY')}`,
-    name: ({anchorDate}) => `Last Fiscal Year (FY${fiscalYearStart(anchorDate).format('YY')})`,
+    name: ({anchorDate}) => `Prev Fiscal Year (FY${fiscalYearStart(anchorDate).format('YY')})`,
     resolve: ({anchorDate}) => {
         const end = fiscalYearStart(anchorDate).previousDay();
         return {start: end.add(1, 'days').subtract(1, 'years'), end};

--- a/client-app/src/desktop/tabs/forms/DateRangePickerPanel.ts
+++ b/client-app/src/desktop/tabs/forms/DateRangePickerPanel.ts
@@ -362,7 +362,8 @@ class DateRangePickerPanelModel extends HoistModel {
         makeObservable(this);
 
         this.pickerModel = new DateRangePickerModel({
-            anchorDate: () => this.anchorDate,
+            // The anchor input can be cleared - the model requires a date, so fall back to today.
+            anchorDate: () => this.anchorDate ?? LocalDate.today(),
             filterField: 'date',
             // Weekdays less a few fixed-date holidays - drives the `lastBusinessDay` preset.
             isBusinessDay: d => d.isWeekday && !FIXED_HOLIDAYS.includes(d.format('MM-DD')),

--- a/client-app/src/desktop/tabs/forms/index.ts
+++ b/client-app/src/desktop/tabs/forms/index.ts
@@ -1,5 +1,6 @@
 export * from './FormPanel';
 export * from './InputsPanel';
+export * from './DateRangePickerPanel';
 export * from './PickerPanel';
 export * from './SelectPanel';
 export * from './ToolbarFormPanel';

--- a/client-app/src/desktop/tabs/grids/ZoneGridPanel.ts
+++ b/client-app/src/desktop/tabs/grids/ZoneGridPanel.ts
@@ -95,13 +95,12 @@ class ZoneGridPanelModel extends HoistModel {
                 ? ['City', 'Win/Lose', 'Company']
                 : ['Win/Lose', 'City', 'Company'];
         },
-        groupSortFn: (a, b, groupField) => {
-            if (a === b) return 0;
+        groupSortFn: (a, b, groupField, {gridModel}) => {
             if (groupField === 'winLose') {
+                if (a === b) return 0;
                 return a === 'Winner' ? -1 : 1;
-            } else {
-                return a < b ? -1 : 1;
             }
+            return gridModel.defaultGroupSortFn(a, b);
         },
         restoreDefaultsFn: () => this.restoreDefaultsFn(),
         columns: [


### PR DESCRIPTION
Adds a Forms > DateRangePicker tab exercising the new hoist-react `DateRangePicker` and `DateRangePickerModel` (hoist-react #4648, including its review follow-up #4653; this PR includes #898 likewise).

- Option controls for every prop and config: trigger styling, range readout, step buttons, footer note, intent; tabs and presets (picks shown in catalog order), commit on change, anchor day as `'localDay'` / `'appDay'` / a pinned `LocalDate`, business day mode, max date, and the two date formats - the single-day one including a function that adds the year only outside the current one.
- A live readout of the model's derived values: value, labels, current and prior ranges, `anchorDay`, `anchorDate`, `today`, and the range filter.
- A grid filtered by `currentRangeFilter`, with current vs. prior stats.
- Variants: a stretched trigger in a narrow host, a single-tab period picker, and app-defined fiscal-year presets (`fytd`, `prevFy`) with an outlined trigger.
- `wrapperOption` gains `alignTop` for a control that stacks several inputs.

Requires the hoist-react branch with `desktop/cmp/daterange` (88.0.0-SNAPSHOT line). Type-checks against a local hoist-react checkout via the `paths` override in `client-app/tsconfig.json`, which is left commented out as usual.

hoist-react PR: https://github.com/xh/hoist-react/pull/4648
