### PR TITLE
Migrate off APIs removed in hoist-react v88

### DIFF
--- a/client-app/src/admin/tests/columnFilters/store/StoreColumnFilterPanelModel.ts
+++ b/client-app/src/admin/tests/columnFilters/store/StoreColumnFilterPanelModel.ts
@@ -1,5 +1,5 @@
 import {FilterChooserModel} from '@xh/hoist/cmp/filter';
-import {boolCheckCol, ExcelFormat, GridModel, localDateCol} from '@xh/hoist/cmp/grid';
+import {boolCheck, ExcelFormat, GridModel, localDate} from '@xh/hoist/cmp/grid';
 import {HoistModel, managed, XH} from '@xh/hoist/core';
 import {CompoundFilter, FieldFilter} from '@xh/hoist/data';
 import {fmtNumberTooltip, millionsRenderer, numberRenderer} from '@xh/hoist/format';
@@ -86,7 +86,7 @@ export class StoreColumnFilterPanelModel extends HoistModel {
                 },
                 {
                     field: 'active',
-                    ...boolCheckCol,
+                    ...boolCheck,
                     headerName: '',
                     chooserName: 'Active Status',
                     tooltip: (active, {record}) =>
@@ -140,7 +140,7 @@ export class StoreColumnFilterPanelModel extends HoistModel {
                 },
                 {
                     field: 'trade_date',
-                    ...localDateCol,
+                    ...localDate,
                     width: 150
                 }
             ]

--- a/client-app/src/admin/tests/cube/CubeTestModel.ts
+++ b/client-app/src/admin/tests/cube/CubeTestModel.ts
@@ -1,5 +1,5 @@
 import {ChartModel} from '@xh/hoist/cmp/chart';
-import {GridModel, timeCol, TreeStyle} from '@xh/hoist/cmp/grid';
+import {GridModel, time, TreeStyle} from '@xh/hoist/cmp/grid';
 import {fragment} from '@xh/hoist/cmp/layout';
 import {HoistModel, managed, XH} from '@xh/hoist/core';
 import {numberEditor, textEditor} from '@xh/hoist/desktop/cmp/grid';
@@ -387,7 +387,7 @@ export class CubeTestModel extends HoistModel {
                 {
                     field: 'time',
                     editable: false,
-                    ...timeCol
+                    ...time
                 }
             ]
         });

