### PR TITLE
DateRangePicker demo: anchorDay, businessDayMode, prev* presets

### DIFF
--- a/client-app/src/desktop/common/Wrapper.scss
+++ b/client-app/src/desktop/common/Wrapper.scss
@@ -148,6 +148,17 @@
     min-height: 26px;
   }
 
+  // Label centered against the first of a stack of inputs, rather than the whole stack.
+  &__option-row--top {
+    align-items: flex-start;
+
+    .tbox-wrapper__option-label {
+      display: grid;
+      align-items: center;
+      min-height: 30px;
+    }
+  }
+
   &__option-label {
     flex: 1;
     min-width: 0;

--- a/client-app/src/desktop/common/Wrapper.ts
+++ b/client-app/src/desktop/common/Wrapper.ts
@@ -6,6 +6,7 @@ import {panel} from '@xh/hoist/desktop/cmp/panel';
 import {Icon} from '@xh/hoist/icon';
 import {bindable, makeObservable} from '@xh/hoist/mobx';
 import {isArray, isEmpty} from 'lodash';
+import classNames from 'classnames';
 import {ReactElement, ReactNode} from 'react';
 import {toolboxLink, ToolboxLinkProps} from '../../core/cmp/ToolboxLink';
 import './Wrapper.scss';
@@ -172,6 +173,11 @@ interface WrapperOptionProps extends HoistProps {
      * Use to describe what the option does or why a developer might reach for it.
      */
     info?: ReactNode;
+    /**
+     * True to align the label with the top of the control rather than its vertical center - for a
+     * control that stacks several inputs, so the label sits beside the first of them.
+     */
+    alignTop?: boolean;
 }
 
 /**
@@ -182,14 +188,17 @@ interface WrapperOptionProps extends HoistProps {
  */
 export const [WrapperOption, wrapperOption] = hoistCmp.withFactory<WrapperOptionProps>({
     displayName: 'WrapperOption',
-    render({label, control, propName, info}) {
+    render({label, control, propName, info, alignTop}) {
         return div({
             className: 'tbox-wrapper__option',
             // Native tooltip with the full property name - useful when the revealed pill ellipsizes.
             title: propName,
             items: [
                 div({
-                    className: 'tbox-wrapper__option-row',
+                    className: classNames(
+                        'tbox-wrapper__option-row',
+                        alignTop && 'tbox-wrapper__option-row--top'
+                    ),
                     items: [
                         div({
                             className: 'tbox-wrapper__option-label',

--- a/client-app/src/desktop/common/grid/SampleGridModel.ts
+++ b/client-app/src/desktop/common/grid/SampleGridModel.ts
@@ -120,13 +120,12 @@ export class SampleGridModel extends HoistModel {
             levelLabels: () => {
                 return [...this.groupingChooserModel.valueDisplayNames, 'Company'];
             },
-            groupSortFn: (a, b, groupField) => {
-                if (a === b) return 0;
+            groupSortFn: (a, b, groupField, {gridModel}) => {
                 if (groupField === 'winLose') {
+                    if (a === b) return 0;
                     return a === 'Winner' ? -1 : 1;
-                } else {
-                    return a < b ? -1 : 1;
                 }
+                return gridModel.defaultGroupSortFn(a, b);
             },
             restoreDefaultsFn: () => this.restoreDefaultsFn(),
             colDefaults: {
@@ -210,8 +209,9 @@ export class SampleGridModel extends HoistModel {
             allowEmpty: true,
             commitOnChange: true,
             dimensions: [
-                {name: 'city', displayName: 'City'},
-                {name: 'winLose', displayName: 'Win/Lose'}
+                {name: 'city'},
+                {name: 'winLose', displayName: 'Win/Lose'},
+                {name: 'trade_date'}
             ],
             initialValue: []
         });

--- a/client-app/src/desktop/tabs/forms/DateRangePickerPanel.ts
+++ b/client-app/src/desktop/tabs/forms/DateRangePickerPanel.ts
@@ -428,7 +428,7 @@ class DateRangePickerPanelModel extends HoistModel {
 
         this.fiscalPickerModel = new DateRangePickerModel({
             tabs: ['presets', 'custom'],
-            presets: [FISCAL_YTD, LAST_FISCAL_YEAR, 'qtd', 'ytd', 'prev90Days'],
+            presets: [FISCAL_YTD, PREV_FISCAL_YEAR, 'qtd', 'ytd', 'prev90Days'],
             initialValue: 'fytd'
         });
 
@@ -545,10 +545,10 @@ const FISCAL_YTD: DateRangePreset = {
     })
 };
 
-const LAST_FISCAL_YEAR: DateRangePreset = {
-    token: 'lastFy',
+const PREV_FISCAL_YEAR: DateRangePreset = {
+    token: 'prevFy',
     label: ({anchorDate}) => `FY${fiscalYearStart(anchorDate).format('YY')}`,
-    name: ({anchorDate}) => `Last Fiscal Year (FY${fiscalYearStart(anchorDate).format('YY')})`,
+    name: ({anchorDate}) => `Prev Fiscal Year (FY${fiscalYearStart(anchorDate).format('YY')})`,
     resolve: ({anchorDate}) => {
         const end = fiscalYearStart(anchorDate).previousDay();
         return {start: end.add(1, 'days').subtract(1, 'years'), end};

--- a/client-app/src/desktop/tabs/forms/DateRangePickerPanel.ts
+++ b/client-app/src/desktop/tabs/forms/DateRangePickerPanel.ts
@@ -34,12 +34,14 @@ export const dateRangePickerPanel = hoistCmp.factory({
             icon: Icon.calendarRange(),
             description: [
                 '`DateRangePicker` is a dropdown control for selecting a period of time - one compact',
-                'trigger that can express presets (MTD, Last 30 Days, ...), relative lookbacks, calendar',
+                'trigger that can express presets (MTD, Prev 30 Days, ...), relative lookbacks, calendar',
                 'months and years, and custom ranges of dates. Its popover offers a tab for each of those',
                 'selection shapes, and the backing model controls which tabs and presets appear.',
                 '',
                 'The applied value is a single `DateRangeSelection` - plain JSON that persists as-is and',
-                're-resolves as the anchor date moves, so a saved `mtd` stays month-to-date. The',
+                're-resolves as the anchor day moves, so a saved `mtd` stays month-to-date. The step',
+                'buttons (and arrow keys on the trigger) walk a preset or lookback back and forth',
+                'without changing what it is - stepped ranges keep rolling with the day. The',
                 '`DateRangePickerModel` resolves it to current and prior `LocalDateRange`s and to',
                 '`FieldFilterSpec`s ready to apply to a Store or query. The grid here is filtered by',
                 "the picker's `currentRangeFilter`, with the prior range summarized for comparison.",
@@ -141,13 +143,22 @@ export const dateRangePickerPanel = hoistCmp.factory({
                             control: switchInput({model: model.pickerModel, bind: 'commitOnChange'})
                         }),
                         wrapperOption({
-                            label: 'Anchor date',
-                            propName: 'DateRangePickerConfig.anchorDate',
-                            info: 'Relative and to-date selections resolve against this date.',
+                            label: 'Anchor day',
+                            propName: 'DateRangePickerConfig.anchorDay',
+                            info: 'Relative and to-date selections resolve against this day. Here a function returning this input, so it can be pinned to any date; apps typically leave the default - the live local day.',
                             control: dateInput({
                                 bind: 'anchorDate',
                                 valueType: 'localDate',
                                 width: 130
+                            })
+                        }),
+                        wrapperOption({
+                            label: 'Business day mode',
+                            propName: 'DateRangePickerConfig.businessDayMode',
+                            info: 'Single days step by business day (weekdays less a few fixed holidays here). Multi-day ranges are unaffected.',
+                            control: switchInput({
+                                model: model.pickerModel,
+                                bind: 'businessDayMode'
                             })
                         }),
                         wrapperOption({
@@ -249,6 +260,7 @@ const readout = hoistCmp.factory<DateRangePickerPanelModel>(({model}) => {
             readoutRow({label: 'currentRange', value: fmtRange(m.currentRange)}),
             readoutRow({label: 'priorRange', value: fmtRange(m.priorRange)}),
             readoutRow({label: 'anchorDate', value: m.anchorDate.isoString}),
+            readoutRow({label: 'today', value: m.today.isoString}),
             readoutRow({
                 label: 'currentRangeFilter',
                 value: JSON.stringify(m.currentRangeFilter)
@@ -363,9 +375,9 @@ class DateRangePickerPanelModel extends HoistModel {
 
         this.pickerModel = new DateRangePickerModel({
             // The anchor input can be cleared - the model requires a date, so fall back to today.
-            anchorDate: () => this.anchorDate ?? LocalDate.today(),
+            anchorDay: () => this.anchorDate ?? LocalDate.today(),
             filterField: 'date',
-            // Weekdays less a few fixed-date holidays - drives the `lastBusinessDay` preset.
+            // Weekdays less a few fixed-date holidays - the calendar behind `businessDayMode`.
             isBusinessDay: d => d.isWeekday && !FIXED_HOLIDAYS.includes(d.format('MM-DD')),
             persistWith: {localStorageKey: 'toolboxDateRangePicker'}
         });
@@ -377,7 +389,7 @@ class DateRangePickerPanelModel extends HoistModel {
 
         this.fiscalPickerModel = new DateRangePickerModel({
             tabs: ['presets', 'custom'],
-            presets: [FISCAL_YTD, LAST_FISCAL_YEAR, 'qtd', 'ytd', 'last90Days'],
+            presets: [FISCAL_YTD, LAST_FISCAL_YEAR, 'qtd', 'ytd', 'prev90Days'],
             initialValue: 'fytd'
         });
 

--- a/client-app/src/desktop/tabs/forms/DateRangePickerPanel.ts
+++ b/client-app/src/desktop/tabs/forms/DateRangePickerPanel.ts
@@ -6,6 +6,7 @@ import {
     DATE_RANGE_PICKER_TABS,
     DATE_RANGE_PRESET_TOKENS,
     dateRangePicker,
+    type DateRangeFormat,
     DateRangePickerModel,
     type DateRangePickerTab,
     type DateRangePreset,
@@ -188,11 +189,23 @@ export const dateRangePickerPanel = hoistCmp.factory({
                         wrapperOption({
                             label: 'Date format',
                             propName: 'DateRangePickerConfig.dateFormat',
+                            info: 'For the two ends of a range.',
                             control: select({
                                 bind: 'dateFormat',
                                 enableFilter: false,
-                                width: 140,
-                                options: ['YYYY-MM-DD', 'MM/DD/YYYY', 'DD MMM YYYY', 'ddd, MMM D']
+                                width: 150,
+                                options: ['YYYY-MM-DD', 'MM/DD/YYYY', 'DD MMM YYYY']
+                            })
+                        }),
+                        wrapperOption({
+                            label: 'Day format',
+                            propName: 'DateRangePickerConfig.dayFormat',
+                            info: 'For a single day, and the anchor date in the footer. The last option is a function that adds the year only outside the current one.',
+                            control: select({
+                                bind: 'dayFormat',
+                                enableFilter: false,
+                                width: 150,
+                                options: Object.keys(DAY_FORMATS)
                             })
                         })
                     ]
@@ -368,6 +381,7 @@ class DateRangePickerPanelModel extends HoistModel {
     @bindable.ref anchorDate: LocalDate = LocalDate.today();
     @bindable allowFutureDates = false;
     @bindable dateFormat = 'YYYY-MM-DD';
+    @bindable dayFormat: keyof typeof DAY_FORMATS = 'ddd MMM D';
 
     /** Record counts and totals within the current and prior ranges, across all loaded data. */
     @computed
@@ -462,6 +476,10 @@ class DateRangePickerPanelModel extends HoistModel {
             },
             {track: () => this.dateFormat, run: fmt => (this.pickerModel.dateFormat = fmt)},
             {
+                track: () => this.dayFormat,
+                run: key => (this.pickerModel.dayFormat = DAY_FORMATS[key])
+            },
+            {
                 // The pinned date input can be cleared - the model requires a date, so fall back
                 // to today until one is entered.
                 track: () => [this.anchorMode, this.anchorDate],
@@ -484,6 +502,17 @@ class DateRangePickerPanelModel extends HoistModel {
         );
     }
 }
+
+/** Day formats offered by the demo - strings, plus a function that adds the year only when needed. */
+const DAY_FORMATS: Record<string, DateRangeFormat> = {
+    'ddd MMM D': 'ddd MMM D',
+    'ddd MMM D, YYYY': 'ddd MMM D, YYYY',
+    'YYYY-MM-DD': 'YYYY-MM-DD',
+    'Year if not current': d =>
+        d.format(
+            d.moment.year() === LocalDate.today().moment.year() ? 'ddd MMM D' : 'ddd MMM D, YYYY'
+        )
+};
 
 /** New Year's Day, Independence Day, and Christmas - enough to show `isBusinessDay` in action. */
 const FIXED_HOLIDAYS = ['01-01', '07-04', '12-25'];

--- a/client-app/src/desktop/tabs/forms/DateRangePickerPanel.ts
+++ b/client-app/src/desktop/tabs/forms/DateRangePickerPanel.ts
@@ -146,21 +146,23 @@ export const dateRangePickerPanel = hoistCmp.factory({
                             label: 'Anchor day',
                             propName: 'DateRangePickerConfig.anchorDay',
                             info: 'Relative and to-date selections resolve against this day. The live modes follow the clock; a pinned date never moves.',
-                            control: hbox({
+                            control: vbox({
                                 gap: 6,
+                                alignItems: 'flex-start',
                                 items: [
                                     select({
                                         bind: 'anchorMode',
                                         enableFilter: false,
-                                        width: 110,
+                                        width: 130,
                                         options: [
                                             {value: 'localDay', label: "'localDay'"},
                                             {value: 'appDay', label: "'appDay'"},
                                             {value: 'pinned', label: 'LocalDate'}
                                         ]
                                     }),
+                                    // Always present so the option's height is stable.
                                     dateInput({
-                                        omit: model.anchorMode !== 'pinned',
+                                        disabled: model.anchorMode !== 'pinned',
                                         bind: 'anchorDate',
                                         valueType: 'localDate',
                                         width: 130

--- a/client-app/src/desktop/tabs/forms/DateRangePickerPanel.ts
+++ b/client-app/src/desktop/tabs/forms/DateRangePickerPanel.ts
@@ -145,11 +145,27 @@ export const dateRangePickerPanel = hoistCmp.factory({
                         wrapperOption({
                             label: 'Anchor day',
                             propName: 'DateRangePickerConfig.anchorDay',
-                            info: 'Relative and to-date selections resolve against this day. Here a function returning this input, so it can be pinned to any date; apps typically leave the default - the live local day.',
-                            control: dateInput({
-                                bind: 'anchorDate',
-                                valueType: 'localDate',
-                                width: 130
+                            info: 'Relative and to-date selections resolve against this day. The live modes follow the clock; a pinned date never moves.',
+                            control: hbox({
+                                gap: 6,
+                                items: [
+                                    select({
+                                        bind: 'anchorMode',
+                                        enableFilter: false,
+                                        width: 110,
+                                        options: [
+                                            {value: 'localDay', label: "'localDay'"},
+                                            {value: 'appDay', label: "'appDay'"},
+                                            {value: 'pinned', label: 'LocalDate'}
+                                        ]
+                                    }),
+                                    dateInput({
+                                        omit: model.anchorMode !== 'pinned',
+                                        bind: 'anchorDate',
+                                        valueType: 'localDate',
+                                        width: 130
+                                    })
+                                ]
                             })
                         }),
                         wrapperOption({
@@ -259,6 +275,7 @@ const readout = hoistCmp.factory<DateRangePickerPanelModel>(({model}) => {
             readoutRow({label: 'displayName', value: m.displayName}),
             readoutRow({label: 'currentRange', value: fmtRange(m.currentRange)}),
             readoutRow({label: 'priorRange', value: fmtRange(m.priorRange)}),
+            readoutRow({label: 'anchorDay', value: JSON.stringify(m.anchorDay)}),
             readoutRow({label: 'anchorDate', value: m.anchorDate.isoString}),
             readoutRow({label: 'today', value: m.today.isoString}),
             readoutRow({
@@ -347,6 +364,7 @@ class DateRangePickerPanelModel extends HoistModel {
     // Model options
     @bindable.ref tabs: DateRangePickerTab[] = [...DATE_RANGE_PICKER_TABS];
     @bindable.ref presets: DateRangePresetToken[] = [...DEFAULT_DATE_RANGE_PRESETS];
+    @bindable anchorMode: 'localDay' | 'appDay' | 'pinned' = 'localDay';
     @bindable.ref anchorDate: LocalDate = LocalDate.today();
     @bindable allowFutureDates = false;
     @bindable dateFormat = 'YYYY-MM-DD';
@@ -374,8 +392,6 @@ class DateRangePickerPanelModel extends HoistModel {
         makeObservable(this);
 
         this.pickerModel = new DateRangePickerModel({
-            // The anchor input can be cleared - the model requires a date, so fall back to today.
-            anchorDay: () => this.anchorDate ?? LocalDate.today(),
             filterField: 'date',
             // Weekdays less a few fixed-date holidays - the calendar behind `businessDayMode`.
             isBusinessDay: d => d.isWeekday && !FIXED_HOLIDAYS.includes(d.format('MM-DD')),
@@ -435,11 +451,22 @@ class DateRangePickerPanelModel extends HoistModel {
             {track: () => this.presets, run: presets => this.pickerModel.setPresets(presets)},
             {track: () => this.dateFormat, run: fmt => (this.pickerModel.dateFormat = fmt)},
             {
-                track: () => [this.allowFutureDates, this.anchorDate],
+                // The pinned date input can be cleared - the model requires a date, so fall back
+                // to today until one is entered.
+                track: () => [this.anchorMode, this.anchorDate],
                 run: () => {
-                    const {allowFutureDates, anchorDate} = this;
-                    this.pickerModel.setMaxDate(
-                        allowFutureDates ? anchorDate.add(1, 'years') : null
+                    const {anchorMode, anchorDate} = this;
+                    this.pickerModel.setAnchorDay(
+                        anchorMode === 'pinned' ? (anchorDate ?? LocalDate.today()) : anchorMode
+                    );
+                }
+            },
+            {
+                track: () => [this.allowFutureDates, this.pickerModel.anchorDate],
+                run: () => {
+                    const {allowFutureDates, pickerModel} = this;
+                    pickerModel.setMaxDate(
+                        allowFutureDates ? pickerModel.anchorDate.add(1, 'years') : null
                     );
                 }
             }

--- a/client-app/src/desktop/tabs/forms/DateRangePickerPanel.ts
+++ b/client-app/src/desktop/tabs/forms/DateRangePickerPanel.ts
@@ -145,6 +145,7 @@ export const dateRangePickerPanel = hoistCmp.factory({
                         wrapperOption({
                             label: 'Anchor day',
                             propName: 'DateRangePickerConfig.anchorDay',
+                            alignTop: true,
                             info: 'Relative and to-date selections resolve against this day. The live modes follow the clock; a pinned date never moves.',
                             control: vbox({
                                 gap: 6,

--- a/client-app/src/desktop/tabs/forms/DateRangePickerPanel.ts
+++ b/client-app/src/desktop/tabs/forms/DateRangePickerPanel.ts
@@ -377,7 +377,7 @@ class DateRangePickerPanelModel extends HoistModel {
     // Model options
     @bindable.ref tabs: DateRangePickerTab[] = [...DATE_RANGE_PICKER_TABS];
     @bindable.ref presets: DateRangePresetToken[] = [...DEFAULT_DATE_RANGE_PRESETS];
-    @bindable anchorMode: 'localDay' | 'appDay' | 'pinned' = 'appDay';
+    @bindable anchorMode: 'localDay' | 'appDay' | 'pinned' = 'localDay';
     @bindable.ref anchorDate: LocalDate = LocalDate.today();
     @bindable allowFutureDates = false;
     @bindable dateFormat = 'YYYY-MM-DD';
@@ -474,10 +474,17 @@ class DateRangePickerPanelModel extends HoistModel {
                         sortBy(presets, it => DATE_RANGE_PRESET_TOKENS.indexOf(it))
                     )
             },
-            {track: () => this.dateFormat, run: fmt => (this.pickerModel.dateFormat = fmt)},
+            // These options have their own defaults on this model - apply them at once, so the
+            // picker starts where the options say rather than at its own defaults.
+            {
+                track: () => this.dateFormat,
+                run: fmt => (this.pickerModel.dateFormat = fmt),
+                fireImmediately: true
+            },
             {
                 track: () => this.dayFormat,
-                run: key => (this.pickerModel.dayFormat = DAY_FORMATS[key])
+                run: key => (this.pickerModel.dayFormat = DAY_FORMATS[key]),
+                fireImmediately: true
             },
             {
                 // The pinned date input can be cleared - the model requires a date, so fall back
@@ -488,7 +495,8 @@ class DateRangePickerPanelModel extends HoistModel {
                     this.pickerModel.setAnchorDay(
                         anchorMode === 'pinned' ? (anchorDate ?? LocalDate.today()) : anchorMode
                     );
-                }
+                },
+                fireImmediately: true
             },
             {
                 track: () => [this.allowFutureDates, this.pickerModel.anchorDate],

--- a/client-app/src/desktop/tabs/forms/DateRangePickerPanel.ts
+++ b/client-app/src/desktop/tabs/forms/DateRangePickerPanel.ts
@@ -160,9 +160,8 @@ export const dateRangePickerPanel = hoistCmp.factory({
                                             {value: 'pinned', label: 'LocalDate'}
                                         ]
                                     }),
-                                    // Always present so the option's height is stable.
                                     dateInput({
-                                        disabled: model.anchorMode !== 'pinned',
+                                        omit: model.anchorMode !== 'pinned',
                                         bind: 'anchorDate',
                                         valueType: 'localDate',
                                         width: 130

--- a/client-app/src/desktop/tabs/forms/DateRangePickerPanel.ts
+++ b/client-app/src/desktop/tabs/forms/DateRangePickerPanel.ts
@@ -228,8 +228,6 @@ const mainToolbar = hoistCmp.factory<DateRangePickerPanelModel>(({model}) => {
             footerNote: model.showFooterNote ? undefined : null,
             testId: 'drp'
         }),
-        toolbarSep(),
-        span({className: 'tb-drp-panel__title', item: pickerModel.displayName}),
         filler(),
         statBlock({label: 'Current', stat: stats.current}),
         toolbarSep(),

--- a/client-app/src/desktop/tabs/forms/DateRangePickerPanel.ts
+++ b/client-app/src/desktop/tabs/forms/DateRangePickerPanel.ts
@@ -192,7 +192,7 @@ export const dateRangePickerPanel = hoistCmp.factory({
                                 bind: 'dateFormat',
                                 enableFilter: false,
                                 width: 140,
-                                options: ['YYYY-MM-DD', 'MM/DD/YYYY', 'DD MMM YYYY']
+                                options: ['YYYY-MM-DD', 'MM/DD/YYYY', 'DD MMM YYYY', 'ddd, MMM D']
                             })
                         })
                     ]
@@ -364,7 +364,7 @@ class DateRangePickerPanelModel extends HoistModel {
     // Model options
     @bindable.ref tabs: DateRangePickerTab[] = [...DATE_RANGE_PICKER_TABS];
     @bindable.ref presets: DateRangePresetToken[] = [...DEFAULT_DATE_RANGE_PRESETS];
-    @bindable anchorMode: 'localDay' | 'appDay' | 'pinned' = 'localDay';
+    @bindable anchorMode: 'localDay' | 'appDay' | 'pinned' = 'appDay';
     @bindable.ref anchorDate: LocalDate = LocalDate.today();
     @bindable allowFutureDates = false;
     @bindable dateFormat = 'YYYY-MM-DD';

--- a/client-app/src/desktop/tabs/forms/DateRangePickerPanel.ts
+++ b/client-app/src/desktop/tabs/forms/DateRangePickerPanel.ts
@@ -381,7 +381,11 @@ class DateRangePickerPanelModel extends HoistModel {
 
     // Model options
     @bindable.ref tabs: DateRangePickerTab[] = [...DATE_RANGE_PICKER_TABS];
-    @bindable.ref presets: DateRangePresetToken[] = [...DEFAULT_DATE_RANGE_PRESETS];
+    // The defaults plus Prev Day, so the demo shows a single-day walk from both presets.
+    @bindable.ref presets: DateRangePresetToken[] = sortBy(
+        [...DEFAULT_DATE_RANGE_PRESETS, 'prevDay'],
+        it => DATE_RANGE_PRESET_TOKENS.indexOf(it)
+    );
     @bindable anchorMode: 'localDay' | 'appDay' | 'pinned' = 'localDay';
     @bindable.ref anchorDate: LocalDate = LocalDate.today();
     @bindable.ref maxDate: LocalDate = null;

--- a/client-app/src/desktop/tabs/forms/DateRangePickerPanel.ts
+++ b/client-app/src/desktop/tabs/forms/DateRangePickerPanel.ts
@@ -203,11 +203,11 @@ export const dateRangePickerPanel = hoistCmp.factory({
                             })
                         }),
                         wrapperOption({
-                            label: 'Day format',
-                            propName: 'DateRangePickerConfig.dayFormat',
+                            label: 'Single day format',
+                            propName: 'DateRangePickerConfig.singleDayFormat',
                             info: 'For a single day, and the anchor date in the footer. The last option is a function that adds the year only outside the current one.',
                             control: select({
-                                bind: 'dayFormat',
+                                bind: 'singleDayFormat',
                                 enableFilter: false,
                                 width: 150,
                                 options: Object.keys(DAY_FORMATS)
@@ -390,7 +390,7 @@ class DateRangePickerPanelModel extends HoistModel {
     @bindable.ref anchorDate: LocalDate = LocalDate.today();
     @bindable.ref maxDate: LocalDate = null;
     @bindable dateFormat = 'YYYY-MM-DD';
-    @bindable dayFormat: keyof typeof DAY_FORMATS = 'ddd MMM D';
+    @bindable singleDayFormat: keyof typeof DAY_FORMATS = 'ddd MMM D';
 
     /** Record counts and totals within the current and prior ranges, across all loaded data. */
     @computed
@@ -491,8 +491,8 @@ class DateRangePickerPanelModel extends HoistModel {
                 fireImmediately: true
             },
             {
-                track: () => this.dayFormat,
-                run: key => (this.pickerModel.dayFormat = DAY_FORMATS[key]),
+                track: () => this.singleDayFormat,
+                run: key => (this.pickerModel.singleDayFormat = DAY_FORMATS[key]),
                 fireImmediately: true
             },
             {

--- a/client-app/src/desktop/tabs/forms/DateRangePickerPanel.ts
+++ b/client-app/src/desktop/tabs/forms/DateRangePickerPanel.ts
@@ -181,10 +181,15 @@ export const dateRangePickerPanel = hoistCmp.factory({
                             })
                         }),
                         wrapperOption({
-                            label: 'Allow future dates',
+                            label: 'Max date',
                             propName: 'DateRangePickerConfig.maxDate',
-                            info: 'Sets maxDate one year past the anchor. Off, nothing beyond the anchor is selectable.',
-                            control: switchInput({bind: 'allowFutureDates'})
+                            info: 'Latest selectable date. Empty, it is the anchor date, so nothing in the future is selectable.',
+                            control: dateInput({
+                                bind: 'maxDate',
+                                valueType: 'localDate',
+                                enableClear: true,
+                                width: 130
+                            })
                         }),
                         wrapperOption({
                             label: 'Date format',
@@ -330,7 +335,7 @@ const variants = hoistCmp.factory<DateRangePickerPanelModel>(({model}) =>
             }),
             variantRow({
                 label: 'Single tab - months and years only',
-                info: "tabs: ['monthYear'] - no rail, and the popover shrinks to fit.",
+                info: "tabs: ['period'] - no rail, and the popover shrinks to fit.",
                 item: dateRangePicker({model: model.monthPickerModel, testId: 'drp-month'})
             }),
             variantRow({
@@ -379,7 +384,7 @@ class DateRangePickerPanelModel extends HoistModel {
     @bindable.ref presets: DateRangePresetToken[] = [...DEFAULT_DATE_RANGE_PRESETS];
     @bindable anchorMode: 'localDay' | 'appDay' | 'pinned' = 'localDay';
     @bindable.ref anchorDate: LocalDate = LocalDate.today();
-    @bindable allowFutureDates = false;
+    @bindable.ref maxDate: LocalDate = null;
     @bindable dateFormat = 'YYYY-MM-DD';
     @bindable dayFormat: keyof typeof DAY_FORMATS = 'ddd MMM D';
 
@@ -413,7 +418,7 @@ class DateRangePickerPanelModel extends HoistModel {
         });
 
         this.monthPickerModel = new DateRangePickerModel({
-            tabs: ['monthYear'],
+            tabs: ['period'],
             initialValue: {kind: 'month', year: LocalDate.today().moment.year(), month: 1}
         });
 
@@ -498,15 +503,7 @@ class DateRangePickerPanelModel extends HoistModel {
                 },
                 fireImmediately: true
             },
-            {
-                track: () => [this.allowFutureDates, this.pickerModel.anchorDate],
-                run: () => {
-                    const {allowFutureDates, pickerModel} = this;
-                    pickerModel.setMaxDate(
-                        allowFutureDates ? pickerModel.anchorDate.add(1, 'years') : null
-                    );
-                }
-            }
+            {track: () => this.maxDate, run: maxDate => this.pickerModel.setMaxDate(maxDate)}
         );
     }
 }

--- a/client-app/src/desktop/tabs/forms/DateRangePickerPanel.ts
+++ b/client-app/src/desktop/tabs/forms/DateRangePickerPanel.ts
@@ -447,7 +447,11 @@ class DateRangePickerPanelModel extends HoistModel {
                 // selected again, as the model requires at least one.
                 track: () => this.tabs,
                 run: tabs => {
-                    if (!isEmpty(tabs)) this.pickerModel.setTabs(tabs);
+                    if (isEmpty(tabs)) return;
+                    // As with presets below - catalog order, not pick order.
+                    this.pickerModel.setTabs(
+                        sortBy(tabs, it => DATE_RANGE_PICKER_TABS.indexOf(it))
+                    );
                 }
             },
             {

--- a/client-app/src/desktop/tabs/forms/DateRangePickerPanel.ts
+++ b/client-app/src/desktop/tabs/forms/DateRangePickerPanel.ts
@@ -20,7 +20,7 @@ import {fmtNumber} from '@xh/hoist/format';
 import {Icon} from '@xh/hoist/icon';
 import {bindable, computed, makeObservable} from '@xh/hoist/mobx';
 import {LocalDate} from '@xh/hoist/utils/datetime';
-import {isEmpty} from 'lodash';
+import {isEmpty, sortBy} from 'lodash';
 import {wrapper, wrapperOption, wrapperOptionGroup} from '../../common';
 import './DateRangePickerPanel.scss';
 
@@ -450,7 +450,14 @@ class DateRangePickerPanelModel extends HoistModel {
                     if (!isEmpty(tabs)) this.pickerModel.setTabs(tabs);
                 }
             },
-            {track: () => this.presets, run: presets => this.pickerModel.setPresets(presets)},
+            {
+                // The picker appends in pick order - present presets in their catalog order instead.
+                track: () => this.presets,
+                run: presets =>
+                    this.pickerModel.setPresets(
+                        sortBy(presets, it => DATE_RANGE_PRESET_TOKENS.indexOf(it))
+                    )
+            },
             {track: () => this.dateFormat, run: fmt => (this.pickerModel.dateFormat = fmt)},
             {
                 // The pinned date input can be cleared - the model requires a date, so fall back

--- a/client-app/src/desktop/tabs/grids/ZoneGridPanel.ts
+++ b/client-app/src/desktop/tabs/grids/ZoneGridPanel.ts
@@ -95,13 +95,12 @@ class ZoneGridPanelModel extends HoistModel {
                 ? ['City', 'Win/Lose', 'Company']
                 : ['Win/Lose', 'City', 'Company'];
         },
-        groupSortFn: (a, b, groupField) => {
-            if (a === b) return 0;
+        groupSortFn: (a, b, groupField, {gridModel}) => {
             if (groupField === 'winLose') {
+                if (a === b) return 0;
                 return a === 'Winner' ? -1 : 1;
-            } else {
-                return a < b ? -1 : 1;
             }
+            return gridModel.defaultGroupSortFn(a, b);
         },
         restoreDefaultsFn: () => this.restoreDefaultsFn(),
         columns: [


### PR DESCRIPTION
Companion to hoist-react #4653 (https://github.com/xh/hoist-react/pull/4653), stacked on #897.

- `anchorDate` config becomes `anchorDay`; presets renamed (`last90Days` -> `prev90Days`); tab id `period`; `singleDayFormat`.
- Anchor day option is a select over `'localDay'`, `'appDay'`, and a pinned `LocalDate`, with the date input shown only for the last.
- Business day mode switch, and a Max date input bound directly to `maxDate`.
- Date format and Single day format selects, the latter including a function that adds the year only outside the current one.
- `anchorDay` + `today` rows in the model readout; the redundant `displayName` toolbar span is dropped.
- Initial presets are the defaults plus `prevDay`; picked presets and tabs are ordered by catalog order rather than pick order.
- Option defaults are applied to the picker at construction, so the demo never starts out of sync.
- `wrapperOption` gains `alignTop` for a control that stacks several inputs.
