### PR TITLE
Demo `Column.cellFlag` and a framed custom tooltip on the SampleGrid

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,10 @@
 -->
 ## 11.0.0-SNAPSHOT - unreleased
 
+### Technical
+
+* Updated the `SampleGrid` Volume column to demo hoist-react's new `Column.cellFlag` and a custom tooltip that explains the flag, replacing a hand-rolled cell class and the custom SCSS that styled it.
+
 
 ## 10.0.1 - 2026-09-10
 

--- a/client-app/src/core/Toolbox.scss
+++ b/client-app/src/core/Toolbox.scss
@@ -18,3 +18,10 @@ html {
     color-scheme: dark;
   }
 }
+
+// Spacing for the note line in the Volume column's custom tooltip. The tooltip's frame comes from
+// Hoist's own `xh-grid-tooltip-frame` - only this content layout is app-specific.
+.tb-flag-tooltip__note {
+  gap: var(--xh-pad-half-px);
+  margin-top: var(--xh-pad-half-px);
+}

--- a/client-app/src/core/columns/Trades.ts
+++ b/client-app/src/core/columns/Trades.ts
@@ -1,5 +1,7 @@
 import {ExcelFormat, localDateCol, tags} from '@xh/hoist/cmp/grid';
+import {hbox, vbox} from '@xh/hoist/cmp/layout';
 import {dateRenderer, millionsRenderer, numberRenderer, fmtNumberTooltip} from '@xh/hoist/format';
+import {Icon} from '@xh/hoist/icon';
 import {ColumnSpec} from '@xh/hoist/cmp/grid';
 
 export const profitLossCol: ColumnSpec = {
@@ -26,6 +28,11 @@ export const winLoseCol: ColumnSpec = {
     excludeFromChooser: true
 };
 
+// Demos Column.cellFlag - flags unusually high volume without disturbing the cell's contents.
+// A single predicate drives both the flag and its tooltip, so the two cannot drift apart.
+const HIGH_VOLUME = 9000000000,
+    isHighVolume = (volume: number) => volume >= HIGH_VOLUME;
+
 export const tradeVolumeCol: ColumnSpec = {
     field: {
         name: 'trade_volume',
@@ -35,14 +42,30 @@ export const tradeVolumeCol: ColumnSpec = {
     },
     width: 110,
     align: 'right',
-    tooltip: val => fmtNumberTooltip(val),
+    // Explains the flag. Hoist frames only string tooltips, so this custom element tooltip opts
+    // into the standard frame with `xh-grid-tooltip-frame`.
+    tooltip: volume =>
+        isHighVolume(volume)
+            ? vbox({
+                  className: 'xh-grid-tooltip-frame',
+                  items: [
+                      fmtNumberTooltip(volume),
+                      hbox({
+                          className: 'tb-flag-tooltip__note',
+                          alignItems: 'center',
+                          items: [
+                              Icon.warning({intent: 'warning'}),
+                              'Unusually high volume - review before trading.'
+                          ]
+                      })
+                  ]
+              })
+            : fmtNumberTooltip(volume),
     renderer: millionsRenderer({
         precision: 1,
         label: true
     }),
-    cellClassRules: {
-        'tb-sample-grid__high-volume-cell': ({value}) => value >= 9000000000
-    },
+    cellFlag: volume => (isHighVolume(volume) ? 'warning' : null),
     excelFormat: ExcelFormat.NUM_DELIMITED
 };
 

--- a/client-app/src/desktop/common/grid/SampleGrid.scss
+++ b/client-app/src/desktop/common/grid/SampleGrid.scss
@@ -10,15 +10,6 @@
       margin-right: 4px;
     }
   }
-
-  // To demo Column.cellClassRules
-  .ag-row:not(.ag-row-pinned) {
-    .tb-sample-grid__high-volume-cell {
-      color: var(--xh-intent-warning-text-color);
-      border-left: 4px solid var(--xh-intent-warning) !important;
-      border-right: 4px solid var(--xh-intent-warning) !important;
-    }
-  }
 }
 
 .tb-sample-grid-tooltip {

--- a/client-app/src/desktop/tabs/grids/StandardGridPanel.ts
+++ b/client-app/src/desktop/tabs/grids/StandardGridPanel.ts
@@ -48,6 +48,11 @@ export const standardGridPanel = hoistCmp.factory({
                     notes: 'Hoist-managed data classes, including Store and StoreRecord.'
                 },
                 {
+                    url: '$HR/cmp/grid/README.md#cell-corner-flags',
+                    text: 'Cell flag docs',
+                    notes: 'Config, precedence vs. validation, and the flag size CSS custom property.'
+                },
+                {
                     url: 'https://www.ag-grid.com/javascript-data-grid/',
                     text: 'AG Grid Docs',
                     notes: 'API documentation and guides for the underlying AG Grid library.'


### PR DESCRIPTION
Draft until the hoist-react side lands and a SNAPSHOT is published - see Blocked below.

Depends on:
- xh/hoist-react#4684 - adds `Column.cellFlag`
- xh/hoist-react#4686 - adds `xh-grid-tooltip-frame` (stacked on #4684)

### Cell flag

The `SampleGrid` Volume column marked high volume through a hand-rolled `cellClassRules` entry plus supporting SCSS:

```scss
color: var(--xh-intent-warning-text-color);
border-left: 4px solid var(--xh-intent-warning) !important;
border-right: 4px solid var(--xh-intent-warning) !important;
```

Two `!important` declarations fighting the grid's own cell borders, plus a text recolor that collided with the ledger coloring in the adjacent P&L column. That is now a `cellFlag` returning an `Intent` - no `!important` anywhere, and the cell's contents are untouched.

### Tooltip

The Volume tooltip now explains the flag, as a real app would rather than leaving the marker unexplained. It is a custom *element* tooltip, so it is not framed automatically - it opts into Hoist's standard chrome with `xh-grid-tooltip-frame`, supplying only the spacing for its own note line. This doubles as the reference example for the class added in hoist-react#4686.

A single `isHighVolume` predicate drives both the flag and the tooltip, so the threshold cannot drift between them.

### Blocked

CI will fail `pnpm typecheck` until a hoist-react SNAPSHOT carrying both features is published, since `tsc` resolves `@xh/hoist` from npm and `cellFlag` is not there yet. The commit was made with `--no-verify` for the same reason - `prettier --check` and `lint` both pass; only the type-check against the published package is affected.

Type-checks and lints clean against a local hoist-react checkout. Ready to un-draft once the SNAPSHOT is available and `pnpm install` picks it up.

### Testing

Verified in a local Toolbox running against an inline hoist-react: flags appear on exactly the Volume cells at or above the threshold and nowhere else, scale correctly across sizing modes, and render in both light and dark themes. The tooltip renders framed and consistent with the grid's other tooltips.