--- a/client-app/src/core/columns/General.ts
+++ b/client-app/src/core/columns/General.ts
@@ -1,4 +1,4 @@
-import {boolCheckCol} from '@xh/hoist/cmp/grid';
+import {boolCheck} from '@xh/hoist/cmp/grid';
 import {ColumnSpec} from '@xh/hoist/cmp/grid';
 
 export const nameCol: ColumnSpec = {
@@ -9,7 +9,7 @@ export const nameCol: ColumnSpec = {
 };
 
 export const activeCol: ColumnSpec = {
-    ...boolCheckCol,
+    ...boolCheck,
     field: {name: 'active', type: 'bool'},
     headerName: '',
     chooserName: 'Active Status'

--- a/client-app/src/core/columns/Sales.ts
+++ b/client-app/src/core/columns/Sales.ts
@@ -1,4 +1,4 @@
-import {boolCheckCol} from '@xh/hoist/cmp/grid';
+import {boolCheck} from '@xh/hoist/cmp/grid';
 import {numberRenderer, percentRenderer} from '@xh/hoist/format';
 import {ColumnSpec} from '@xh/hoist/cmp/grid';
 
@@ -62,7 +62,7 @@ export const commissionCol: ColumnSpec = {
 };
 
 export const retainCol: ColumnSpec = {
-    ...boolCheckCol,
+    ...boolCheck,
     field: {name: 'retain', type: 'bool'},
     width: 70
 };

--- a/client-app/src/core/columns/Trades.ts
+++ b/client-app/src/core/columns/Trades.ts
@@ -1,4 +1,4 @@
-import {ExcelFormat, localDateCol, tags} from '@xh/hoist/cmp/grid';
+import {ExcelFormat, localDate, tags} from '@xh/hoist/cmp/grid';
 import {dateRenderer, millionsRenderer, numberRenderer, fmtNumberTooltip} from '@xh/hoist/format';
 import {ColumnSpec} from '@xh/hoist/cmp/grid';
 
@@ -47,7 +47,7 @@ export const tradeVolumeCol: ColumnSpec = {
 };
 
 export const tradeDateCol: ColumnSpec = {
-    ...localDateCol,
+    ...localDate,
     field: {
         name: 'trade_date',
         type: 'localDate',

--- a/client-app/src/desktop/tabs/grids/ExternalSortGridPanelModel.ts
+++ b/client-app/src/desktop/tabs/grids/ExternalSortGridPanelModel.ts
@@ -1,6 +1,6 @@
 import {XH, HoistModel, managed, LoadSpec, PlainObject} from '@xh/hoist/core';
 import {bindable, makeObservable} from '@xh/hoist/mobx';
-import {GridModel, localDateCol, ExcelFormat} from '@xh/hoist/cmp/grid';
+import {GridModel, localDate, ExcelFormat} from '@xh/hoist/cmp/grid';
 import {fmtNumberTooltip, millionsRenderer, numberRenderer} from '@xh/hoist/format';
 
 export class ExternalSortGridPanelModel extends HoistModel {
@@ -107,7 +107,7 @@ export class ExternalSortGridPanelModel extends HoistModel {
                         displayName: 'Date',
                         description: 'Date of last trade (including related derivatives)'
                     },
-                    ...localDateCol,
+                    ...localDate,
                     width: 150
                 }
             ]

--- a/client-app/src/desktop/tabs/grids/InlineEditingPanelModel.ts
+++ b/client-app/src/desktop/tabs/grids/InlineEditingPanelModel.ts
@@ -1,4 +1,4 @@
-import {checkboxRenderer, GridModel, localDateCol} from '@xh/hoist/cmp/grid';
+import {checkboxRenderer, GridModel, localDate} from '@xh/hoist/cmp/grid';
 import {HoistModel, managed, XH} from '@xh/hoist/core';
 import {dateIs, lengthIs, numberIs, required, Store, StoreRecord} from '@xh/hoist/data';
 import {
@@ -355,7 +355,7 @@ export class InlineEditingPanelModel extends HoistModel {
                 },
                 {
                     field: 'date',
-                    ...localDateCol,
+                    ...localDate,
                     editable: ifNotRestricted,
                     editor: props =>
                         dateEditor({

--- a/client-app/src/desktop/tabs/grids/RestGridPanel.ts
+++ b/client-app/src/desktop/tabs/grids/RestGridPanel.ts
@@ -11,7 +11,8 @@ import {
     RestGridConfig,
     viewAction
 } from '@xh/hoist/desktop/cmp/rest';
-import {boolCheckCol, ExcelFormat, numberCol} from '@xh/hoist/cmp/grid';
+import * as Col from '@xh/hoist/cmp/grid/columns';
+import {ExcelFormat} from '@xh/hoist/cmp/grid';
 import {wrapper} from '../../common';
 import {numberInput, switchInput, textArea} from '@xh/hoist/desktop/cmp/input';
 
@@ -122,12 +123,12 @@ const modelSpec: RestGridConfig = {
         },
         {
             field: 'employees',
-            ...numberCol,
+            ...Col.number,
             width: 120
         },
         {
             field: 'isActive',
-            ...boolCheckCol,
+            ...Col.boolCheck,
             width: 100
         },
         {

--- a/client-app/src/desktop/tabs/home/widgets/activity/ActivityWidgetModel.ts
+++ b/client-app/src/desktop/tabs/home/widgets/activity/ActivityWidgetModel.ts
@@ -1,6 +1,6 @@
 import {GridModel} from '@xh/hoist/cmp/grid';
 import {span, div, vbox, p} from '@xh/hoist/cmp/layout';
-import {dateTimeCol, localDateCol} from '@xh/hoist/cmp/grid/columns/DatesTimes';
+import {dateTime, localDate} from '@xh/hoist/cmp/grid/columns/DatesTimes';
 import {lookup, managed, HoistModel, XH} from '@xh/hoist/core';
 import {DashViewModel} from '@xh/hoist/desktop/cmp/dash';
 import {actionCol, calcActionColWidth} from '@xh/hoist/desktop/cmp/grid/columns/Actions';
@@ -154,13 +154,13 @@ export class ActivityWidgetModel extends HoistModel implements RepoFilterModel {
                     width: 60
                 },
                 {
-                    ...localDateCol,
+                    ...localDate,
                     field: 'committedDay',
                     filterable: true,
                     hidden: true
                 },
                 {
-                    ...dateTimeCol,
+                    ...dateTime,
                     field: 'committedDate',
                     filterable: true
                 },

--- a/client-app/src/examples/filemanager/FileManagerModel.ts
+++ b/client-app/src/examples/filemanager/FileManagerModel.ts
@@ -1,5 +1,5 @@
 import {HoistModel, managed, XH} from '@xh/hoist/core';
-import {fileExtCol, GridModel} from '@xh/hoist/cmp/grid';
+import {fileExt, GridModel} from '@xh/hoist/cmp/grid';
 import {actionCol, calcActionColWidth} from '@xh/hoist/desktop/cmp/grid';
 import {computed, makeObservable} from '@xh/hoist/mobx';
 import {Icon} from '@xh/hoist/icon';
@@ -47,7 +47,7 @@ export class FileManagerModel extends HoistModel {
             {
                 colId: 'icon',
                 field: 'name',
-                ...fileExtCol
+                ...fileExt
             },
             {field: 'name', flex: 1},
             {
@@ -178,11 +178,10 @@ export class FileManagerModel extends HoistModel {
             .run(async ctx => {
                 const sel = this.gridModel.selectedRecord,
                     {name} = sel.data,
-                    response = await XH.fetch({
-                        url: 'fileManager/download',
-                        params: {filename: name},
-                        span: ctx.span
-                    });
+                    response = await XH.fetch(
+                        {url: 'fileManager/download', params: {filename: name}},
+                        {span: ctx.span}
+                    );
                 const blob = await response.blob();
                 downloadBlob(blob, name);
                 XH.toast({

--- a/client-app/src/examples/recalls/RecallsPanelModel.ts
+++ b/client-app/src/examples/recalls/RecallsPanelModel.ts
@@ -1,4 +1,4 @@
-import {GridModel, localDateCol} from '@xh/hoist/cmp/grid';
+import {GridModel, localDate} from '@xh/hoist/cmp/grid';
 import {HoistModel, LoadSpec, managed, persist, XH} from '@xh/hoist/core';
 import {compactDateRenderer} from '@xh/hoist/format';
 import {Icon} from '@xh/hoist/icon/Icon';
@@ -72,7 +72,7 @@ export class RecallsPanelModel extends HoistModel {
             },
             {
                 field: 'recallDate',
-                ...localDateCol,
+                ...localDate,
                 headerName: 'Date',
                 width: 100,
                 renderer: compactDateRenderer()

--- a/client-app/src/examples/todo/TodoPanelModel.ts
+++ b/client-app/src/examples/todo/TodoPanelModel.ts
@@ -1,4 +1,4 @@
-import {GridModel, localDateCol} from '@xh/hoist/cmp/grid';
+import {GridModel, localDate} from '@xh/hoist/cmp/grid';
 import {HoistModel, managed, persist, SizingMode, XH} from '@xh/hoist/core';
 import {RecordAction} from '@xh/hoist/data';
 import {actionCol} from '@xh/hoist/desktop/cmp/grid';
@@ -246,7 +246,7 @@ export class TodoPanelModel extends HoistModel {
                 },
                 {
                     field: 'dueDate',
-                    ...localDateCol,
+                    ...localDate,
                     width: 140,
                     rendererIsComplex: true,
                     renderer: (v, {record}) => this.dueDateRenderer(v, {record})


### PR DESCRIPTION
Companion to [xh/hoist-react#4679](https://github.com/xh/hoist-react/pull/4679), which removes hoist-react deprecations whose target version has been reached.

**This can merge ahead of the library PR** - every replacement API already exists in the published `88.0.0-SNAPSHOT`, so the branch typechecks against both that and the hoist-react branch.

### Changes

* **`Col`-suffixed column spec aliases → un-suffixed equivalents** (`localDateCol` → `localDate`, `boolCheckCol` → `boolCheck`, `dateTimeCol` → `dateTime`, `timeCol` → `time`, `fileExtCol` → `fileExt`, `numberCol` → `number`). 27 occurrences across 12 files. These were deprecated by code comment back in the 2022 TypeScript rewrite.
  * `RestGridPanel` moves to the `import * as Col from '@xh/hoist/cmp/grid/columns'` namespace convention already used in the Hoist Admin Console - `Col.number` reads better than a bare `number` in a column spec list. (A value named `number` does not actually shadow the `number` type; this is style, not necessity.)
* **`FileManagerModel` passed `span` as a `FetchOptions` field**, removed in v88. It now passes a `CallContextLike` as `XH.fetch`'s second argument:
  ```ts
  // before
  await XH.fetch({url: 'fileManager/download', params: {filename: name}, span: ctx.span});
  // after
  await XH.fetch({url: 'fileManager/download', params: {filename: name}}, {span: ctx.span});
  ```

Nothing else in Toolbox touched the removed APIs - no usages of `HoistBase.withSpan()`, `PersistenceProvider.mergePersistOptions()`, `LogSource`, or `PopoverFilterChooser`, and every other `loadSpec` / `span` site already used the context second-arg form.

### No changelog entry

These are internal API migrations with no user-visible effect, and Toolbox's changelog is parsed at build time and surfaced in-app to developers and clients evaluating Hoist.

### Verification

`pnpm typecheck` and `pnpm lint` pass, run two ways:

1. **Against the hoist-react branch**, via the `paths` toggle in `client-app/tsconfig.json` (re-commented before committing, per the warning in that file - the diff does not touch it). Reverting just the `src` changes under that config produces 16 errors, including the `FetchOptions.span` one, so the check is genuinely exercising the removals.
2. **Against the published `88.0.0-SNAPSHOT`** in `node_modules`, which is what CI and the release build check.

Not exercised at runtime - every change is a mechanical rename apart from the `XH.fetch` call, which is type-checked against the same signature the runtime uses.

---
_Generated by [Claude Code](https://claude.ai/code/session_01SJfEZfW8WTE9uZsKe2GowK)_