### PR TITLE
Add MockDirectoryService, replacing the doLoadUsersForDirectoryGroups override

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,10 @@
 -->
 ## 11.0.0-SNAPSHOT - unreleased
 
+### Bug Fixes
+
+* Fixed the Admin Console Roles tab reporting "No enabled directory service in this application" for every assigned directory group, and returning no results from its group search. Toolbox's mock directory now backs those lookups via a new `MockDirectoryService`, alongside the group membership resolution it already provided.
+
 
 ## 10.0.1 - 2026-09-10
 

--- a/grails-app/services/io/xh/toolbox/user/MockDirectoryService.groovy
+++ b/grails-app/services/io/xh/toolbox/user/MockDirectoryService.groovy
@@ -1,0 +1,73 @@
+package io.xh.toolbox.user
+
+import io.xh.hoist.BaseService
+import io.xh.hoist.config.ConfigService
+import io.xh.hoist.directory.DirectoryService
+import io.xh.hoist.util.ErrorOr
+
+/**
+ * Mock {@link DirectoryService} for Toolbox, so that all group-related controls in the Admin
+ * Console Roles UI are live even when no real directory connection is configured.
+ *
+ * <p>Groups and their members come from a `mockDirectoryGroups` config, JSON formatted like:
+ * `{"testGroupName": ["user1@example.com", "user2@example.com"]}`. Any name not in that config
+ * resolves to an empty group, and the special name `sim_error` mocks a lookup failure.
+ *
+ * @see RoleService - selects this service when neither LdapService nor EntraIdService is enabled.
+ */
+class MockDirectoryService extends BaseService implements DirectoryService {
+
+    ConfigService configService
+
+    static clearCachesConfigs = ['mockDirectoryGroups']
+
+    boolean getEnabled() {
+        true
+    }
+
+    String getDirectoryGroupsDescription() {
+        'Search the mock directory, or enter any name to mock a group.'
+    }
+
+    Map<String, ErrorOr<Set<String>>> loadUsersForDirectoryGroups(Set<String> groups, boolean strictMode) {
+        groups.collectEntries { group ->
+            [group, simError(group) ?: ErrorOr.of((mockGroups[group] ?: []) as Set)]
+        }
+    }
+
+    Map<String, ErrorOr<Map>> describeDirectoryGroups(Set<String> groups) {
+        groups.collectEntries { group ->
+            [group, simError(group) ?: ErrorOr.of([displayName: group])]
+        }
+    }
+
+    List<Map> searchDirectoryGroups(String namePart) {
+        mockGroups.keySet()
+            .findAll { it.toLowerCase().contains(namePart.toLowerCase()) }
+            .collect { [id: it, displayName: it] }
+    }
+
+    Map getAdminStats() {[
+        config: configForAdminStats('mockDirectoryGroups'),
+        groupCount: mockGroups.size()
+    ]}
+
+    //------------------------
+    // Implementation
+    //------------------------
+    private Map<String, List<String>> getMockGroups() {
+        configService.getMap('mockDirectoryGroups', [:])
+    }
+
+    /**
+     * Mirror real DirectoryService behavior for a single group that fails to resolve - report the
+     * error as per-group data (in strict and non-strict modes alike, as with e.g. 'Directory Group
+     * not found'), rather than throwing and failing the lookup as a whole. Displays as a warning
+     * on the group within the Admin Console Roles UI.
+     */
+    private <T> ErrorOr<T> simError(String group) {
+        group == 'sim_error'
+            ? ErrorOr.error('There was a simulated error looking up this directory group.')
+            : null
+    }
+}

--- a/grails-app/services/io/xh/toolbox/user/RoleService.groovy
+++ b/grails-app/services/io/xh/toolbox/user/RoleService.groovy
@@ -1,7 +1,7 @@
 package io.xh.toolbox.user
 
+import io.xh.hoist.directory.DirectoryService
 import io.xh.hoist.role.provided.DefaultRoleService
-import io.xh.hoist.util.ErrorOr
 
 /**
  * Toolbox leverages Hoist's built-in, database-backed Role management and its associated Admin Console UI.
@@ -11,35 +11,16 @@ import io.xh.hoist.util.ErrorOr
  */
 class RoleService extends DefaultRoleService {
 
+    MockDirectoryService mockDirectoryService
+
     /**
-     * Toolbox does not currently connect to an external directory, but supports a `mockDirectoryGroups` config
-     * so we can simulate directory group lookups and see all group-related controls in the Admin Console Roles UI.
-     *
-     * Config should be JSON formatted like: `{"testGroupName": ["user1@example.com", "user2@example.com"]}`.
-     *
-     * This mock code also supports use of the special group name `sim_error` to mock a lookup failure.
+     * Use a real directory service when one is enabled - in particular EntraIdService against the
+     * XH Entra ID tenant, for which Toolbox is the framework testbed. Falls back to
+     * {@link MockDirectoryService} when no real directory connection is configured, so that group
+     * resolution, display names, and group search all stay live in the Admin Console Roles UI.
      */
-    protected Map<String, ErrorOr<Set<String>>> doLoadUsersForDirectoryGroups(Set<String> groups, boolean strictMode) {
-        // Delegate to a real directory service when one is enabled - in particular EntraIdService
-        // against the XH Entra ID tenant, for which Toolbox is the framework testbed. Falls back
-        // to the mock support below when no real directory connection is configured.
-        if (ldapService.enabled || entraIdService.enabled) {
-            return super.doLoadUsersForDirectoryGroups(groups, strictMode)
-        }
-
-        def config = configService.getMap('mockDirectoryGroups', [:])
-
-        return groups.collectEntries { group ->
-            if (config[group]) return [group, ErrorOr.of(config[group] as Set)]
-            if (group == 'sim_error') {
-                // Mirror real DirectoryService behavior for a single group that fails to
-                // resolve - report the error as per-group data (in strict and non-strict modes
-                // alike, as with e.g. 'Directory Group not found'), rather than throwing and
-                // failing the lookup as a whole. Displays as a warning on the group within the
-                // Admin Console Roles UI.
-                return [group, ErrorOr.error('There was a simulated error looking up this directory group.')]
-            }
-            return [group, ErrorOr.of([] as Set)]
-        }
+    protected DirectoryService getDirectoryService() {
+        def svc = super.getDirectoryService()
+        svc.enabled ? svc : mockDirectoryService
     }
 }


### PR DESCRIPTION
Companion to xh/hoist-core#602.

Toolbox mocked only directory group membership resolution, via a `doLoadUsersForDirectoryGroups` override. Group display names and group search went straight to the (disabled) real directory service, so the Admin Console Roles tab reported `No enabled directory service in this application` for every assigned group and returned nothing from its group picker.

The mock directory now sits behind the full `DirectoryService` contract instead - membership, display names, and search - in a new `MockDirectoryService`, still driven by the `mockDirectoryGroups` config and still honoring the `sim_error` name. `RoleService` selects it through hoist-core's `getDirectoryService` seam:

```groovy
protected DirectoryService getDirectoryService() {
    def svc = super.getDirectoryService()
    svc.enabled ? svc : mockDirectoryService
}
```

Delegating to `super` first keeps a real directory service in charge whenever one is enabled - in particular the Entra ID testbed path - and picks up the `directoryGroupProvider` config handling for free.

Requires the hoist-core PR: the `doLoadUsersForDirectoryGroups` extension point is gone there.
